### PR TITLE
add optimization.operand and optimization.variable to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ packages = [
     "optiland.analysis",
     "optiland.geometries",
     "optiland.materials",
+    "optiland.optimization.operand",
+    "optiland.optimization.variable",
     "optiland.optimization",
     "optiland.rays",
     "optiland.samples",


### PR DESCRIPTION
* the `pyproject.toml` was missing build instructions for the nested modules in optimize: operand and variable.

the version on pypi works fine overall, however the `Tutorial_5c_Optimization_Case_Study.ipynb` example notebook throws an import error

`
ModuleNotFoundError: No module named 'optiland.optimization.variable'
`

* the same happend when i clone the repo and built + install the local the package.
* including explicit instructions in `pyproject.toml` works out 

great work! 

and 
best regards

