### PR TITLE
add SurfaceViewer to vizualize surfaces

### DIFF
--- a/optiland/optic.py
+++ b/optiland/optic.py
@@ -22,7 +22,7 @@ from optiland.rays import PolarizedRays, PolarizationState, RayGenerator
 from optiland.distribution import create_distribution
 from optiland.geometries import Plane, StandardGeometry
 from optiland.materials import IdealMaterial
-from optiland.visualization import OpticViewer, OpticViewer3D, LensInfoViewer
+from optiland.visualization import SurfaceViewer, OpticViewer, OpticViewer3D, LensInfoViewer
 from optiland.pickup import PickupManager
 from optiland.solves import SolveManager
 
@@ -293,6 +293,28 @@ class Optic:
             if surface.aperture is not None:
                 surface.aperture.scale(scale_factor)
 
+    def draw_surface(self,
+        surface_index,
+        projection='2d',
+        num_points=256,
+        figsize=(7, 5.5),
+        title=None):
+        """
+        Visualize a surface.
+
+        Args:
+            surface_index (int): Index of the surface to be visualized.
+            projection (str): The type of projection to use for visualization.
+                Can be '2d' or '3d'.
+            num_points (int): The number of points to sample along each axis
+                for the visualization.
+            figsize (tuple): The size of the figure in inches.
+                Defaults to (7, 5.5).
+            title (str): Title.
+        """
+        viewer = SurfaceViewer(self)
+        viewer.view(surface_index, projection, num_points, figsize, title)
+        
     def draw(self, fields='all', wavelengths='primary', num_rays=3,
              distribution='line_y', figsize=(10, 4), xlim=None, ylim=None,
              title=None, reference=None):

--- a/optiland/visualization/__init__.py
+++ b/optiland/visualization/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 
-from .visualization import OpticViewer, OpticViewer3D, LensInfoViewer
+from .visualization import SurfaceViewer, OpticViewer, OpticViewer3D, LensInfoViewer

--- a/optiland/visualization/visualization.py
+++ b/optiland/visualization/visualization.py
@@ -84,8 +84,8 @@ class SurfaceViewer:
         _, ax = plt.subplots(figsize=figsize)
         im = ax.imshow(np.flipud(z), extent=[-1, 1, -1, 1])
 
-        ax.set_xlabel('Normalized X [mm]')
-        ax.set_ylabel('Normalized Y [mm]')
+        ax.set_xlabel('Normalized X')
+        ax.set_ylabel('Normalized Y')
         if title is not None:
             ax.set_title(title)
         else:
@@ -118,8 +118,8 @@ class SurfaceViewer:
                                cmap='viridis', linewidth=0,
                                antialiased=False)
 
-        ax.set_xlabel('Normalized X [mm]')
-        ax.set_ylabel('Normalized Y [mm]')
+        ax.set_xlabel('Normalized X')
+        ax.set_ylabel('Normalized Y')
         ax.set_zlabel("Deviation to plane [mm]")
         if title is not None:
             ax.set_title(title)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -2,7 +2,7 @@ import pkg_resources
 from unittest.mock import patch
 import pytest
 import numpy as np
-from optiland.visualization import OpticViewer, OpticViewer3D, LensInfoViewer
+from optiland.visualization import SurfaceViewer, OpticViewer, OpticViewer3D, LensInfoViewer
 from optiland.samples.objectives import (
     TessarLens,
     ReverseTelephoto
@@ -48,6 +48,55 @@ class InvalidMaterial(BaseMaterial):
 
     def k(self, wavelength):
         return -42
+
+class TestSurfaceViewer:
+    def test_init(self):
+        lens = TessarLens()
+        viewer = SurfaceViewer(lens)
+        assert viewer.optic == lens
+
+    @patch('matplotlib.pyplot.show')
+    def test_view(self, mock_show):
+        lens = ReverseTelephoto()
+        viewer = SurfaceViewer(lens)
+        viewer.view(surface_index=1)
+        mock_show.assert_called_once()
+        plt.close()
+
+    @patch('matplotlib.pyplot.show')
+    def test_view_2d(self, mock_show):
+        lens = ReverseTelephoto()
+        viewer = SurfaceViewer(lens)
+        viewer.view(surface_index=1, projection='2d')
+        mock_show.assert_called_once()
+        plt.close()
+
+    @patch('matplotlib.pyplot.show')
+    def test_view_3d(self, mock_show):
+        lens = ReverseTelephoto()
+        viewer = SurfaceViewer(lens)
+        viewer.view(surface_index=1, projection='3d')
+        mock_show.assert_called_once()
+        plt.close()
+
+    @patch('matplotlib.pyplot.show')
+    def test_view_bonded_lens(self, mock_show):
+        lens = TessarLens()
+        viewer = SurfaceViewer(lens)
+        viewer.view(surface_index=1)
+        mock_show.assert_called_once()
+        plt.close()
+
+    @patch('matplotlib.pyplot.show')
+    def test_view_reflective_lens(self, mock_show):
+        lens = HubbleTelescope()
+        viewer = SurfaceViewer(lens)
+        viewer.view(surface_index=1)
+        mock_show.assert_called_once()
+        plt.close()
+
+
+
 
 
 class TestOpticViewer:


### PR DESCRIPTION
Following the implementation of Zernike surfaces I was curious about their shape. In freeform manufacturing, deviation to the best sphere is crutial.

Now, using `lens.draw_surface(surface_index=1)` the user can view the surface shape in 2D or 3D :
![image](https://github.com/user-attachments/assets/c714d916-9681-4a48-b1aa-4bbc3fad67a8)
![image](https://github.com/user-attachments/assets/8c7d4d0a-e25f-4b35-91d5-918ed19a4eed)

Note that this computed using `.sag()`: for aspheric surfaces it includes the contributions from the base conic and the polynomials.
I'm not sure that the deviations are actually correct, they seem to small but maybe I'm mistaken?