### PR TITLE
Spot Diagram: Correctly transform global coordinates to local image surface coordinates for tilted surfaces

### DIFF
--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -450,10 +450,19 @@ class SpotDiagram:
             # Without the airy disk, just use the geometric spot radius with a buffer.
             adjusted_axis_lim = axis_lim * buffer
 
+        # Determining the labels for the x and y axes based on the image surface effective orientation.
+        cs = self.optic.image_surface.geometry.cs
+        effective_orientation = np.abs(cs.get_effective_rotation_euler())
+        # Define a small tolerance to apply the new label 
+        tol = 0.01 # adjust it, if necessary
+        if effective_orientation[0] > tol or effective_orientation[1] > tol:
+            x_label, y_label = 'U (mm)', 'V (mm)'
+        else:
+            x_label, y_label = 'X (mm)', 'Y (mm)'         
         
         ax.axis('square')
-        ax.set_xlabel('X (mm)')
-        ax.set_ylabel('Y (mm)')
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(y_label)
         ax.set_xlim((-adjusted_axis_lim, adjusted_axis_lim))
         ax.set_ylim((-adjusted_axis_lim, adjusted_axis_lim))
         ax.set_title(f'Hx: {field[0]:.3f}, Hy: {field[1]:.3f}')

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -371,13 +371,25 @@ class SpotDiagram:
                 rays. Defaults to 'hexapolar'.
 
         Returns:
-            list: A list containing the x, y, and intensity values of the
+            list: A list containing the local x-coordinates, local y-coordinates, and intensity values of the
                 generated spot data.
         """
         self.optic.trace(*field, wavelength, num_rays, distribution)
-        x = self.optic.surface_group.x[-1, :]
-        y = self.optic.surface_group.y[-1, :]
+        
+        # Extract the global intersection coordinates from the image surface (i.e. final surface)
+        
+        x_global = self.optic.surface_group.x[-1, :]
+        y_global = self.optic.surface_group.y[-1, :]
+        z_global = self.optic.surface_group.z[-1, :] 
         intensity = self.optic.surface_group.intensity[-1, :]
+        
+        from optiland.visualization.utils import transform
+        
+        # Now, convert the global coordinates to the image's local coordinate system.
+        # If is_global == True, then the transform function will call the image surface's geometry.localize(points) method
+        # to convert the global coordinates into local coordinates
+        x, y, _ = transform(x_global, y_global, z_global, self.optic.image_surface, is_global=True)
+        
         return [x, y, intensity]
 
     def _plot_field(self, ax, field_data, field, axis_lim,


### PR DESCRIPTION
 (fixes #68)
### Description
When the image surface is tilted (e.g., with a rotation such as `rx=np.pi/2`), the spot diagram generated by the `SpotDiagram` analysis does not display the correct spot location. Instead, it shows an incorrect distribution (e.g., a horizontal line at Y=0).

### Cause
The issue arises because the ray-tracing routine stores the intersection points in the global coordinate system. The current implementation of `_generate_field_data` directly extracts these global coordinates from the final (image) surface without converting them into the local coordinate system of the tilted image plane.

### Proposed Fix
I modified `_generate_field_data `in `spot_diagram.py` to transform the global coordinates into the image surface's local coordinate system using the existing `transform()` utility function with `is_global=True`. The spot is now correctly visualized:

### Testing
With this change, when running the same optical system as described in the bug issue, the resulting spot diagram now shows the spot correctly positioned according to the image plane's local coordinate system, as in the image:

![spot_better](https://github.com/user-attachments/assets/6e7d4177-8d24-4529-8de6-0a65d281b85b)

I would also appreciate some input regarding the new axes naming, because here having "Y" and "X" loses a bit the sense I think. Any suggestions?

Let me know if any further changes are needed! :)

