### PR TITLE
Change pkg_resources to importlib.resources

### DIFF
--- a/optiland/materials/abbe.py
+++ b/optiland/materials/abbe.py
@@ -7,7 +7,8 @@ coefficient is ignored in this model and is always set to zero.
 
 Kramer Harrison, 2024
 """
-import pkg_resources
+#import pkg_resources
+from importlib import resources
 import numpy as np
 from optiland.materials.base import BaseMaterial
 
@@ -67,9 +68,12 @@ class AbbeMaterial(BaseMaterial):
         X_poly = np.hstack([X**i for i in range(1, 4)])
 
         # File contains fit coefficients
-        coefficients_file = pkg_resources.resource_filename(
-            'optiland.database', 'glass_model_coefficients.npy'
+        coefficients_file = str(
+        resources.files('optiland.database').joinpath('glass_model_coefficients.npy')
         )
+        #coefficients_file = pkg_resources.resource_filename(
+        #    'optiland.database', 'glass_model_coefficients.npy'
+        #)
         coefficients = np.load(coefficients_file)
         return X_poly @ coefficients
 

--- a/optiland/materials/material.py
+++ b/optiland/materials/material.py
@@ -9,7 +9,8 @@ to define the optical properties of a material (or glass) in Optiland.
 Kramer Harrison, 2024
 """
 import os
-import pkg_resources
+#import pkg_resources
+from importlib import resources
 import pandas as pd
 from optiland.materials.material_file import MaterialFile
 
@@ -41,9 +42,10 @@ class Material(MaterialFile):
     """
 
     _df = None
-    _filename = pkg_resources.resource_filename(
-        'optiland.database', 'catalog_nk.csv'
-    )
+    _filename = str(
+        resources.files('optiland.database').joinpath('catalog_nk.csv')
+        )
+
 
     def __init__(self, name, reference=None, robust_search=True,
                  min_wavelength=None, max_wavelength=None):
@@ -218,9 +220,10 @@ class Material(MaterialFile):
         material_data = filtered_df.loc[0].to_dict()
         filename = filtered_df.loc[0, 'filename']
 
-        full_filename = pkg_resources.resource_filename(
-            'optiland.database', os.path.join('data-nk', filename)
-        )
+        full_filename = str(
+            resources.files('optiland.database').joinpath('data-nk', filename)
+            )
+
         return full_filename, material_data
 
     def to_dict(self):

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib import resources
 import pytest
 import numpy as np
 from optiland import materials
@@ -42,8 +42,8 @@ def test_mirror_material():
 
 class TestMaterialFile:
     def test_formula_1(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/ami/AMTIR-3.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/ami/AMTIR-3.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.n(4) == pytest.approx(2.6208713861212907, abs=1e-10)
@@ -56,8 +56,8 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_2(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/schott/BAFN6.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/schott/BAFN6.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.n(0.4) == pytest.approx(1.6111748495969627, abs=1e-10)
@@ -74,8 +74,8 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_3(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/hikari/BASF6.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/hikari/BASF6.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.n(0.4) == pytest.approx(1.6970537915318815, abs=1e-10)
@@ -92,8 +92,10 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_4(self):
-        rel_file = 'database/data-nk/main/CaGdAlO4/Loiko-o.yml'
-        filename = pkg_resources.resource_filename('optiland', rel_file)
+        rel_file = 'data-nk/main/CaGdAlO4/Loiko-o.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath(rel_file)
+        )
         material = materials.MaterialFile(filename)
         assert material.n(0.4) == pytest.approx(1.9829612788706874, abs=1e-10)
         assert material.n(0.6) == pytest.approx(1.9392994674994937, abs=1e-10)
@@ -110,8 +112,8 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_5(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/main/YbF3/Amotchkina.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/main/YbF3/Amotchkina.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.n(0.4) == pytest.approx(1.5874342875, abs=1e-10)
@@ -128,8 +130,8 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_6(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/main/CO2/Bideau-Mehu.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/main/CO2/Bideau-Mehu.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.n(0.4) == pytest.approx(1.0004592281255849, abs=1e-10)
@@ -147,8 +149,8 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_7(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/main/Y2O3/Nigara.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/main/Y2O3/Nigara.yml')
         )
         # No material in the database currently uses formula 7, so we fake it
         material = materials.MaterialFile(filename)
@@ -167,8 +169,8 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_8(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/main/AgBr/Schroter.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/main/AgBr/Schroter.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.n(0.5) == pytest.approx(2.3094520454859557, abs=1e-10)
@@ -186,8 +188,10 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_formula_9(self):
-        rel_file = 'database/data-nk/organic/CH4N2O - urea/Rosker-e.yml'
-        filename = pkg_resources.resource_filename('optiland', rel_file)
+        rel_file = 'data-nk/organic/CH4N2O - urea/Rosker-e.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath(rel_file)
+        )
         material = materials.MaterialFile(filename)
         assert material.n(0.3) == pytest.approx(1.7043928702073146, abs=1e-10)
         assert material.n(0.6) == pytest.approx(1.605403788031452, abs=1e-10)
@@ -204,8 +208,10 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_tabulated_n(self):
-        rel_file = 'database/data-nk/main/Y3Al5O12/Bond.yml'
-        filename = pkg_resources.resource_filename('optiland', rel_file)
+        rel_file = 'data-nk/main/Y3Al5O12/Bond.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath(rel_file)
+        )
         material = materials.MaterialFile(filename)
         assert material.n(1.0) == pytest.approx(1.8197, abs=1e-10)
         assert material.n(2.0) == pytest.approx(1.8035, abs=1e-10)
@@ -222,8 +228,10 @@ class TestMaterialFile:
             material.n(1.0)
 
     def test_tabulated_nk(self):
-        rel_file = 'database/data-nk/main/B/Fernandez-Perea.yml'
-        filename = pkg_resources.resource_filename('optiland', rel_file)
+        rel_file = 'data-nk/main/B/Fernandez-Perea.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath(rel_file)
+        )
         material = materials.MaterialFile(filename)
         assert material.n(0.005) == pytest.approx(0.9947266437313135,
                                                   abs=1e-10)
@@ -236,16 +244,16 @@ class TestMaterialFile:
         assert material.k(0.15) == pytest.approx(1.7791319513647896, abs=1e-10)
 
     def test_set_formula_type_twice(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/ami/AMTIR-3.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/ami/AMTIR-3.yml')
         )
         material = materials.MaterialFile(filename)
         with pytest.raises(ValueError):
             material._set_formula_type('formula 2')
 
     def test_to_dict(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/ami/AMTIR-3.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/ami/AMTIR-3.yml')
         )
         material = materials.MaterialFile(filename)
         assert material.to_dict() == {
@@ -254,8 +262,8 @@ class TestMaterialFile:
         }
 
     def test_from_dict(self):
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/ami/AMTIR-3.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/ami/AMTIR-3.yml')
         )
         material_dict = {
             'filename': filename,

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,4 +1,5 @@
-import pkg_resources
+#import pkg_resources
+from importlib import resources
 from unittest.mock import patch
 import pytest
 import numpy as np
@@ -344,9 +345,12 @@ class TestLensInfoViewer:
 
     def test_view_material_file(self, capsys):
         lens = ReverseTelephoto()
-        filename = pkg_resources.resource_filename(
-            'optiland.database', 'data-nk/glass/hoya/LAC9.yml'
+        filename = str(
+        resources.files('optiland.database').joinpath('data-nk/glass/hoya/LAC9.yml')
         )
+        #filename = pkg_resources.resource_filename(
+        #    'optiland.database', 'data-nk/glass/hoya/LAC9.yml'
+        #)
         mat = MaterialFile(filename)
         lens.surface_group.surfaces[2].material_post = mat
         viewer = LensInfoViewer(lens)


### PR DESCRIPTION
The library named pkg_resources kept giving warnings on the tests. It will be deprecated as stated in https://setuptools.pypa.io/en/latest/pkg_resources.html .

This PR includes switching from pkg_resources to importlib.resources, as suggested in the formerly given link.