### PR TITLE
Fix: Handle Missing Extinction Coefficient Data by Defaulting to Zero

### DIFF
--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -91,10 +91,10 @@ class MaterialFile(BaseMaterial):
         """
         # If the extinction coefficient is missing from the file, return 0
         if self._k is None or self._k_wavelength is None:
-            if not self.k_warning_printed:
+            if not self._k_warning_printed:
                 material_name = os.path.basename(self.filename)
                 print(f"WARNING: No extinction coefficient data found for {material_name}. Assuming it is 0.")
-                self.k_warning_printed = True # we set it to True to avoid printing the warning again            
+                self._k_warning_printed = True # we set it to True to avoid printing the warning again            
             
             if np.isscalar(wavelength):
                 return 0.0

--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -91,12 +91,14 @@ class MaterialFile(BaseMaterial):
         Raises:
             ValueError: If no extinction coefficient data is found.
         """
-        try:
-            return np.interp(wavelength, self._k_wavelength, self._k)
-        except ValueError:
-            file = os.path.basename(self.filename)
-            raise ValueError(f'No extinction coefficient data found for '
-                             f'{file}.')
+        # If the extinction coefficient is missing from the file, return 0
+        if self._k is None or self._k_wavelength is None:
+            print("WARNING: Extinction coefficient not found. It is assumed to be 0")
+            if np.isscalar(wavelength):
+                return 0.0
+            else:
+                return np.zeros_like(wavelength) # if there is an array of wvls
+        return np.interp(wavelength, self._k_wavelength, self._k)
 
     def _formula_1(self, w):
         """

--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -40,7 +40,7 @@ class MaterialFile(BaseMaterial):
     """
     def __init__(self, filename):
         self.filename = filename
-
+        self._k_warning_printed = False
         self.coefficients = []
         self._k_wavelength = None
         self._k = None
@@ -91,7 +91,7 @@ class MaterialFile(BaseMaterial):
         """
         # If the extinction coefficient is missing from the file, return 0
         if self._k is None or self._k_wavelength is None:
-            if not hasattr(self, "k_warning_printed") or not self.k_warning_printed:
+            if not self.k_warning_printed:
                 material_name = os.path.basename(self.filename)
                 print(f"WARNING: No extinction coefficient data found for {material_name}. Assuming it is 0.")
                 self.k_warning_printed = True # we set it to True to avoid printing the warning again            

--- a/optiland/materials/material_file.py
+++ b/optiland/materials/material_file.py
@@ -80,24 +80,27 @@ class MaterialFile(BaseMaterial):
     def k(self, wavelength):
         """
         Retrieves the extinction coefficient of the material at a
-        given wavelength.
+        given wavelength. If no exxtinction coefficient data is found, it is 
+        assumed to be 0 and prints a warning message, only once. 
 
         Args:
             wavelength (float or numpy.ndarray): The wavelength(s) in microns.
 
         Returns:
             float or numpy.ndarray: The extinction coefficient of the material.
-
-        Raises:
-            ValueError: If no extinction coefficient data is found.
         """
         # If the extinction coefficient is missing from the file, return 0
         if self._k is None or self._k_wavelength is None:
-            print("WARNING: Extinction coefficient not found. It is assumed to be 0")
+            if not hasattr(self, "k_warning_printed") or not self.k_warning_printed:
+                material_name = os.path.basename(self.filename)
+                print(f"WARNING: No extinction coefficient data found for {material_name}. Assuming it is 0.")
+                self.k_warning_printed = True # we set it to True to avoid printing the warning again            
+            
             if np.isscalar(wavelength):
                 return 0.0
             else:
                 return np.zeros_like(wavelength) # if there is an array of wvls
+            
         return np.interp(wavelength, self._k_wavelength, self._k)
 
     def _formula_1(self, w):

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -102,9 +102,8 @@ class TestMaterialFile:
         assert material.n(1.5) == pytest.approx(1.9081487808757178, abs=1e-10)
         assert material.abbe() == pytest.approx(40.87771013627357, abs=1e-10)
 
-        # This material has no k values, check that it raises an error
-        with pytest.raises(ValueError):
-            material.k(1.0)
+        # This material has no k values, check that it raises a warning
+        assert material.k(1.0) == 0.0
 
         # force invalid coefficients to test the exception
         material.coefficients = [1.0, 0.58, 0.12, 0.87]
@@ -139,9 +138,8 @@ class TestMaterialFile:
         assert material.n(1.5) == pytest.approx(1.0004386003514163, abs=1e-10)
         assert material.abbe() == pytest.approx(76.08072467952312, abs=1e-10)
 
-        # This material has no k values, check that it raises an error
-        with pytest.raises(ValueError):
-            material.k(1.0)
+        # This material has no k values, check that it raises a warning
+        assert material.k(1.0) == 0.0
 
         # force invalid coefficients to test the exception
         material.coefficients = [1.0, 0.58, 0.12, 0.87]
@@ -178,9 +176,8 @@ class TestMaterialFile:
         assert material.n(0.65) == pytest.approx(2.237243954654548, abs=1e-10)
         assert material.abbe() == pytest.approx(14.551572168536392, abs=1e-10)
 
-        # This material has no k values, check that it raises an error
-        with pytest.raises(ValueError):
-            material.k(1.0)
+        # This material has no k values, check that it raises a warning
+        assert material.k(1.0) == 0.0
 
         # force invalid coefficients to test the exception
         material.coefficients = [1.0, 0.58, 0.12]
@@ -198,9 +195,8 @@ class TestMaterialFile:
         assert material.n(1.0) == pytest.approx(1.5908956870937045, abs=1e-10)
         assert material.abbe() == pytest.approx(34.60221948120884, abs=1e-10)
 
-        # This material has no k values, check that it raises an error
-        with pytest.raises(ValueError):
-            material.k(1.0)
+        # This material has no k values, check that it raises a warning
+        assert material.k(1.0) == 0.0
 
         # force invalid coefficients to test the exception
         material.coefficients = [1.0, 0.58, 0.12, 0.87]
@@ -218,9 +214,8 @@ class TestMaterialFile:
         assert material.n(3.0) == pytest.approx(1.7855, abs=1e-10)
         assert material.abbe() == pytest.approx(52.043469741225195, abs=1e-10)
 
-        # This material has no k values, check that it raises an error
-        with pytest.raises(ValueError):
-            material.k(1.0)
+        # This material has no k values, check that it raises a warning
+        assert material.k(1.0) == 0.0
 
         # Test case when no tabulated data available
         material._n = None


### PR DESCRIPTION
### Description
This PR addresses the issue where the `MaterialFile.k()` function raises a `ValueErro`r when no extinction coefficient data is found in the material file (e.g., with Malitson.yml - this came up when I was using the "fused_silica" material, for example). 

### Proposed Fix
- **Updated the `k()` Method in `material_file.py`:**
  - **Data Check:**  
    The method now checks whether `self._k` or `self._k_wavelength` is `None`. If one of them is missing, the function will set a default extinction coefficient of zero.
  - **Warning Message:**  
    A print statement has been added to notify the user, because it may be important for some of their analyses:
    > "WARNING: Extinction coefficient not found. It is assumed to be 0"
  - **Return Values:**  
    - If the input `wavelength` is a scalar, the method returns `0.0`.
    - If the input `wavelength` is a NumPy array, it returns an array of zeros matching the shape of the input.
  - **Interpolation:**  
    If the extinction data is present, the method uses `np.interp` to interpolate the extinction coefficient for the given wavelengths, as the already implemented approach.

### Testing
Here is the warning being triggered, but it allows the script to continue running:

![image](https://github.com/user-attachments/assets/810ae3d7-5f4f-41ac-a898-aef5244f67c1)

### Additional Modifications
I would also need some suggestions on how to show this warning message only once. Right now it will show up multiple times, as many as the method k() is called. 
Any ideas on how I can improve this?

Thanks :)
Manuel 
