### PR TITLE
fix: asphere coeff `get_value()`

### DIFF
--- a/optiland/optimization/variable/asphere_coeff.py
+++ b/optiland/optimization/variable/asphere_coeff.py
@@ -8,6 +8,7 @@ optical system.
 Kramer Harrison, 2024
 """
 
+import numpy as np
 from optiland.optimization.variable.base import VariableBehavior
 
 
@@ -44,7 +45,16 @@ class AsphereCoeffVariable(VariableBehavior):
             float: The current value of the aspheric coefficient.
         """
         surf = self._surfaces.surfaces[self.surface_number]
-        value = surf.geometry.c[self.coeff_number]
+        try:
+            value = surf.geometry.c[self.coeff_number]
+        except IndexError:
+            pad_width_i = max(0, self.coeff_number + 1)
+            c_new = np.pad(surf.geometry.c,
+                           pad_width=(0, pad_width_i),
+                           mode='constant',
+                           constant_values=0)
+            surf.geometry.c = c_new
+            value = 0
         if self.apply_scaling:
             return self.scale(value)
         return value


### PR DESCRIPTION
Fix the `IndexError` raised when when no coeffs are defined on the surface.
It happens, for example, when a surface is defined as an even asphere with an empty coefs list and an operand is set:

```python3
lens.add_surface(index=1,  radius=100, thickness=10, surface_type='even_asphere', coefficients=[])
problem.add_variable(lens, 'asphere_coeff', surface_number=1, coeff_number=5, min_val=-1, max_val=1)
```

raises `IndexError: list index out of range`.
I simply reused what's already implemented in `zernike_coeff.py`.
drpaprika

