### PR TITLE
Add comments to surfaces

### DIFF
--- a/optiland/optic.py
+++ b/optiland/optic.py
@@ -97,7 +97,7 @@ class Optic:
             return self.polarization
 
     def add_surface(self, new_surface=None, surface_type='standard',
-                    index=None, is_stop=False, material='air', **kwargs):
+                    comment='', index=None, is_stop=False, material='air', **kwargs):
         """
         Adds a new surface to the optic.
 
@@ -119,8 +119,8 @@ class Optic:
             ValueError: If index is not provided when defining a new surface.
         """
         self.surface_group.add_surface(
-            new_surface=new_surface, surface_type=surface_type, index=index,
-            is_stop=is_stop, material=material, **kwargs
+            new_surface=new_surface, surface_type=surface_type, comment=comment,
+            index=index, is_stop=is_stop, material=material, **kwargs
             )
 
     def add_field(self, y, x=0.0, vx=0.0, vy=0.0):

--- a/optiland/surfaces/object_surface.py
+++ b/optiland/surfaces/object_surface.py
@@ -21,6 +21,8 @@ class ObjectSurface(Surface):
         geometry (Geometry): The geometry of the surface.
         material_post (Material): The material of the surface after
             interaction.
+        comment (str, optional): A comment for the surface. Defaults 
+            to ''.
 
     Attributes:
         is_infinite (bool): Indicates whether the surface is infinitely

--- a/optiland/surfaces/object_surface.py
+++ b/optiland/surfaces/object_surface.py
@@ -27,13 +27,14 @@ class ObjectSurface(Surface):
             far away.
     """
 
-    def __init__(self, geometry, material_post):
+    def __init__(self, geometry, material_post, comment=''):
         super().__init__(
             geometry=geometry,
             material_pre=material_post,
             material_post=material_post,
             is_stop=False,
-            aperture=None
+            aperture=None,
+            comment=comment,
         )
 
     @property

--- a/optiland/surfaces/standard_surface.py
+++ b/optiland/surfaces/standard_surface.py
@@ -45,6 +45,7 @@ class Surface:
                  bsdf: BaseBSDF = None,
                  is_reflective: bool = False,
                  surface_type: str = None,
+                 comment: str = "",
                  ):
         self.geometry = geometry
         self.material_pre = material_pre
@@ -56,6 +57,7 @@ class Surface:
         self.bsdf = bsdf
         self.is_reflective = is_reflective
         self.surface_type = surface_type
+        self.comment = comment
 
         self.reset()
 

--- a/optiland/surfaces/standard_surface.py
+++ b/optiland/surfaces/standard_surface.py
@@ -32,6 +32,7 @@ class Surface:
             surface. Defaults to None.
         coating (BaseCoating, optional): The coating applied to the surface.
             Defaults to None.
+        comment (str, optional): A comment for the surface. Defaults to ''.
     """
     _registry = {}  # registry for all surfaces
 
@@ -45,7 +46,7 @@ class Surface:
                  bsdf: BaseBSDF = None,
                  is_reflective: bool = False,
                  surface_type: str = None,
-                 comment: str = "",
+                 comment: str = '',
                  ):
         self.geometry = geometry
         self.material_pre = material_pre

--- a/optiland/surfaces/surface_factory.py
+++ b/optiland/surfaces/surface_factory.py
@@ -53,6 +53,7 @@ class SurfaceFactory:
 
         Args:
             surface_type (str): The type of surface to create.
+            comment (str): A comment for the surface.
             index (int): The index of the surface.
             is_stop (bool): Indicates whether the surface is a stop surface.
             material (str): The material of the surface.

--- a/optiland/surfaces/surface_factory.py
+++ b/optiland/surfaces/surface_factory.py
@@ -46,7 +46,7 @@ class SurfaceFactory:
         self._use_absolute_cs = False
         self._last_surface = None  # placeholder for last surface object
 
-    def create_surface(self, surface_type, index, is_stop, material,
+    def create_surface(self, surface_type, comment, index, is_stop, material,
                        **kwargs):
         """
         Create a surface object based on the given parameters.
@@ -126,7 +126,7 @@ class SurfaceFactory:
 
         return Surface(geometry, material_pre, material_post, is_stop,
                        is_reflective=is_reflective, coating=coating,
-                       bsdf=bsdf, surface_type=surface_type, **filtered_kwargs)
+                       bsdf=bsdf, surface_type=surface_type, comment=comment, **filtered_kwargs)
 
     def _configure_cs(self, index, **kwargs):
         """

--- a/optiland/surfaces/surface_factory.py
+++ b/optiland/surfaces/surface_factory.py
@@ -117,7 +117,7 @@ class SurfaceFactory:
         geometry = config['geometry'](cs, **filtered_params)
 
         if index == 0:
-            return ObjectSurface(geometry, material_post)
+            return ObjectSurface(geometry, material_post, comment)
 
         # Filter out unexpected surface parameters
         common_params = ['aperture']

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -168,6 +168,7 @@ class SurfaceGroup:
                 provided, a new surface will be created based on the other
                 arguments.
             surface_type (str, optional): The type of surface to create.
+            comment (str, optional): A comment for the surface. Defaults to ''.
             index (int, optional): The index at which to insert the new
                 surface. If not provided, the surface will be appended to the
                 end of the list.

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -158,7 +158,7 @@ class SurfaceGroup:
             surface.trace(rays)
         return rays
 
-    def add_surface(self, new_surface=None, surface_type='standard',
+    def add_surface(self, new_surface=None, surface_type='standard', comment='',
                     index=None, is_stop=False, material='air', **kwargs):
         """
         Adds a new surface to the list of surfaces.
@@ -186,7 +186,7 @@ class SurfaceGroup:
                 raise ValueError('Must define index when defining surface.')
 
             new_surface = self.surface_factory.create_surface(
-                surface_type, index, is_stop, material, **kwargs
+                surface_type, comment, index, is_stop, material, **kwargs
                 )
 
         if new_surface.is_stop:

--- a/optiland/visualization/visualization.py
+++ b/optiland/visualization/visualization.py
@@ -221,6 +221,7 @@ class LensInfoViewer:
             if surf.is_stop:
                 surf_type[-1] = 'Stop - ' + surf_type[-1]
 
+        comments = [surf.comment for surf in self.optic.surface_group.surfaces]
         radii = self.optic.surface_group.radii
         thicknesses = np.diff(self.optic.surface_group.positions.ravel(),
                               append=np.nan)
@@ -250,6 +251,7 @@ class LensInfoViewer:
 
         df = pd.DataFrame({
             'Type': surf_type,
+            'Comment': comments,
             'Radius': radii,
             'Thickness': thicknesses,
             'Material': mat,

--- a/tests/test_optic.py
+++ b/tests/test_optic.py
@@ -50,6 +50,15 @@ class TestOptic:
         self.optic.set_field_type('angle')
         assert self.optic.field_type == 'angle'
 
+    def test_set_comment(self):
+        self.optic.add_surface(index=0, surface_type='standard',
+                               material='SF11', thickness=5, comment="Object surface")
+        self.optic.add_surface(index=1, surface_type='standard',
+                               material='SF11', thickness=5, comment="First surface")
+        
+        assert self.optic.surface_group.surfaces[0].comment == "Object surface"
+        assert self.optic.surface_group.surfaces[1].comment == "First surface"
+
     def test_set_radius(self):
         self.optic.add_surface(index=0, surface_type='standard',
                                material='SF11', thickness=5)

--- a/tests/test_surface_factory.py
+++ b/tests/test_surface_factory.py
@@ -19,6 +19,7 @@ class TestSurfaceFactory:
     def test_create_surface_standard(self):
         surface = self.factory.create_surface(
             surface_type='standard',
+            comment='Standard',
             index=1,
             is_stop=False,
             material='air',
@@ -35,6 +36,7 @@ class TestSurfaceFactory:
     def test_create_surface_even_asphere(self):
         surface = self.factory.create_surface(
             surface_type='even_asphere',
+            comment='Even Asphere',
             index=1,
             is_stop=False,
             material='air',
@@ -53,6 +55,7 @@ class TestSurfaceFactory:
     def test_create_surface_odd_asphere(self):
         surface = self.factory.create_surface(
             surface_type='odd_asphere',
+            comment='Odd Asphere',
             index=1,
             is_stop=False,
             material='air',
@@ -71,6 +74,7 @@ class TestSurfaceFactory:
     def test_create_surface_polynomial(self):
         surface = self.factory.create_surface(
             surface_type='polynomial',
+            comment='Polynomial',
             index=1,
             is_stop=False,
             material='air',
@@ -93,6 +97,7 @@ class TestSurfaceFactory:
     def test_create_surface_chebyshev(self):
         surface = self.factory.create_surface(
             surface_type='chebyshev',
+            comment='Chebyshev',
             index=1,
             is_stop=False,
             material='air',
@@ -119,6 +124,7 @@ class TestSurfaceFactory:
     def test_create_surface_object(self):
         surface = self.factory.create_surface(
             surface_type='standard',
+            comment='Object',
             index=0,
             is_stop=False,
             material='air',
@@ -135,6 +141,7 @@ class TestSurfaceFactory:
         with pytest.raises(ValueError):
             self.factory.create_surface(
                 surface_type='invalid',
+                comment='Invalid',
                 index=1,
                 is_stop=False,
                 material='air',
@@ -145,6 +152,7 @@ class TestSurfaceFactory:
         with pytest.raises(ValueError):
             self.factory.create_surface(
                 surface_type='standard',
+                comment='Invalid',
                 index=42,
                 is_stop=False,
                 material='air',
@@ -154,6 +162,7 @@ class TestSurfaceFactory:
     def test_create_surface_with_coating(self):
         surface = self.factory.create_surface(
             surface_type='standard',
+            comment='Coating',
             index=1,
             is_stop=False,
             material='air',
@@ -168,6 +177,7 @@ class TestSurfaceFactory:
     def test_create_surface_with_fresnel(self):
         surface = self.factory.create_surface(
             surface_type='standard',
+            comment='Fresnel',
             index=1,
             is_stop=False,
             material='air',
@@ -183,6 +193,7 @@ class TestSurfaceFactory:
         with pytest.raises(ValueError):
             self.factory.create_surface(
                 surface_type='standard',
+                comment='Invalid',
                 index=1,
                 is_stop=False,
                 material='air',
@@ -193,6 +204,7 @@ class TestSurfaceFactory:
     def test_absolute_coordinates(self):
         surface = self.factory.create_surface(
             surface_type='standard',
+            comment='Absolute',
             index=1,
             is_stop=False,
             material='air',
@@ -213,6 +225,7 @@ class TestSurfaceFactory:
         with pytest.raises(ValueError):
             self.factory.create_surface(
                 surface_type='standard',
+                comment='Invalid',
                 index=1,
                 is_stop=False,
                 material='air',

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -279,6 +279,7 @@ class TestLensInfoViewer:
         viewer.view()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out
@@ -290,6 +291,7 @@ class TestLensInfoViewer:
         lens.info()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out
@@ -302,6 +304,7 @@ class TestLensInfoViewer:
         viewer.view()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out
@@ -321,6 +324,7 @@ class TestLensInfoViewer:
         viewer.view()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out
@@ -336,6 +340,7 @@ class TestLensInfoViewer:
         viewer.view()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out
@@ -357,6 +362,7 @@ class TestLensInfoViewer:
         viewer.view()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out
@@ -371,6 +377,7 @@ class TestLensInfoViewer:
         viewer.view()
         captured = capsys.readouterr()
         assert 'Type' in captured.out
+        assert 'Comment' in captured.out
         assert 'Radius' in captured.out
         assert 'Thickness' in captured.out
         assert 'Material' in captured.out


### PR DESCRIPTION
OpticStudio allows to add comments to surfaces, which helps to add information about the function of each surface. When automating model creation, this helps with debugging because it is easier to check if the surfaces were added in the right order. This would be helpful in Optiland as well. I added a `comment` property to the `surface` class, and added this property to the `LensInfoViewer` as well, so the comments also show up when calling `Optic.info`.

## Example

```python
from optiland.optic import Optic

lens = Optic()

lens.set_aperture("EPD", 1)
lens.set_field_type("angle")
lens.add_field(0, 0)
lens.add_wavelength(0.55)

lens.add_surface(index=0, thickness=float("inf"), comment="Object")
lens.add_surface(index=1, radius=10, thickness=5, is_stop=True, material="BK7", comment="Lens front")
lens.add_surface(index=2, radius=-10, thickness=10, comment="Lens back")
lens.add_surface(index=3, thickness=float("inf"), comment="Image plane")

lens.info()
```

Output:
```
╒════╤═════════════════╤═════════════╤══════════╤═════════════╤════════════╤═════════╤═════════════════╕
│    │ Type            │ Comment     │   Radius │   Thickness │ Material   │   Conic │   Semi-aperture │
╞════╪═════════════════╪═════════════╪══════════╪═════════════╪════════════╪═════════╪═════════════════╡
│  0 │ Planar          │ Object      │      inf │         inf │ Air        │       0 │       0.5       │
│  1 │ Stop - Standard │ Lens front  │       10 │           5 │ BK7        │       0 │       0.5       │
│  2 │ Standard        │ Lens back   │      -10 │          10 │ Air        │       0 │       0.414634  │
│  3 │ Planar          │ Image plane │      inf │         nan │ Air        │       0 │       0.0596243 │
╘════╧═════════════════╧═════════════╧══════════╧═════════════╧════════════╧═════════╧═════════════════╛
```

## Considerations

Another possible name for this property would be 'label'.

## Additional remarks

The `LensInfoViewer` currently only prints the table. You could consider returning it instead, so the result can be included in e.g. logs of a program using OptiLand. It would also make `LensInfoViewer` easier to test (i.e. no need to capture output).