### PR TITLE
Reciprocal radius

### DIFF
--- a/docs/api/api_optimization.rst
+++ b/docs/api/api_optimization.rst
@@ -1,9 +1,9 @@
 Optimization
 ============
 
-This section covers the optimization functionality of the Optiland package. The optimization module 
-provides a set of tools for optimizing optical systems. It includes a variety of optimization algorithms, 
-such as gradient-based and evolutionary algorithms, as well as tools for defining optimization variables 
+This section covers the optimization functionality of the Optiland package. The optimization module
+provides a set of tools for optimizing optical systems. It includes a variety of optimization algorithms,
+such as gradient-based and evolutionary algorithms, as well as tools for defining optimization variables
 and objectives.
 
 The optimization module is divided into three subcategories:
@@ -56,6 +56,7 @@ The `optimization.variable` subpackage contains the following modules:
    optimization.variable.index
    optimization.variable.polynomial_coeff
    optimization.variable.radius
+   optimization.variable.reciprocal_radius
    optimization.variable.thickness
    optimization.variable.tilt
    optimization.variable.variable

--- a/docs/api/optimization/variable/optimization.variable.reciprocal_radius.rst
+++ b/docs/api/optimization/variable/optimization.variable.reciprocal_radius.rst
@@ -1,0 +1,7 @@
+optimization.variable.reciprocal_radius
+=========================================
+
+.. automodule:: optimization.variable.reciprocal_radius
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/examples/Example_Optimization_Using_Reciprocal_Radii.ipynb
+++ b/docs/examples/Example_Optimization_Using_Reciprocal_Radii.ipynb
@@ -1,0 +1,610 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a7bf11e-2620-48d0-bd11-e377baae7ddf",
+   "metadata": {},
+   "source": [
+    "# Example - Optimization Using Reciprocal Radii\n",
+    "\n",
+    "### April 2025\n",
+    "\n",
+    "This example demonstrates smooth surface transitions during optimization using the \"reciprocal_radius\" variable. This approach helps design optical systems without initially knowing whether each surface should be concave or convex.\n",
+    "\n",
+    "The \"reciprocal_radius\" is defined as 1/radius (the inverse of the radius of curvature). You define initial conditions using the regular \"radius\" parameter, but the optimization operates on this proxy variable instead.\n",
+    "\n",
+    "While the libary code attempts to handle edge cases, there are limitations. It's best to avoid setting the initial radius to exactly zero (which is physically meaningless) or infinity. Instead, use very large or very small values as starting points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6403783e-b126-406d-8299-339780cfa1c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "from optiland import analysis, optic, optimization\n",
+    "\n",
+    "# Disable the warning \"findfont: Font family 'cambria' not found.\" when running on Linux\n",
+    "logging.getLogger(\"matplotlib.font_manager\").disabled = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5ad6d48-081d-4a54-8501-4811fcda5c99",
+   "metadata": {},
+   "source": [
+    " ## 1. Definition of initial system\n",
+    "\n",
+    " We'll define a simple BK7 plano-concave singlet and optimize it to focus on the focal plane.\n",
+    "\n",
+    " We'll try two optimization approaches:\n",
+    " - First using the standard \"radius\" variable\n",
+    " - Then using the \"reciprocal_radius\" variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "099b5744-2fa1-4a40-abf3-9d1220a7b897",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Singlet(optic.Optic):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # Define surfaces\n",
+    "        # object plane:\n",
+    "        self.add_surface(index=0, thickness=np.inf)\n",
+    "        # first surface, initially concave:\n",
+    "        self.add_surface(\n",
+    "            index=1, radius=-100, thickness=5, material=\"BK7\", is_stop=True\n",
+    "        )\n",
+    "        # the second surface is flat:\n",
+    "        self.add_surface(index=2, radius=np.inf, thickness=45)\n",
+    "        # image plane:\n",
+    "        self.add_surface(index=3)\n",
+    "\n",
+    "        # Define aperture\n",
+    "        self.set_aperture(aperture_type=\"EPD\", value=10.0)\n",
+    "\n",
+    "        # Define fields\n",
+    "        self.set_field_type(field_type=\"angle\")\n",
+    "        self.add_field(y=0)\n",
+    "        self.add_field(y=1)\n",
+    "        self.add_field(y=2)\n",
+    "\n",
+    "        # Define wavelengths\n",
+    "        # Uncomment the blue and red wavelengths to see chromatic aberration effects\n",
+    "        # self.add_wavelength(value=0.4861)\n",
+    "        self.add_wavelength(value=0.5876, is_primary=True)\n",
+    "        # self.add_wavelength(value=0.6563)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d289e9e2-2b62-4447-bf5b-e38ffa18d412",
+   "metadata": {},
+   "source": [
+    "Here's our starting lens configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9284227-b308-40b2-bcfc-2ed4d3449969",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1QAAAEUCAYAAAAspncYAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUrNJREFUeJzt3XmUJGWdLv7njTW32nqhF7pakQYZWQQFG/oIDMrVAVFH2TxHNsXBuWo3jMPVwTOOgwPo2C3qdWHAewFF7nCVGe44DKMX/DXXBVwQ9Igg68AA3Ui3VHWtmbG87++PiMyMiIyoyspasjL6+XDyZGZs+VZFdxNPft/3DaGUUiAiIiIiIqI507rdACIiIiIiol7FQEVERERERNQhBioiIiIiIqIOMVARERERERF1iIGKiIiIiIioQwxUREREREREHWKgIiIiIiIi6hADFRERERERUYeMbjdgOZFSYteuXejr64MQotvNISIiIiKiLlFKYXx8HOvXr4emZdehGKgidu3aheHh4W43g4iIiIiIlonnnnsOGzZsyFzPQBXR19cHAHjq6f9ovO4WKSVGR0cxODg4YyKm3sFzmk88r/nDc5pPPK/5w3OaP8vtnI6Pj+PgVx00ay5goIqod/Pr6+tDf39/V9sipYTv++jv718Wf6Bo/nhO84nnNX94TvOJ5zV/eE7zZ7me09mGAi2flhIREREREfUYBioiIiIiIqIOMVARERERERF1iIGKiIiIiIioQwxURERERETUVUopOI4D13WhlOp2c+aEs/wREREREdGi8KWPKW8K4844xt1xTLgTGHeC5wmn+X68Og7r/5kAgPd9+GKs6V/T5Za3j4GKiIiIiIhS1fwaJpyJRhiaqAejyLJoQGqum8CEO4FJdyLz2LZuo2L2oWJW0K/34dV4NQDAV/5S/XgLgoGKiIiIiCiHpJKYcidjoScahsadCUy640H4SQakcHtHOqnHFhAom2X0WUEg6jP7ULYqWF8+EJXBCvqsPvSZfahYlUZoamwbPlu61Tie4zi49lc7AAAr7BVL8vtZKAxURERERETLkOu7jRA07mR0l4usm0iEpgl3Agrp45FMzYwFnnrIWVdeh4oZhiCrgr5oEGos60PJLEMTnI4BYKAiIiIiIlpwSilMeVPpXeKiFaPUdUEYqvnVzOOXjTIqjYpPBRWzgjWlNTjY2pRaDQrCUHOZrdtL+NvINwYqIiIiIqIET7ph0JnIGDMUHyuUDEaT7mTmWCBdGI0QVO8aVzYrWF06ILasYlZiIaj+XDbK0DV9iX8jlIWBioiIiIhyRSmFql+NjBVKVINi44hal024E5j2pjOPXzSKLYFnVXEVDuo/KCMEhRUisw99VgW2XoAQYgl/I7SYGKiIiIiIaFnxpR+GnHgIigajcWccf5j4A1zNSXShC/bzlZd6bE1o8e5vYQB6ReEVjTAUHSsUDUbBPmUYmrnEvxFazhioiIiIiGjBKKWCqbYzxgo1uss1ws94IwTVQ9OUN5V5fFsvBN3ljAqKWhGDxSEM2kMY7tvYMnFCS6XI7EPRKLI6RAuKgYqIiIiIGqSSmHQnG0EnOX4odjPWxmxy8dDkSjf12AIipeJTwYbKhpZl0RDUF5l629SD6pCUEiMjIxgaGoKmcbY56h4GKiIiIqIccXyn5Z5Dse5yKQGpuW4CU+5k5lTblmYFkyI0Jk6ooN/qx4GV9fEwFJmGOxqUSkaJU23nkVKANw04U4A7BeEGz3Amm6/dKQhnMlw+BbjxdapaBXBMcLzJl4DCxq7+SHPBQEVERES0TEglg6m2U7vJ1cNQortcOBNdPTRl3YgVQBCEzEos6Kwtr8Mhg4dmjhlqTr5Q4VTbvUypRngJwk39dRhsomGoHnzcKQh3MiUoxUMT3CmIjBAea4JRAMwSYJagzBJgha+tMlRxoLmh1lsRpbdaS0RERLSM1W/EGusul3Yz1sg9h6LLJr1JSCVTj21oRqzyU7/x6prS2mYISrkBa31dyShxqu3lTslIBScZYCZTw1D2uqlEUJpsrwlGMQg9Vhh66gHIKkEVVwADw7Hl8e3KUFbwnNwfZgmY4c+f5zjA53cEb4orFuK3uWQYqIiIiIgQTKYw7U2nhqC0+xBNJoLRuDPzjVhLRqnZXS4cF3RA8QAcPPCqWEBK7S5nBjdi5WQKy0As9CSrO5OtFZxo17d6NSet0lNf3k4TokEnWukxS1CllYC1ESoMNenblSNhqPkaZglgl8w5Y6AiIiKiXPCk11LxqXeTG6+NY8/YHni6h0kvvBmrM964KWt9n+wbseqNewhFg87K/lUt4Scaguqvy2YZRo91Y+pp0k90b0tWcCZbKjjN9xMzV3pmuD9VVDy0JCo95dXNYGOVY+uaAagcC0rN7YoMPcsM/2YTERFR1wVTbVcj44LqFaGU7nLRm7FGls10I9aCXkDZKKPf7g9DTh9WFFbiFf2vzAxB0ecCb8S68BqhZ7JlTI5IW97S1W0SK6fGYConXvVxpyC87EphnYIIA0s5vdJTWZOo4ES2iwWlcksYYujZvzBQERER0bz50sekN9kyiUJaCGp0l4t0oxt3Zr4Ra31cUDkSdDb2bQxvytqcUjsagurjiCpmBRp0TrHdCem1zsjmJKs+KZMatHSJS+nq5tdm/fhY6LHKia5uRfjlA6CXhyLblDK6urWGIRhFgCGZFgADFREREaHm15o3XE2ZTCF9XbO73KSXPeDd1u1I4AmC0YA9gAMrG5rhJzGZQiUxmcJ8q0NSpk/0kAu+m9q1Lda9rWX66qnEdpOJ6lC43M+eMbBOCS0yQUG5pauaKgxGKjjl1i5sqZMahA+jkBl6pJQYZUimZYCBioiIqMdJJTHlTqZOnBCdUruxrF49imw/041Yy2Y5EXj6sL58IPqGskNQswtdBZZuLfFvZBnyndSJC1rv2TPTFNXJCQ/CLnEZ5y5KCT0+HicydkeZJaiBoUQFp5yYya0c6RJXjld6dJuVHtqvMVARERF1meM7qfccmoh1iWt2nZtsmW0u+0aspmY2QlA07Kyv34g1ZaKF6CxzJbO8f9yIVakg9LQ1ccFkswtb6sQFye5tkxAyvTtjrAmakZicoBwPM6WVM05cUL+fT2qlR7cYeogWCQMVERHRPCilMOVNxUJQy81YU9dNNJbVZhhLUjbKkTAUhJ01pTU42NqUPmYovBlrfVmubsRaDz2x8TitExfE7ssTdmFTziSGJvfBEi6EO90c+xMNRG2FHjNR6UmM3WnM3haduKAcqfQkx/REpqxmJY+6xPMlHF/C9RUcr/5awvHSl0W3dcN9o9u2LGu8zljmS/iuizeH7fn9WA2vKBS6+juZCwYqIiLar3nSjYWefbUx/H7kRagRhQlvEpPhhAmp44nCKbezbsSqC6MRgur3FyqbFRxQWtNy49VKymQKZaPcezdiVQrwa4mJC2aaonoy/XVyUoN6UMqY1jzWBN1qvfeOUYIQJlAaCGZvS1RwMicuMEtQViVS6TGX4JdIeSSl6ihoxAKN17p/WsjJ3D8jEMn0AndbdE3A1AUsXYOpa7AMLXwtIq+D5aYuULR0DCSWWboGU0g4DwbHLFm99e8eAxUREfUspRSqfrV5c1WnOXNcbMxQyrL6c3WGG7EWjWJLd7lVxVU4qP+gRgjqC8cO1WebCwJSsNxerlNtKwV41VknLohXfiZjU1a3dnWL3OcnI2DGmqDbKZWeoMuasvuBytp4F7YZp6iub1cOpqtOCT1SSs7ytx9QSs0YNFLDRwfVmCDYqEbAmSkQ1Zd780ktQCx8BK+1yOtEoDE0lGy9Zdu0kJO6f3TbWfbXtYX5N85xHFwbBqq+Qm9FlN5qLRER5YonPUxGJlNI7S6Xti4y0cLMN2KNVH7CQLSysDKyrFklatyA1SjDm/Rx4OoDYRld7IKlFOBNz2niglg1JxaU4sEI7vQcQk/GPXoKg0D/esAsQbYzcUFsMoQSwJvc9jTPnzk8zNrty5dwvRn2jwaaGfavuh48Cbiyud18mLpoCQ+N90br8nLBwNAM1ZhYoEnZPxaIZtjf0MTy/HKGADBQERFRh+o3Yk0bK1S/r1Csu1ysghRsN+VNZR7f1gvN7nJhGBoqrMDG/le0TJwQrSDV1xWNYkcXIFJKjLgjMNq54FcqZYrqlHvvJKeoTg1Ek61d4jImmog1wSikzsqmrBJUcRDoPzAIPW1MXBANQzBLQK91N8yZaBex1MrJbN2+Il3E2qq8zDY2JhJo5lNs0QRmDx+JLmL9qdUYAc+pYaBSblRS2qncZFVjTF2DtkDVFtq/MFAREe2nfOk3JlNI3nNowkl0l0ssqwckL2MQv4CIBZxKOC5oQ2VDagjqi802Fyw3F2qsipIZU1S3TlwAdwqaM4n+8ZdhahLCa71nT/Q+P8LNDoSxJhjF+AQF0UpPcQUwMJyYojp74oLYdgw985bWRSxtbMu8BuFH983oIpb2OYvVRSyr21fR0jO7fc2lmjLb/gvVRYzdOGm5YKAiIupRNb8Wu+fQRHIcUSIgNdcFFaNJdyLz2JZmhcGn3iWugn5rAAdWDows62uZZa6+rmSU5jbVtpLNMTjToxBju1Lv2dMyVidjIoPYcm+6vSZEqjS2ZkMr9AVVH6sEVV6VPkV1rDtbpXVMUH3b/WHa8VlEu4h1PIjem6UaM9M4GE+i5nrwlGgJP/NhaCIzPARdxEQkdARdxAbnMA5mxkA0w/6mzi5iREuFgYqIqAvqN2JNGysU6y4XjhWKBaRwe0c6mccvR8YM1atB68rr0TfYOmYoGZAqViV9qm3pN8fgOIkAM/Ei4D7Vci+eaBe47Hv2tBd6FERrBSc6kUH5gNYpqlPv2ZM2qUGxEXp6+VvvtC5iadWUeVVj2piVLK3yshBdxGYMH5GgUTA19BWMeMjRBHzXQX+lBNvQ4+FnllnJWqo57CJGRBEMVEREHXB9N5xiex927dsFrSYw4U3Gu8ZFJlGYaJlgYSLzRqyGZqQGnrWlta3d5SLd5PqsCip6CSUAuldtdk2LdXULw9D0BOC+1DJxQcsU1dFxP172bHh1CiI2BqdlIoO+ta2TE7Tcs6e+LjGpgVFcFjcmrXcR62gQfUo1ZrZuX27sGDPPKjbfLmIzhYe0QDNQMtseB5MViKKhJqsaY+jzD7a9HJSJaHljoCKi/U79RqypXeLSbsYaWxeEodoMU22XjFKz+1t4M9YDSmtwsHVwEIaMMvo0GxXNQJ8w0KcEKtBQUUC/VLA9B8JLVHAmpwB3D+A8kz6Opx6AZrhBbOPnF1qk0pMykUFhXWIa6ngwarlnjxWpCBmFBQs9voxUU2oSzmR17oPo5zClcfSY044LCQEnOVVy+H4+6l3EUsNDtItY+L5sGxgstTcOpq1AlFGNYRcxIqLO5CJQ3XvvvTjllFNS191///04/vjjl7hFRLSY6jdijd5zKB6G4mOFksFo0p2cYaptoxGCKkYRfXoJfbqN1eYQ+uwDUBE6+qCjAg19CujzJczpaawyDfR7HsqeA8ObhpieBMYmAXdva6XHz+6qV6eEnj7VdL3S0z8Y6bZWbglG8S5xkZncrDKg243QU+8iNqdqSlXBmYxWY3y4/hgcf3T2cTDtzEq2CF3EZgsattHsImZoAsp3UCkVYRv6nKops1Vj2EWMiCh/chGo6rZt24bjjjsutmzTpk1dag0RpanfiLU5VihRDYqNI2pdNuFOYHqG8TZFzUJFL6BPt1ERJvqEiVVCw0HQ0KeK6NML6BMrUfF89PseKp6DPrcaPJxpFN19EM5zENKd/WcJQ4/UixB2pVGxaYSg0orGa2kU4elFeEYJrl6EqxXhaAW4WgE1UYCjFVFFAVVhoyoKqEoDjlSz34xyWsIZzxrbIuH4DlyvCsffkzqr2ELcs2XWrlyR4DJQMmcfB2O0PytZ1jia+XQRY9cwIiKai1wFqhNPPBFnnXVWt5tB1OL+++/Dbx9+GLZto1abvUvWcqGg4IX/ucINXgmv5dmF2/J+xdqV0Es6Jpx9GK+NNW/G6k1lVoc0CFSEgT6how8aKkqgTwGrpESf76Piu+j3XPS5DipuFf2+i4qU6JcKFSlRkRLJibaVZkAaRfhGKXjoQbAJQk0lCDZmAX+wC9glCqiKIOBMiwKmlY1pFDAFG5PKxpSyMaksTCob49LClKfDlQpTNQdKanAmsysvM/2WgenwkS7ZRWymsS2moaFs6RhMjG1ZjOmP2UWMiIgoZ4EKAMbHx1EsFmEYufvRqIf96Ic/hBACAwMDmJ5ubwrn2Sgo+PCDICM8+KL52oMHKVxI4YQPF1K48IQLGa7369sKH57w4TYeEq6QcDQFV7RXvRBKoaAAWwEFqVBUEtgl0a8kVvg+XiEl+qRCn5ToC4NPv5SohMvKSsCCBQNB1aYqCqgKE1XYqIaBZgpBoJlSNl5UNiaUhQnfxriyMOZbGPctTCgb0/XtEIQht81/5oRAI0TMGD7qr00NK4v17mEG+koFWIbeWnkx2qvczFSNYRcxIiKi5StXqeN973sfJiYmoOs6TjzxRGzfvh3HHnts5va1Wi1WLRgbGwMQdPeQcn6DjufrkV37sHdkHJUxQPBianlSCkJ5ENIPn4MHpAspHXj+NFx/Gq43jSltFyp9BYgVNRSFC0dW4coaXFWFKx24qgYHLjzlwlUuakHNBy58OPDhCB8OJBwhURMKNSg4bfZEEkqhqBQKSqEoFQpKoth4HTwXpUQh3MaUApYU0JUGQ2nQpQ5DatCUAU0ZEL4BoUxAGoCyIJUFXxpwYaEGEw5MOMpAFVYj3OxGAU+HVR5XK8DVi/C0oPubrxehGWYkULRWXOKVmebrQUPD6tRxLCIWTsxkV7GWwNR5FzEpJUZHRzE4OLhI3cMU5DxnbqO5kVJCKdX1/w/QwuJ5zR+e03yJnsflcC1eb0c7chGoLMvCmWeeidNPPx2rVq3CI488gh07duDEE0/Efffdh2OOOSZ1v8985jO48sorW5aPjo7C99O7JC2Vj//zI3hy78JUMrpBQMKAhAEPBiR0+DDhQ4cPQ/gwUH80tzHgwRAysi7cPrpNbN/mNiZ86KL+GRImPOiQ4XoPUvMA4UFqPiA8+EJCCQ++JoOH8OELCV9IeJqELxQ8oeCGVZrgAbgiCDKOAGpCNB5VLXwO38tkN6gN4bOX+D0phQKCwGMrwFKALQFLCZhKoCQFBpQGU+kwlA5DWtBhQJdG8KxMCJgwlAkBC0LZ0GFBiAIECsGzsCE1G74wITUDUrPgayagWfB1E0ozoXQLjjDhaAY0XYcuAE0TMASgaYAhBDQN0AWgCwFdiz4DuiZQEEBJBN3THnv0USi3hrPPeFswyF8XQWjRutVFTAHww0f41gOkB9QQPDo+spIYH58AoCB489Zc4DnNJ57X/OE5zRfXbY5d3rdvFNPTKfdDXGLj4+NtbSeUUrn86vPJJ5/EUUcdhZNOOgnf+973UrdJq1ANDw/jxd+/hP7+/qVqaqoXnnoYYy+/hErRhgYfCKsfQvnNSkijKuJDSDdc5wIy3CZWNfFi1ZTm8eLHQHgMETlG6mdH9037XJWe6BWCMBIEDy0WQpKhpP7aSayrCg01TUdV08LXWmI/oCqAmgAcAO4cr98taLChwRI6bOiwhAFb6LCEGbzWDFjChClMWFr9YUeeLViaDVMvwNJtmFoBD/z0AfSVV+CgjZtQLg6iYJZhmxWYRhG6aUPXNOiagC6QizEp/+/eezE9PY2t2y7tdlMW3eJXqGip8ZzmE89r/vCc5ovjOPjiF64FAGy79DIUCoUutyjIBmvXHIB9+/bNmA1yUaFKs2nTJrzzne/EP//zP8P3fei63rKNbduw7db0q2la1/9ivureD0Pb8+ic91OaAWgmoOmAbgLCAHQD0IxwXWS9ZsDVjSDY6EYQULQgoFSFgZoooKbVg0r4Tb4AquFzTQXdz6pKoQaJGiSqykct8gjee3Ckh5ryUJNe5s1M0xjCgK3bKOg2bMOGHYaUxjLdRp9ewKrG+vryAuxwvR2+LxjN91Zk/+S2ixFonrh/Hwb0AWxa/3oUCoVchKZ2dPvv0VIRQiyLfzdo4fCc5hPPa/7wnOZH9Bwul3PabhtyG6gAYHh4GI7jYHJysusVp7na9ZZr8NLLu2FUinChUEUYTmQYUJSPqvRQUy5q0kNNuqhJBzW/hqpfQ63+8KqN1/XlTmP9ROtsazJ8pBAQqeEkCCSFRpgZ1G3YRkqg0W1YuhV7b0eCUjIMWboFQ8vHH1Fd17vejZSIiIiIFl4+rlYzPP300ygUCqhUKt1uypxt/e2X8eS+J2fcxtKsjEDSDDHlwsp4sDHs1kATCTEFo7VqUwgrOqZm7jeVlYWmGwY8z5t9QyIiIiLqKbkIVHv27MHq1atjy37961/ju9/9Lk477bRlUTKcq7869hMY2fcyVg6uQtEoxCo+9YCjcQBmzzANA47jdLsZRERERLTAchGozj33XBSLRWzZsgUHHHAAHnnkEdxwww0olUr47Gc/2+3mdeSoVUdhRB/B0NBQTwZCijMMY8HuP0VEREREy0cuAtWf/umf4tZbb8W1116LsbExrF69Gu9+97vxqU99Cps2bep284hgmibHUBERERHlUC4C1bZt27Bt27ZuN4Mok2may+IGdURERES0sNiXjGgJmJbFQEVERESUQwxUREvAMk0opaAYqoiIiIhyhYGKaAlY4Q2kpWr/psZEREREtPwxUBEtAcuyAAA+70VFRERElCsMVERLwLKCChVv7ktERESULwxUREugEHb58zh1OhEREVGuMFARLQE7DFS8FxURERFRvjBQES0Byw7GUEkGKiIiIqJcYaAiWgLFQhEAK1REREREecNARbQE7EIBAAMVERERUd4wUBEtgfoYKskb+xIRERHlCgMV0RIohBUqBioiIiKifGGgIloC9Rv7MlARERER5QsDFdES0LTgrxrHUBERERHlCwMV0RIRQkAp1e1mEBEREdECYqAiWkLs8kdERESULwxUREtECMFARURERJQzDFRES4Rd/oiIiIjyh4GKaImwQkVERESUPwxUREuEFSoiIiKi/GGgIloiQmisUBERERHlDAMV0RIRAqxQEREREeWM0c5G11577bw+5JxzzsGGDRvmdQyiXqdprFARERER5U1bgeryyy/vePyHEAJHH300AxXt9ziGioiIiCh/2gpUAPCFL3wB73znO+d08Jdffhmvf/3r59woojzSNI2BioiIiChn2g5Uq1atwite8Yo5HbxSqcy5QUR5xUBFRERElD9tBaqRkRGUy+U5H3zlypUYGRlhsCICIBioiIiIiHKnrUA1MDDQ8QfMZ1+iPNE4bToRERFR7nDadKIlommclIKIiIgob9oeQ5X0rW99CzfeeCOefvppjIyMtFwoCiGwb9++eTeQKC80TYPv+91uBhEREVFXSCXh+DVU/Rpq9YdXRc2vYbI62diu5tdQQKGLLZ2bjgLVxz/+cezYsQMHHnggjj32WHbrI2qD0DQoz+t2M4iIiIiglIIr3TDYVJshxwve13ynsa4efqrR916tdd/keukE78NtHelktkeXOt6FdwEARmovY6DcO/mio0D19a9/HWeccQbuuOMOaBp7DRK1Q9c0OOzyR0RERCk86TVCSbyK0wwk1UTAaQQar9ayLC0Q1fxauG2wTKH96xJdGCjoNmzdhm2Ez3oBtm6Fr21UzApWFlbC1u1w20Jk2+B94xi6DdsoBM+aBV0Z+Pb1twEADiiuWaxf86LouMvf6aefzjBFNAe8sS8REVFvUEqlBJRIyPEyqjaNyky02pOyf6LKU/Vr8FX7vVgERCSktAaUemjpt/pj6wtGPQSl7Ks31xWM+Htbt2FoHceGtjhOs3qlid7KGB39Zs444wz8+Mc/xgc/+MGFbg9RbvELCCIiorlTSoXVm3jXsml3GntH98KqmXCki5pfheM7bVZxkoGoWQlyZFDZmQtTM1srMIlQMmAPYk00pBg2LC0MP4ltC9GAE64rRNabmgkhxCL9xmmuOgpUX/7yl/H2t78dH/nIR/D+978fw8PD0HW9ZbsVK1bMu4FEecFARUREeeBLPx5UIt3U2q7ihOuTY2+agSi+vVTt33ZEF/osVRcbZbOCocKKWEiJVnkKafsnu6npFmy9AEuzoGut18G0/+goUJXLZWzZsgXbt2/Hddddl7kdZzQjamKXPyIiWmj1rmmOdBqTCaQFkui4mfQw5DTfe637R0ORJ+c2wVJy3Iyl2y0Bpc/qa3ZLS4Yco3XsjaXbsISF2mQVq1ccgKJRhG0E+xqauUi/baJ0HQWqj3zkI/j617+O448/Hps3b+Ysf0RtYIWKiCj/POmmhpK0sTPVSFUmfba0ZpUnLSTVH3NhaEbrxACJbmgDdn/KOJtCo2uapQWVmYKRVcVpdlOzNGvRuqZJKTEiRjBUHuL/Y6mrOgpU//t//2+cf/75uPnmmxe4OUT5xQoVEdHSkko2Qsi0O42XJvdgD/bAVU4jpDjJCoyXXcVJ78YWP4av2u+dowktu1tZWLkpmiUMFoYaQcVqzKiWPltaIRmQIhMRsGsa0eLoKFCZponjjz9+odtClGuC354R0X5MKdUY7N+4z02km9psVZzUkOPV4CRmU4tu70p3Tm3MnPEs0s2sXJ8SOnW2tMKMEwzEu7oVYGgGJxYgyoGOAtV73vMe/Ou//iv+/M//fKHbQ5RbrFAR0XISvedNI9CkjJ1pBJSWGdKc1v1TqjjRStBc7nmT7JpmhRMApE4JnTILWizkGDZMYcKZcrBqcBWKZrGlimPpVs9N1UzUFUoBSgLSBaQH+F7wLF1A+oD0IBqv07cRLcs9aJFp0+FMAoVC937GOeooUJ177rnYunUr3va2t+H9738/Nm7cmDrL3+te97p5N5AoL/gtJBFlkUombuTZ3tiZaLUnOVtafDKC1v3n0jWtec+b5LiZaCgpYMAaiMyAFl1voaWKE5lsIBmGLN1a8HveSCkxMjKCoSGOt6FFpBSgfMB3G0Eh9vBdiGjQiCyH9AHlQfiJMJLYRqQtj3xm+vGbgWbGz5fJY7SGIjHHym/bvzoYgNgGABDVUaB/5aJ8zmLo6F+rE088EQDwq1/9Ct/73vda1iulIITgLH9EEQxURL2h3jVt3BmHqyJTOHvJykzGlNCRAJMacrxa0NUtUvVxpDN7wyKCSQHSAkkztAzZ5cRU0CmBJnVK6cjYG3ZNo4Wk1IJWNYTvoDg+Br1oQSg/s/IRO0ZL0EkJEjOFodSwFP0Z5jYD4px+fRCAbgKa0frQTShNB7T6+ujr4KF0E9B0KLMIaJXmet0ARHN9sL0ZP0bLNol26OFnxNoVbqubgAi2UVnH1gw4ngK+8IXgZ+0/cNF+j4uho0B10003LXQ7iHJP48UIUUeiXdOcZMUmZdxM9o08k49Et7TIWJ65dE3ThZF5I896ZaZiVrCyPvYmMQvaTBMM2JoVq/gUwnE47JqWQ0pmX6j7bnChnrIc0gPUDEGhUbVoDQf1isiMlY9Y2IhUO1R0fUrlo7FNpDIyh3tJtcuq//qEHrs4b160B69VygV89MJfhRf+Si8AhdbAolLCQeb6mQKN0FNCURh0ssJSGJiQ97/3c/xiaTnpKFBdeOGFC90Oov0AAxX1vvo9b9oZO5MMObEw1MaU0vXlvmr/G99o17RYNzMjY+xNYha0+jTPXtXDUP8KFI0CZqviLHTXNEqod6GSrRfw9Yt9kXqR3wwHQnqA56Awvg960Q4u7JNVi8TFfyxIZCxHpFvUjIFGRY/RWtWA70LMIcTP+VfYcoEev/hvWZ+48A/ChgVlllK3aT1+uD4MNCqj2lHfRrVUO1orJWnbSAiM7JvA0MpV0HT+PaTu4Z8+oiXCAhUtNKVUWL1J71oWHTvj+E6bVZzWKaHj98mZ2z1vTM3MGDfTDCUD9iDWREOKYcPS7BlnS4tWeKJjb0zNnHfXtJ4aa6NUarek+HiK9Av4WBjJqnw09m+tiMxa+WipariJsSXtVD7cBe1CZaf9CjUzcgGfrCiEF/6plQ+zuY1uQ1nl7PVZgUYLw0jGsRtdpFIqItnHT1RKhJ7f/wFJCei1/FduaNnrOFA9++yz+MY3voGnn34aIyMjLbOXCSHwL//yL/NuYLtqtRr+5m/+BrfccgtGRkZw1FFH4aqrrsJ/+S//ZcnaQDQTjj/IP1/6rdM6+8171LRTxamvjwaklv0j28s5dKHRhZ4+JXSk61nZrGCosCJ9tjQjY+xNsptafda0bt/zpl6FmGNVQ/Nc2GMj0F4uQlPxC//k+A7RUhFJrJ+xqpFV+ZglDEW7gc1hYok5//qEllJRiHZxyh4nEV2vzHJqV6jMsRZaymfUA0+kqtFyjJRQpCLLJTSMjk1icMVKaIbdbAsR0Tx1FKj+8R//ERdeeCE8z8Pg4CAGBgZatlnqi8eLLroIt99+Oy677DIccsghuPnmm3H66adj586deOMb37ikbSFKw0C1tOpd05zIfW7SAkl03Ex6GHKa7zOmlK5603CkA2+O36S3Tg4QjI+JBpQ+q69lgoD4JANpIceKBR7bCPY1NLP54SkX59EuTy2Dw5NVC88D5L7UfVuqGilVi8zKh0wcI2WcR2rlIyXQzGe8RlolI0o1ukOlDc42I+vTu0Kpelcoo5hRGZll4Hcs3KQP8E7tZhWpdsw0ODzYLmff+ksJVdMBqwIs98ojEfWUjgLVFVdcgcMOOwy33347Dj300IVu05z9/Oc/x2233Ybt27fj8ssvBwBccMEFOOKII/Cxj30M9913X5dbSIT8drlokyfd1FAy0408nchsavEube1NKT0XpmZGwowFW6s/W7A1E7ZuYkAzYetF2JqJgjBgazos6IDjYaBQQkEYsISGAgRsocOGCF5Dgw2goABbBc+WkuE4jtZB4ML3Abe+vBareMTHYmTPiBWf8jZlgPqijtdIXpxHKwqJWahSBmcH4zXsoLIxw+DxRnemlqpGerUjNvBbZH++FAL7xqfQP7QSmmG1hKFcd6EiIqI56yhQ7d27Fx/72MeWRZgCgNtvvx26ruOSSy5pLCsUCrj44ovxiU98As899xyGh4e72EKiYLD8YlBKwYcPT3rwlAdfefCUD095jWX1h5+5PLrMD9+78JQbPEsPvqq/r3+GBz9xnPrnTpQn4ZV83Hn7/wmnh3bho/1qgVYPJEJHQWiwocMWGmyEYQUCZQisUAI20AgrllIoKBO2MlCQRdhKoSB92FLCVhIF6aPg+7Clj4LvwvZ92NKF7XvQo1WRRRJ0oUpWBfTGhbpKq0hEwkGzC1WxtZvTjNPZZnWRah0fklnVSA4MzxpbIrSeDxtKSvgYAfqGWMkgIqJZdRSoNm/ejP/8z/9c6LZ07KGHHsKhhx6K/v7+2PI3vOENAIL7ZaUFqlqthlqt+S322NgYAEBKCSkXfmrPuZisufjd7yfRN6Wxq9hiURIi/CZfqOBCWsiwAiA9COU3lgWv69/6O/D8Gly/CkdW4fhVeNKBI6twpQNH1sLn4OFKF45y8dLIHkyZ0/j2A3fDg4QHHz4kfCXD9yp8jr5W8KHgCQUXKlwePFyh4AHwFuiPh6EUTKVgKgTPiL83EFmnFMpovg62bz1GYUwFoUYFz0HAUUG4UfF1FjRYSoMtjGDcTditSWkGlNAbF/qNZY3lkefotoYOJYKQolKOJTUdU5qBqcZyI2Xb+meFxxSJ9ZoBKXRMTNVQ6utvVE+a25qxtvVkFyo/fMzICx/VRW/OUlBKYXyc//7mDc9r/vCc5ovnNm8YPOV4sKzuXosDaDsPdBSovvjFL+K0007Dsccei7POOquTQyyo3bt3Y926dS3L68t27dqVut9nPvMZXHnllS3LR0dHu35T4t/9fgLvv+2xLn26gg4JAz4M+NDhw4QPHRImPOgifIYMl/vNbWPrEtuI5nbNhwyOL+LHiT2EhAEPRtgmPbG/EC6kkJCaBykUfOHDFxK+kPA0CV+TcIWEJwBXhEFEU6gJgZoQqGoCjhCo1t+Hz/V1yWU1IaDm8A+3oRRsBVimgmkAhvcyDACGEtAVYChAD1/rEDCUgKVEuExAUwKa0qBBQFcaNCUgos/QoCkNQmoQSkBAg1A6hNIApQMqeA+lA9ABqQHKCNfpUEqHgg4FDT40yPDZhwapUpZBwIOGWmS5hAY/sm2wjR57+NDhqvAZOnxocGHAhwYPOnprWnkJwAkfdXu71BYiIqLeZ8DH+cXg9cPP/B6HHzjY1fYAwPj4eFvbdRSojjzySFx99dV4z3veg3K5jA0bNkDX4zPlCCHw61//upPDz9n09DRsu3UIcaFQaKxPc8UVV+CjH/1o4/3Y2BiGh4cxODjYUu1aasf9x7/hB8c8hYKlxysokapJo5IifQgVVlqkF9m2uT5edcneFtIPZrXqkASaYST6HAkm05qJqq6jKnTUdB01oaGqaahpOvYJEb6P7AugJiIPqOZDyJSOZGFwSCEAWDBgCR22MGAJE5YWPgsTlmbBFCaKmoUBzYIZzlRmajYsrRC81wswtAIsvQBTK8A0ijD1IgyjBFMrwtKLMPUCrHBfTQRt+cmPf4xdu17A5uOPz/03ab984AHUajWc+55zu92URRd8QzqOvr6+3J/X/QXPaT7xvOYPz2m+eK6L79/2EADgiFeuwWCl1OUWoSXfZOkoUH3ta1/D1q1bUSgUcPDBB6fO8reUisVirOteXbVabaxPY9t2ahDTNK3r9x4pPfJtvHLvY7EB0bNOUWsYgGYDWiUc62DA1fQgrMQCThh6EA8pVSjUIFFVwXMNPmpKoqp81MJHVXqoKQ816aGm3OBZusE4GenCke6sP1uUpVmx2cri95kJllUiN960tPh9aVKncE658WZ9djRDM7r2j+4zZQnPrGHTSjv3//A/bzmY9qs4csNgt5uy6IJ7FkkMDQ10/d8NWhg8p/nE85o/PKf54jgOvh++LlnGsjin7baho0B1zTXXYMuWLbjzzju7HqaAoGvfCy+80LJ89+7dAID169cvdZPm7d9O2ornXv5P6LYOR9YSN96sz2jmJGY3i9zM0w1eqznM5KULI/PGmwW9CEu3UNELWJmcwtmIh5pYyDGaIcmKLK+/13pxTEmn1OLNqkZERERE3dFRoNq3bx/e+973LoswBQBHH300du7cibGxsVhXvZ/97GeN9b3mm4/ejGfGno3dcDMZUGzdRr/VH1tfMOKVmaz70qRVcQyt4/s8UxuSN78mIiIiot7X0RX0ySefjN/85jcL3ZaOnXXWWdixYwduuOGGxn2oarUabrrpJmzevLknp0z/5lu+hdHRUQwNDS2LkicREREREbXqKFBdd911OO200/C5z30OF198MVauXLnQ7ZqTzZs34+yzz8YVV1yBl156CZs2bcI3vvENPPPMM/if//N/drVtncr7GJv9EStURERERPnTUaB6zWteAyklrrjiClxxxRUoFAqps/zt27dvQRrZjm9+85v45Cc/iVtuuQUjIyM46qijcOedd+Kkk05asjYQzYR5ioiIiCh/OgpUZ5555rKroBQKBWzfvh3bt2/vdlOIUrFCRURERJQ/HQWqm2++eYGbQZR/DFRERERE+cPZDoiWCAMVERERUf60FagefPBBjI6Ozvngvu/jwQcfxOTk5Jz3JcobBbXsusoSERER0fy0FaiOO+443HXXXXM++OjoKI477rjG/aCI9mdKym43gYiIiIgWWFtjqJRS+N3vfocf/vCHczr4vn372M2JKCSlZIWKiIiIKGfanpTiqquuwtVXXz2ngyvFLk5EdfxygYiIiCh/2gpUO3funNeHvPa1r53X/kR5wAoVERERUf60FahOPvnkxW4HUe6xQkVERESUP5w2nWiJSE5KQURERJQ7DFRES4Rd/oiIiIjyh4GKaIlITtJCRERElDsMVERLRLFCRURERJQ7bQeqE044AQ8//PBitoUo1ziGioiIiCh/2g5UzzzzDF7/+tfjE5/4BKrV6mK2iSiXOIaKiIiIKH/aDlSPPfYYPvCBD+Bzn/scjjzySNxzzz2L2S6i3GGgIiIiIsqftgNVf38/vvrVr+L+++9Hf38/3vrWt+L888/Hnj17FrN9RLkhJSelICIiIsqbtm7sG3XcccfhF7/4Bb785S/jk5/8JO68804MDw+3bCeEwK9//esFaSRRHijFChURERFR3sw5UAGA53nYs2cParUaVq5ciZUrVy50u4hyR0oJTePEmkRERER5MudAdc899+BDH/oQnn76aXzoQx/C1Vdfjb6+vsVoG1GucAwVERERUf60/XX5nj17cN555+Gtb30rSqUS7rvvPvz3//7fGaaI2qR4Y18iIiKi3Gm7QvXqV78ajuPgs5/9LD760Y9C1/XFbBdR7jBQEREREeVP24Hq+OOPx9e+9jW88pWvXMTmEOUXu/wRERER5U/bgequu+5azHYQ5Z5SipNSEBEREeUMr+6IlggDFREREVH+8OqOaIlwDBURERFR/jBQES0RpRQ0TuZCRERElCsMVERLSGOFioiIiChXGKiIlgjHUBERERHlD6/uiJaAlBIAGKiIiIiIcoZXd0RLwPM8AAxURERERHnDqzuiJVCr1QAwUBERERHlDa/uiJZAtVoFAOic5Y+IiIgoVxioiJZArRYEKlaoiIiIiPKFV3dES6De5Y8VKiIiIqJ8YaAiWgLVKgMVERERUR4xUBEtAYcVKiIiIqJcYqAiWgLs8kdERESUTwxUREugykBFRERElEsMVERLoNHlzzC63BIiIiIiWkgMVERLwHEdAIDBChURERFRrjBQES0Bp+ZACAHB+1ARERER5Qqv7oiWgOs6vKkvERERUQ7xCo9oCbiuy0BFRERElEO8wiNaAg4DFREREVEu9fyUYzfffDPe9773pa7bvXs31q5du8QtImrluS6nTCciIuohSin4yodSChISSkn4KniWUJDKh1QKUsnmtpDhsmCdQmSfcFupZPrxpA8JFW7b3K7leFKGnxP93MixZzle8ueSstmexmcljpc8fqPtifY1j1N/NI+X/Hlj75UEfOBoHA0A2Fvdiw2FDd39AzAHPR+o6j796U/joIMOii0bHBzsTmOIEjzPY6AiItrPKKVaL0QRuZgNL0ibF8jxC9PoxWvyArl5YRq/eM260I1f2M90oRv93HgASB4vPVAkf97EzzXDhf1MASPevvrxJFzPhdBE+LnJ9mX/3qPBI+vn7zUCAprQGg8BAV3oEEKE7zXoQoMQGjQhoAk9eEa4fX05IscQkX3Q3Cf5Pr69AVOLbBv73Hj7Yu89wIMHALB1u8u/zbnJTaA67bTTcOyxx3a7GUSpPM+DZVndbgYR9aDYhXf0m+7EhW/sG+f6RWXKN+nRC93o8VovuCPfdGccL7gQjX5u5MI+43ipgSL2DX70m+7kz5X4drzRnrTjt17IO64DzdDCoJP982ZVIpIX3lntq3+ugur2H585a1zgInHhnbz4zbrwRvxiPfk+efzoxXr0vSk0aLodbhffr348AQHHcVAqlGLt0sN1WuwCvr6PltKONoJHy8/fGjDSfv6ZjpcMGNnHS7QRaT+XgBCi23985sVxHFz7/+0AAPSZfV1uzdzkJlABwPj4OEqlEisBtOz4vg+DN/WlLop945x2YZryLXLqhW5LN43WC/isC9G0C860C++ZvknOOt5cuuZkdmEJ2yGlRM2pQTd1qGR3mawLbMiUnz+lfY3PnKly0LxYr7ezl8znW3KR8q152rfkWd+az/wtuYCn+7AtG7oWXIDWn2e6qNWgQdNSLrwT7dMgoGkpF94t7zXoWsqFd0rAqB8vvjwRWBIX8skL8eSFd8uFfOLn6iVSSoyMjGBoaIjjlKmrcnOFd8opp2BiYgKWZeGtb30rPv/5z+OQQw7pdrOIAAT/6PdK0K93UQEACQmo8BlodIFIfa8ABQkFYFJMYlqbxouTu2MX4sn+19kXpjN90511Yd/e8bK/Sa6/nqWLSKKfua8karUqdNMIL77jF86zftONeDtm+3kzu8tElqcdv9fM9i3xTBe22ReX2d+Sxy82BaSSMGFA04yWQJD8ljx24d3Gt+RBW9LakXLhnfnzZ3fDif+8sx9vtm/JU3+ulG/Jo9+kL0e8+CaixdLzgapUKuGiiy7CKaecgv7+fvzyl7/Etddeiy1btuDBBx/E8PBw5r61Wg21Wq3xfmxsDEDwj66U3b0A+cvbf4OnXhqH0SMX4UtOKejwmw/lw4AHHRK68qDDhwEfGnwYKlwOL9wu2EeLvA7WSRjwIOAByoUSDpRwoeBCCRdSuJDCg4QHX3iQwoMPD76Q8IQPHz584cMTsvFww+faUBBBfvCggAKgBIJnCMjw2qP+J665DpFtg/7hwfvwGPX3afuEx2oeW8U+I/P9Ql0H9QWPf/7uPy/QAecuuJAVjQvflgvPxsVl2rfmyQt0fYZvxjX4voTlmcG33bGL7WA7SxipF55p3xpHv4VOdkNJ7Z7SzrfmmRfv7XVJya4MxC+0M8NG4pvyrICyXL4ll1JidHQUg4ODvPCeI6WCLxWWIynDL1S6/P93Wjg8p/kSPY/L4Vq83o52LKtAJaWE4zhtbWvbNoQQOOecc3DOOec0lv/pn/4p3vrWt+Kkk07C1VdfjX/4h3/IPMZnPvMZXHnllS3LR0dH4fv+3H+ABbShT4NwTZiWiTlfWigFHR40FQQNDT50Fb6HB00FoaOxPAwkwXofmvIi+4XvwwCiN46ROHbsGMH65vH8+OcpGTmGBw2J9kT205QHHz5cKHjChyMkXPjwBFAVAjVNBM+RR/19VWtdNhXuE9tOaLH9HW1uv3FTAZYCTCVgKQELAqbSggd0mMqC7frQGt8cI3goQECFzwCgoNVfK0ALQ46m6s/hNtF9AQgVPGvhcTUVboPIc7i9Hl2uFLTwdfBQiWXR5+AYjdeR9XoY9/TwZ9HD4wQhFuGzggEFPXp81WxLcGzE1tXbroe/Ey3yszW2Vc2fW4/8HurLFpoSGiDCowsNSuiACM6E0HQoEbZA0yPbaIAIXkNEtoksbxxXhK0XIr6svg1E/L2IHAfJZZHjoP5ZeqI94W9Z0yPb1I8fbN84DlLaU98eyX0ix4l8dnOb+Gd7ic8O2t387ObPlnKcyL4q8dlA/feoo+V3DRE5T/E/LUpJjI9PAFAQgoEqL3he84fnNF9c12283rdvFNPT3Z+YYnx8vK3thFpGXyXde++9OOWUU9ra9tFHH8Vhhx2Wuf6EE07Anj178OSTT2Zuk1ahGh4exou/fwn9/f3tN3wRGP92KeSex2FogJAeEH34LqD8YLlfX+4C0gekC7GI3XtcoaNmWKjqOmq6iZpmoKYZqOo6qpqOWvgIwoyGqqaF4UZDTQA1CNQEUBVADUAVCjUoOEIFr5VEDRI1JVGFj5ry5zR6QIcGWzObD90KHpoNW7dR0INnSy+gYNiwjSJsvQDbKMIyCuH7YrCdEWwbPAqR1/VjFWDpFrQ2/hHfsf1zqFQqWLdu3aJ94yJV+ADgK0AqAanC1wje+yq6XWR9+L7+2g/3lUi8bxy/+d5POdbIvjFouolXHfJquL6E40s4noLrS3ieB8/34Xl+8Oz78DwPvvThh8tFGNwEJHTIIDyJ4H0z1MnEc7DeEEBBVzB1wNIAS1MwddF4bemAqSmYWrDeqC/XACNcbmqAIRQMDTCFCpYLBV0DTBFsZ0DC0AANEr5bQ8m2YGqALiQMEbTXgIImAF0EFdWgX6QM/o6q4HXw8MPn6LL68uYyUV8uw2fI+PYy8hr1fVTwb0N0O0Q+J7ZOAQg/R6a0CfXlyXZKiB4b5xOlEA1zGqAFf5pEI9RFgqumN4NZNAhqiW3RujwWArVIYEwGai0ZXGd6RINvIkintb/xuvXzk+Ez/khfnt2+emBt/XwV/V1l/g7jvyuV+jO00d4IVh7zh+c0XxzHwRe/cC0AYNull6FQKHS5RUE2WLvmAOzbt2/GbLCsKlSHHXYYbrrppra2Xbdu3Yzrh4eH8dhjj824jW3bsO3W9KtpWvf/YlYOgF+bhl4oA7oBaAaUFjxDNwGhQ2lGpLICTAOoCRUGl7SAEj4rDzUVhBVHeahKDzXloSZd1KSLavhc8x3UpIOaX0PNr6Hq1+CrmSp3CoAXPgK2XmiEmMbDKMTCTX9KWGlua6ccI9zfaA07hras/kg3rFixAnv37oWUEhMTE91uTiqBBfwHwQIOOeQQnHnWa+e8q1IKvlSxEBa8luFrBddLLotv64br0vYf91VzvS+bx3JT9o9s6/oSrj+/0GDqAqauwdI1mIYGq/7eCJfpGiwjbVl8ef0Y6duKyPrI/nr2/oa2ALNDpYSsuT7mFBhjD9UIpSJjedb2LculDyV9TE9NolSwIYRq/mzJYBoG0LTlIhaUo5870/L6Oh+QHkTsd+LHPzNteUsYDwP1fM9JD0sGviI0CC0rBLY+VGpgjYfrlnCYWJ6srrYG3NmDb0tluf4ZyepuWigNjzNzKG1vuap/RktVebYvCVKqxB0E+LSqshBieVy30bxFz+FyOafttmFZXX2uXbsWF1100YIc6+mnn8bq1asX5Fjd8Nk+C0+5Ar42AScMMzWnhppfRc0LAo4j2+seWWdqZiOAFGKBJQwlVgUDuo014XtLt+LbJwJMIRpwjGgFKNjX0qyuj4VYLj7wZ5dwQHSbhBAwdAFD11BaZjPNK6Xg+ioW0Gqujz0vj6JUrsBVaIY8T7ZsGwS47GXR8OZ4EuOuF182Q8j0ZedhTwjMHMh0EQtippEIdHp6cIvuHw9+BixDxI6Vur+uQZtjF9yFqJNJKTE5MgKLf1cDWYErLeAifXmzKpsWZOcQtrM+uxEyUyqy4XIlPUxPTqBULAQV1cw2zRx8YxVcJMJssuKbCLhBUE6rTmeF4mhVu7k8NShHq8ex0J3xO81JVXldPawmg3K9OpoRoGev/s4eflW0uppSjW0J3dFu4bE2pFWPs5aLRBsygmwy4CJjeez3MceAG+0WnvXZie7i0XDdcqwetqwCVSf27NnTEpzuuusu/PKXv8S2bdu61Kr506ChZJRQKVRQMAqtXc6MjKpNogoUdHkrwNIs6Fpv/2El6jYhRBAEDA0Ii9tSSpRRxdBQX1cvvn2pEuFLJULbDJW8aNUuWgmMVvLCfevHmqx56ftHtq1/znw6luuayKzkRYNYS/CLBUCRCG0Zy8L9DSFQnZrEypoB2zRaPqu+7X7zhVHjArVz8710Z1BeBEtRVZ4h4C5EVVlJH9OTEygWCtCESmyfDLjh8sWoKksvcoxkuM6uKieDcvD72H+rygIGIIJrdzG2Cyi8qsstal/PB6otW7bgmGOOwbHHHouBgQE8+OCDuPHGGzE8PIxPfOIT3W5exz76ur9kNYOI2qZrwT11Cuby+uJEKQWvEfZSKnHR4JcRyJrrZ9nfl5h0fLi+m91ddDG6cGZV8qLBr1HVy6raaY2wnrp/LAzO3F10QbpwUv7VKzvo/N+MhQi68zlGNCQrXis1ZQWurKpySvBd8Kpy8jNSqsqu6wH37Ap+hMJAV3+Fc9Xzgercc8/Fv/3bv+H//t//i6mpKaxbtw5/9md/hk996lNYs2ZNt5tHRLRfE0I0gsey7cIZDXK+RM3xsXdkFMVyBa5Eo7qX2YUzsX+yC2e9qhftwtlS9VvELpwzVvJiY+1m6e454/7ZwTG67Vy7cBJRB3q0qiwdB7hnR/DGKs+zBUur5wPVVVddhauuuqrbzSAioh4T68IZIaXEkOFgaGigaz0EZuvCGa3apVXi4mP5svZvBsSJmpfdXTQS/Bxvft2J6l04MwNZShfM+XbhbOwvgKnJKiYxDdvU998unES04Ho+UBEREeXNcu/CGQ1k8aqbSozFm6ESl1bJm6ELZ1olz41U+xayC2dLIEsEv7ardu0ER2Pm7qI6u3ASLXsMVERERNSWaBfO5UbKZthLm3Sl6nh4eXQMdqkcjutr3TZzWUtXz6AL52zBsR4SF6IL52yVvJaunW1U7bL3bw2OaSGTXTiJAgxURERE1PM0TcDSWrtw1kkpMVKWXZnsKdqFM1bJm2vVbsb9g31rkS6caVW/ZEicD0MT7VXyomEsI7yldeFM2z92uwUNmJqowdVrsEydXTipaxioiIiIiBZRL3XhjFfdWrtwpnb3nG3/cNtJx4cz5bbsv1hdODMDWZtVu7QunDNW8tro7mksw+ouzR8DFREREdF+qDe7cDaDWs318fLoPljFMvzwxuqddOF0PIlqogvnTCFxPl04NYH2Alk0+M1S9YvfJH3uwbG+Lbtwdo6BioiIiIiWldm6cAJhN85+teTdOH2Z3Y2y7ardbPuH22Z14cwKifMR7cI5YyCLTKaS1YVzTpO0hMfQlN9oi5xHaO0GBioiIiIiojbpmkDR0lGcx02RF0O0C+eM4+dmq9q1Of6upQtnxnHb7cJpwMf5xeD178drOKhUXOTf2MJhoCIiIiIi6nHRLpzL7ba4MpyYZabbLUxXa9j5nYcAACvKZpdbPDcMVEREREREtGg0TcDWdNgz5CTHcbAzfG0by6v6N5vlNwqRiIiIiIioRzBQERERERERdYiBioiIiIiIqEMMVERERERERB1ioCIiIiIiIuoQAxUREREREVGHGKiIiIiIiIg6xEBFRERERETUIQYqIiIiIiKiDjFQERERERERdYiBioiIiIiIqEMMVERERERERB1ioCIiIiIiIuoQAxUREREREVGHGKiIiIiIiIg6xEBFRERERETUIQYqIiIiIiKiDjFQERERERERdcjodgOIiIiIiGj/ZpomLvuLj2J0dBSmaXa7OXPCChUREREREXWVEAKWZcE0TQghut2cOWGgIiIiIiIi6hADFRERERERUYcYqIiIiIiIiDrEQEVERERERNQhBioiIiIiIqIOMVARERERERF1iPehilBKAQDGx8e73BJASonx8XHoug5NY+7NA57TfOJ5zR+e03ziec0fntP8WW7ntJ4J6hkhCwNVRP2XdvCrDupyS4iIiIiIaDkYHx/HwMBA5nqhZotc+xEpJXbt2oW+vr6u31BsbGwMw8PDeO6559Df39/VttDC4DnNJ57X/OE5zSee1/zhOc2f5XZOlVIYHx/H+vXrZ6yYsUIVoWkaNmzY0O1mxPT39y+LP1C0cHhO84nnNX94TvOJ5zV/eE7zZzmd05kqU3Xd75xIRERERETUoxioiIiIiIiIOsRAtUzZto1PfepTsG27202hBcJzmk88r/nDc5pPPK/5w3OaP716TjkpBRERERERUYdYoSIiIiIiIuoQAxUREREREVGHGKiIiIiIiIg6xEBFRERERETUIQaqZWb37t34q7/6K5xyyino6+uDEAL33ntv5vb33Xcf3vjGN6JUKmHt2rXYtm0bJiYmlq7BNKtarYaPf/zjWL9+PYrFIjZv3oy77767282iNk1MTOBTn/oU/uRP/gQrVqyAEAI333xz6raPPvoo/uRP/gSVSgUrVqzA+eefjz179ixtg2lWv/jFL/CRj3wEhx9+OMrlMjZu3IhzzjkHjz/+eMu2PKe94be//S3OPvtsvOpVr0KpVMKqVatw0kkn4V//9V9btuU57V1XX301hBA44ogjWtbxeqg33HvvvRBCpD5++tOfxrbtpXNqdLsBFPfYY4/h7//+73HIIYfgyCOPxP3335+57a9+9Su8+c1vxh/90R/h2muvxfPPP48dO3bgiSeewL//+78vYatpJhdddBFuv/12XHbZZTjkkENw88034/TTT8fOnTvxxje+sdvNo1ns3bsXn/70p7Fx40a89rWvzfyC4/nnn8dJJ52EgYEBXHPNNZiYmMCOHTvwm9/8Bj//+c9hWdbSNpwy/f3f/z1+8pOf4Oyzz8ZRRx2FF198EV/5ylfwute9Dj/96U8bF2s8p73j2Wefxfj4OC688EKsX78eU1NT+Kd/+ie84x3vwPXXX49LLrkEAM9pL3v++edxzTXXoFwut6zj9VDv2bZtG4477rjYsk2bNjVe99w5VbSsjI2NqT/84Q9KKaW+853vKABq586dqduedtppat26dWrfvn2NZV//+tcVAPX9739/KZpLs/jZz36mAKjt27c3lk1PT6uDDz5YnXDCCV1sGbWrWq2q3bt3K6WU+sUvfqEAqJtuuqllu//6X/+rKhaL6tlnn20su/vuuxUAdf311y9Vc6kNP/nJT1StVoste/zxx5Vt2+q9731vYxnPaW/zPE+99rWvVa9+9asby3hOe9e5556r3vSmN6mTTz5ZHX744bF1vB7qHTt37lQA1He+850Zt+u1c8ouf8tMX18fVqxYMet2Y2NjuPvuu3Heeeehv7+/sfyCCy5ApVLBt7/97cVsJrXp9ttvh67rjW9HAaBQKODiiy/G/fffj+eee66LraN22LaNtWvXzrrdP/3TP+GMM87Axo0bG8tOPfVUHHroofz7uMxs2bKlpRJxyCGH4PDDD8ejjz7aWMZz2tt0Xcfw8DBGR0cby3hOe9MPf/hD3H777fjiF7/Yso7XQ71rfHwcnue1LO/Fc8pA1aN+85vfwPM8HHvssbHllmXh6KOPxkMPPdSlllHUQw89hEMPPTT2DwIAvOENbwAQlLSp973wwgt46aWXWv4+AsG55t/H5U8phd///vdYtWoVAJ7TXjU5OYm9e/fiqaeewhe+8AX8+7//O9785jcD4DntVb7vY+vWrfjABz6AI488smU9r4d60/ve9z709/ejUCjglFNOwQMPPNBY14vnlGOoetTu3bsBAOvWrWtZt27dOvzoRz9a6iZRit27d2eeIwDYtWvXUjeJFsFsfx9ffvll1Go12La91E2jNt1666144YUX8OlPfxoAz2mv+su//Etcf/31AABN0/Dud78bX/nKVwDwnPaqf/iHf8Czzz6Le+65J3U9r4d6i2VZOPPMM3H66adj1apVeOSRR7Bjxw6ceOKJuO+++3DMMcf05DlloFpEUko4jtPWtrZtQwjR9rGnp6cb+yUVCoXGeuqu6enpzHNUX0+9b7a/j/VteKG2PP3ud7/Dhz/8YZxwwgm48MILAfCc9qrLLrsMZ511Fnbt2oVvf/vb8H2/8f9hntPe84c//AF/8zd/g09+8pNYvXp16ja8HuotW7ZswZYtWxrv3/GOd+Css87CUUcdhSuuuALf+973evKcssvfIvrhD3+IYrHY1uOxxx6b07GLxSKAYErupGq12lhP3VUsFjPPUX099b7Z/j5Gt6Hl5cUXX8Tb3vY2DAwMNMY8Ajynveqwww7DqaeeigsuuAB33nknJiYm8Pa3vx1KKZ7THvTXf/3XWLFiBbZu3Zq5Da+Het+mTZvwzne+Ezt37oTv+z15TlmhWkSHHXYYbrrppra2TStrtrN9vSwatXv3bqxfv35Ox6PFsW7dOrzwwgsty+vnjecpH2b7+7hixQp+670M7du3D6eddhpGR0fxox/9KPb3kec0H8466yx88IMfxOOPP85z2mOeeOIJ3HDDDfjiF78Y6x5frVbhui6eeeYZ9Pf383ooJ4aHh+E4DiYnJ3vynDJQLaK1a9fioosuWpRjH3HEETAMAw888ADOOeecxnLHcfCrX/0qtoy65+ijj8bOnTsxNjYWm5jiZz/7WWM99b4DDzwQq1evjg2qrfv5z3/O87wMVatVvP3tb8fjjz+Oe+65B695zWti63lO86HeNWjfvn149atfzXPaQ1544QVIKbFt2zZs27atZf1BBx2ESy+9FFdeeSWvh3Lg6aefRqFQQKVS6clrXHb561EDAwM49dRT8a1vfQvj4+ON5bfccgsmJiZw9tlnd7F1VHfWWWfB933ccMMNjWW1Wg033XQTNm/ejOHh4S62jhbSmWeeiTvvvDM2Ff4PfvADPP744/z7uMz4vo9zzz0X999/P77zne/ghBNOSN2O57R3vPTSSy3LXNfFN7/5TRSLxUZg5jntHUcccQTuuOOOlsfhhx+OjRs34o477sDFF1/M66Ees2fPnpZlv/71r/Hd734Xb3nLW6BpWk+eU6GUUt1uBMVdddVVAIDf/va3uO222/D+978fBx10EICgP3Hdgw8+iC1btuA1r3kNLrnkEjz//PP4/Oc/j5NOOgnf//73u9J2anXOOefgjjvuwF/8xV9g06ZN+MY3voGf//zn+MEPfoCTTjqp282jNnzlK1/B6Ogodu3aheuuuw7vfve7ccwxxwAAtm7dioGBATz33HM45phjMDg4iEsvvRQTExPYvn07NmzYgF/84hfsSrSMXHbZZfjSl76Et7/97anfdJ533nkAwHPaQ971rndhbGwMJ510Eg488EC8+OKLuPXWW/G73/0On//85/HRj34UAM9pHvzxH/8x9u7di4cffrixjNdDveNNb3oTisUitmzZggMOOACPPPIIbrjhBpimifvvvx9/9Ed/BKAHz2l37ytMaQBkPpJ+9KMfqS1btqhCoaBWr16tPvzhD6uxsbEutJqyTE9Pq8svv1ytXbtW2batjjvuOPW9732v282iOXjFK16R+XfyP/7jPxrbPfzww+otb3mLKpVKanBwUL33ve9VL774YvcaTqlOPvnktv+d5TntDf/4j/+oTj31VLVmzRplGIYaGhpSp556qvqXf/mXlm15TnvbySefrA4//PCW5bwe6g1f+tKX1Bve8Aa1YsUKZRiGWrdunTrvvPPUE0880bJtL51TVqiIiIiIiIg6xDFUREREREREHWKgIiIiIiIi6hADFRERERERUYcYqIiIiIiIiDrEQEVERERERNQhBioiIiIiIqIOMVARERERERF1iIGKiIiIiIioQwxUREREREREHWKgIiKiXBNCNB47duzodnNijj766EbbzjjjjG43h4iIOsBARUREy1Y0DGU9/vZv/3bW47zrXe/CLbfcgre97W2L3+g5uOaaa3DLLbdg1apV3W4KERF1yOh2A4iIiLLccsstmev+9m//Fk899RQ2b94863GOOuoonHfeeQvZtAVx+umnAwD++q//usstISKiTjFQERHRspUVgv7H//gfeOqpp7B161acdtppS9wqIiKiJnb5IyKinvLb3/4W27ZtwzHHHIPt27d3fJybb74ZQgj8+Mc/xrZt27B69WoMDg7igx/8IBzHwejoKC644AIMDQ1haGgIH/vYx6CUauz/zDPPNMZlffWrX8WrXvUqlEolvOUtb8Fzzz0HpRT+7u/+Dhs2bECxWMQ73/lOvPzyywvxKyAiomWEFSoiIuoZU1NTOOecc6DrOm677TbYtj3vY27duhVr167FlVdeiZ/+9Ke44YYbMDg4iPvuuw8bN27ENddcg7vuugvbt2/HEUccgQsuuCC2/6233grHcbB161a8/PLL+NznPodzzjkHb3rTm3Dvvffi4x//OJ588kl8+ctfxuWXX44bb7xx3m0mIqLlg4GKiIh6xtatW/HII4/gG9/4Bg499NAFOeaaNWtw1113QQiBD33oQ3jyySexfft2fPCDH8R1110HALjkkkvwyle+EjfeeGNLoHrhhRfwxBNPYGBgAADg+z4+85nPYHp6Gg888AAMI/hf7Z49e3DrrbfiuuuuW5AgSEREywO7/BERUU/4X//rf+HGG2/E+eef3xJq5uPiiy+GEKLxfvPmzVBK4eKLL24s03Udxx57LJ5++umW/c8+++xGmKrvDwTjv+phqr7ccRy88MILC9Z2IiLqPgYqIiJa9p544gn8+Z//OQ499FB87WtfW9Bjb9y4Mfa+Ho6Gh4dblo+MjMxrfwCpxyAiot7FQEVERMtarVbDueeeC8dxcNttt6FSqSzo8XVdb3t5dFKKTvbPOgYREfUujqEiIqJl7fLLL8dDDz2EL33pSzjmmGO63RwiIqIYVqiIiGjZuuOOO/CVr3wF73jHO7Bt27ZuN4eIiKgFK1RERLQs7d69GxdffDF0Xceb3/xmfOtb30rd7uCDD8YJJ5ywxK0jIiIKMFAREdGy9NhjjzUmcLj00kszt7vwwgsZqIiIqGuE4uhYIiLKMSEE/tt/+2/42Mc+hnK5jGKx2O0mNYyOjsLzPLzuda/DUUcdhTvvvLPbTSIiojniGCoiIsq97du3Y/Xq1fjqV7/a7abE/PEf/zFWr16N5557rttNISKiDrHLHxER5drdd9/deH3ooYd2sSWtrr/+eoyPjwMAVq9e3eXWEBFRJ9jlj4iIiIiIqEPs8kdERERERNQhBioiIiIiIqIOMVARERERERF1iIGKiIiIiIioQwxUREREREREHWKgIiIiIiIi6hADFRERERERUYcYqIiIiIiIiDrEQEVERERERNSh/x+ygk1zj6beewAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "lens = Singlet()\n",
+    "lens.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eef5a20a-3d32-4460-a9b1-212127a1f4f2",
+   "metadata": {},
+   "source": [
+    "## 2. Optimization\n",
+    "\n",
+    "Now we'll define the optimization problem to achieve focus on a specific plane and minimize the RMS spot size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6714b791-563a-40ef-99b2-d404e315b219",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem = optimization.OptimizationProblem()\n",
+    "\n",
+    "# Add requirement for spot size\n",
+    "for field in lens.fields.get_field_coords():\n",
+    "    input_data = {\n",
+    "        \"optic\": lens,\n",
+    "        \"Hx\": field[0],\n",
+    "        \"Hy\": field[1],\n",
+    "        \"num_rays\": 5,\n",
+    "        \"wavelength\": \"all\",\n",
+    "        \"distribution\": \"hexapolar\",\n",
+    "        \"surface_number\": 3,\n",
+    "    }\n",
+    "    problem.add_operand(\n",
+    "        operand_type=\"rms_spot_size\", target=0, weight=1, input_data=input_data\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "378b4242-5686-4894-8a6f-c7cb1a8c9245",
+   "metadata": {},
+   "source": [
+    "### Approach 1: Optimizing with \"radius\"\n",
+    "\n",
+    "First, let's try optimizing using the standard \"radius\" variable. We don't set limits here because we can't easily specify that radius should be outside an interval (e.g., radius ≥ 10 or radius ≤ -10)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ee03754-1b53-4cdd-9a20-c5794535d7f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem.add_variable(lens, \"radius\", surface_number=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "004e9639-324e-408c-bb00-a08d0e251ee6",
+   "metadata": {},
+   "source": [
+    "Let's check the initial problem configuration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12463866-f393-47b9-9148-08b5a8c563aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒════╤════════════════════════╤═══════════════════╕\n",
+      "│    │   Merit Function Value │   Improvement (%) │\n",
+      "╞════╪════════════════════════╪═══════════════════╡\n",
+      "│  0 │                69.5755 │                 0 │\n",
+      "╘════╧════════════════════════╧═══════════════════╛\n",
+      "╒════╤════════════════╤══════════╤══════════════╤══════════════╤══════════╤═════════╤═════════╤════════════════╕\n",
+      "│    │ Operand Type   │   Target │ Min. Bound   │ Max. Bound   │   Weight │   Value │   Delta │   Contrib. [%] │\n",
+      "╞════╪════════════════╪══════════╪══════════════╪══════════════╪══════════╪═════════╪═════════╪════════════════╡\n",
+      "│  0 │ rms spot size  │        0 │              │              │        1 │   4.815 │   4.815 │          33.32 │\n",
+      "│  1 │ rms spot size  │        0 │              │              │        1 │   4.816 │   4.816 │          33.33 │\n",
+      "│  2 │ rms spot size  │        0 │              │              │        1 │   4.817 │   4.817 │          33.35 │\n",
+      "╘════╧════════════════╧══════════╧══════════════╧══════════════╧══════════╧═════════╧═════════╧════════════════╛\n",
+      "╒════╤═════════════════╤═══════════╤═════════╤══════════════╤══════════════╕\n",
+      "│    │ Variable Type   │   Surface │   Value │ Min. Bound   │ Max. Bound   │\n",
+      "╞════╪═════════════════╪═══════════╪═════════╪══════════════╪══════════════╡\n",
+      "│  0 │ radius          │         1 │    -100 │              │              │\n",
+      "╘════╧═════════════════╧═══════════╧═════════╧══════════════╧══════════════╛\n"
+     ]
+    }
+   ],
+   "source": [
+    "problem.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88d41f54-a823-401c-981a-ea733250c840",
+   "metadata": {},
+   "source": [
+    "Now we'll run the optimization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a27cb47b-dec8-4410-b205-39ace5477c01",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RUNNING THE L-BFGS-B CODE\n",
+      "\n",
+      "           * * *\n",
+      "\n",
+      "Machine precision = 2.220D-16\n",
+      " N =            1     M =           10\n",
+      "\n",
+      "At X0         0 variables are exactly at the bounds\n",
+      "\n",
+      "At iterate    0    f=  6.95755D+01    |proj g|=  2.79464D+01\n",
+      "\n",
+      "At iterate    1    f=  5.63264D+01    |proj g|=  6.26513D+00\n",
+      "\n",
+      "At iterate    2    f=  5.47559D+01    |proj g|=  4.71442D+00\n",
+      "\n",
+      "At iterate    3    f=  5.18047D+01    |proj g|=  2.39333D+00\n",
+      "\n",
+      "At iterate    4    f=  5.01328D+01    |proj g|=  1.42324D+00\n",
+      "\n",
+      "At iterate    5    f=  4.87170D+01    |proj g|=  7.97435D-01\n",
+      "\n",
+      "At iterate    6    f=  4.76943D+01    |proj g|=  4.57275D-01\n",
+      "\n",
+      "At iterate    7    f=  4.69095D+01    |proj g|=  2.59918D-01\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " This problem is unconstrained.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At iterate    8    f=  4.63210D+01    |proj g|=  1.48244D-01\n",
+      "\n",
+      "At iterate    9    f=  4.58757D+01    |proj g|=  8.44444D-02\n",
+      "\n",
+      "At iterate   10    f=  4.55399D+01    |proj g|=  4.81243D-02\n",
+      "\n",
+      "At iterate   11    f=  4.52863D+01    |proj g|=  2.74234D-02\n",
+      "\n",
+      "At iterate   12    f=  4.50949D+01    |proj g|=  1.56255D-02\n",
+      "\n",
+      "At iterate   13    f=  4.49504D+01    |proj g|=  8.90452D-03\n",
+      "\n",
+      "At iterate   14    f=  4.48414D+01    |proj g|=  5.07612D-03\n",
+      "\n",
+      "At iterate   15    f=  4.47590D+01    |proj g|=  2.89049D-03\n",
+      "\n",
+      "At iterate   16    f=  4.46969D+01    |proj g|=  1.64633D-03\n",
+      "\n",
+      "At iterate   17    f=  4.46500D+01    |proj g|=  9.38626D-04\n",
+      "\n",
+      "At iterate   18    f=  4.46146D+01    |proj g|=  5.37170D-04\n",
+      "\n",
+      "At iterate   19    f=  4.45877D+01    |proj g|=  3.06954D-04\n",
+      "\n",
+      "At iterate   20    f=  4.45673D+01    |proj g|=  1.70530D-04\n",
+      "\n",
+      "At iterate   21    f=  4.45527D+01    |proj g|=  1.00186D-04\n",
+      "\n",
+      "At iterate   22    f=  4.45408D+01    |proj g|=  5.32907D-05\n",
+      "\n",
+      "At iterate   23    f=  4.45329D+01    |proj g|=  3.12639D-05\n",
+      "\n",
+      "At iterate   24    f=  4.45161D+01    |proj g|=  1.49216D-05\n",
+      "\n",
+      "At iterate   25    f=  4.45123D+01    |proj g|=  7.10550D-06\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " Bad direction in the line search;\n",
+      "   refresh the lbfgs memory and restart the iteration.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At iterate   26    f=  4.45123D+01    |proj g|=  7.74500D-05\n",
+      "\n",
+      "           * * *\n",
+      "\n",
+      "Tit   = total number of iterations\n",
+      "Tnf   = total number of function evaluations\n",
+      "Tnint = total number of segments explored during Cauchy searches\n",
+      "Skip  = number of BFGS updates skipped\n",
+      "Nact  = number of active bounds at final generalized Cauchy point\n",
+      "Projg = norm of the final projected gradient\n",
+      "F     = final function value\n",
+      "\n",
+      "           * * *\n",
+      "\n",
+      "   N    Tit     Tnf  Tnint  Skip  Nact     Projg        F\n",
+      "    1     26     55      2     0     0   7.745D-05   4.451D+01\n",
+      "  F =   44.512321103130290     \n",
+      "\n",
+      "CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH             \n"
+     ]
+    }
+   ],
+   "source": [
+    "optimizer = optimization.OptimizerGeneric(problem)\n",
+    "res = optimizer.optimize(tol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f0544a-eae9-4c58-9381-e2d7bd215833",
+   "metadata": {},
+   "source": [
+    "Let's examine the optimization results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36adbdf7-ec60-41c1-b930-d2239e221463",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒════╤════════════════════════╤═══════════════════╕\n",
+      "│    │   Merit Function Value │   Improvement (%) │\n",
+      "╞════╪════════════════════════╪═══════════════════╡\n",
+      "│  0 │                44.5123 │           36.0229 │\n",
+      "╘════╧════════════════════════╧═══════════════════╛\n",
+      "╒════╤════════════════╤══════════╤══════════════╤══════════════╤══════════╤═════════╤═════════╤════════════════╕\n",
+      "│    │ Operand Type   │   Target │ Min. Bound   │ Max. Bound   │   Weight │   Value │   Delta │   Contrib. [%] │\n",
+      "╞════╪════════════════╪══════════╪══════════════╪══════════════╪══════════╪═════════╪═════════╪════════════════╡\n",
+      "│  0 │ rms spot size  │        0 │              │              │        1 │   3.852 │   3.852 │          33.33 │\n",
+      "│  1 │ rms spot size  │        0 │              │              │        1 │   3.852 │   3.852 │          33.33 │\n",
+      "│  2 │ rms spot size  │        0 │              │              │        1 │   3.852 │   3.852 │          33.33 │\n",
+      "╘════╧════════════════╧══════════╧══════════════╧══════════════╧══════════╧═════════╧═════════╧════════════════╛\n",
+      "╒════╤═════════════════╤═══════════╤═════════╤══════════════╤══════════════╕\n",
+      "│    │ Variable Type   │   Surface │   Value │ Min. Bound   │ Max. Bound   │\n",
+      "╞════╪═════════════════╪═══════════╪═════════╪══════════════╪══════════════╡\n",
+      "│  0 │ radius          │         1 │ -325669 │              │              │\n",
+      "╘════╧═════════════════╧═══════════╧═════════╧══════════════╧══════════════╛\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1QAAAD0CAYAAACclWcuAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAARhhJREFUeJzt3XuYHFWdPvD3nLrOfSYXkkAGuYSAchE0GMgjQZRVQZBVbj4PV8UFV01kWRYXHxVwAS8JiCuK4C4EkZVVlJ/KIgo+YUFBAbks91sEQxIgkLkm011ddc7vj6ruruqununuzExPd96PTz/dXXW65qSLifXme84pobXWICIiIiIioprJRneAiIiIiIioWTFQERERERER1YmBioiIiIiIqE4MVERERERERHVioCIiIiIiIqoTAxUREREREVGdGKiIiIiIiIjqxEBFRERERERUJ7PRHZhJlFLYuHEjurq6IIRodHeIiIiIiKhBtNYYGRnBzjvvDCkr16EYqGI2btyI/v7+RneDiIiIiIhmiPXr12PhwoUV9zNQxXR1dQEAXlr318LrRlFKYXBwEL29veMmYmoePKetiee19fCctiae19bDc9p6Zto5HRkZwZ577D5hLmCgiskP8+vq6kJ3d3dD+6KUQhAE6O7unhH/QdH24zltTTyvrYfntDXxvLYentPWM1PP6URTgWZOT4mIiIiIiJoMAxUREREREVGdGKiIiIiIiIjqxEBFREREREQNpbWG53nI5XLQWje6OzXhohRERERERDQhrTWyQTb2yCAbZJHJv/czJfuTbYvtyj/veR72+799AQCn/eMZ2KV3lwb/aavHQEVERERE1GS01vCVnwgqXvScKQk8WT+/rTTwZJDxk++9wCv/fOxRC1OacAwXruHASTzc8Nl00OP0YK504Ain8DlLWpP9dU0pBioiIiIiou2ktKoYUipVcTKxEFNWxUltmww5Squq+yeFLA80hp1432a2o8/pg2O6ZQEoEYqi/a7hwDbswufdxLEdGNKoun+e5+HKtasBAN12Y29fVCsGKiIiIiJqKVpreMqLDS/LJAJJahVmvCpOyjC18OEV3udUrqY+2tIuVGmSgaQYYjrc2eF2MxlUyh9urF2ybT7kmNKc8H5KVB8GKiIiIiKaUr7KReEjVrFJCSiFQOOnBJrSYW1+Bluz2xAIPxGAMlEbjeoXNjCEWQwzJaEkv73b7oYTVWQKlRizuipOaVXINhxIwbXhWgUDFREREdEORGkFLzGErDi0bLy5M+nVnpJAlFrFySLQQdX9ExDFgBIFFlvaZQGly+rGTjbQ1dYN13QrVHGKIcfOV2xSqjim5CUx1Y//9RARERE1iNYaOZUrq8R44wSUxLC02P70kBOrCkVtPeXV1EdLWuUVmJJQ0uv0JefPJPYn5+kkKjZmcliaYziwpFXV0DSlFAYGBtDX1wcpWe2hxmGgIiIiIooEKqgw1KwYSMZbLa04b6dyFacYlMJttQ1NMyaYO+Og0+rEbHd2FGRKKjZm6YprJSHHTM69saRd08ICRDsiBioiIiKakaq/542XHnBiw9QyQQajY6NQhioPOX4WWRUew1d+TX1MWxLaLgkoXXZX2QIBxYCTMvcmparjmOFnzSZbTppoR8BARURERBMqveeNFwsx9d7zpuI9c2KPWox/zxsbUkj02D1wKy0JbUZzdWJzd8qrOMVhara0uWoaETFQERERNaN673njlQaclIUJpuqeN6UroLVZ7eh1+1KXgK5utbTictL2BEPTON+GWorWgMoBygcCP3xWOUAFgPIhCq/T24iKn422p7YpOUaQS92efy1UAJS1iR5BDkKX7A8A4HQAgBjeCLh7NPQrrgUDFRER0XYa7543FaswNd7zpnjfnPrueZN+3xo78X78e94UqzjlNwblPW9oBtEq5UI+utgPchAVtkP5gB4nKETbRUo4gAoAXXxdCCOlbVTJMQI/8blEGIkHGp0MP6KGf9yo+esTEpAWIE3AMAERPUsTkBa0NJL7ZfKh88+WCzgGYFgl+y1ARttjxw60Ady3NeyDyxv7EhERNVQ4NK2kYlPlPW8yfgZD24YgTBGFpMoVn+m4503aKmhl83QmqOLY0XA32sFpDeig5AI/WZ0QqRf5xXBQ2J9SkShULXRamyhIjFMRmbDyER07fox5QQ5SB8V+BDmIGn4Xa/4KZWmAiMKBNAHDghblAaLwMKIwYtjQVntqG23kj1dyDKMkjJQGnonaxPqqy44d+zNIE2jQ3xWB5wH3rQ7f2J0N6UO9GKiIiGhK1XbPm5LFBRpwzxtbOjBhosNuj6145qLH7oFjutEcmwmqOLHFBkrDkG3YvOfNTKR16rAk6LTKRC5xAZ8II5UqH4XPl1dEJqx8lFU1kv2qrvIR9W8qv8IKF/DVVDUKbQwH2upIaZPfXwwDWhgYy+bQ1tEFYVjJykdK6NElFZGJjl8WOoQBsOpKKfg3OhHRDiTtnjeJxQW24543xSFp23fPm3xgKQ0kdmxo2Xj3vEldEtosVnUmuucN59qk0GoSqhqVKhLhZ0XZZ0v2j1vVqFT5iIeOHHbyczAQq2bEh4HVEMJr/vqELK9mlFYtSqsGsXBQHEJVUtWIqhOVqxrxQFP+ubqqGoUhYPE/ixVWNaY5bCilMDowAIu/q9RgLRGo7rnnHhxxxBGp+x544AEccsgh09wjIqLqbM89b4o37Kz+njee8mpaWMAQZtk8m8r3vClfBW3CG3uW3PPGNpzmG5qWcnEeH/IkUoZFjVu1SAyXKg0S4wSWlGOnBpqU0JOofKQEmqmdr2GkXsDnL+x1WThIrypow61QGQmPrYWBjOfDbe+EiFc5JqhqxANNWlWjUPmo8NlGDqEiounREoEqb+XKlTj44IMT2xYtWtSg3hBRs6nmnjee8hI35Mz4GQyODkLaElkVH6aW8vmUxQUm4543pXNnCnNvUhYMqHzPm3hIKrbfrqFpqfM1khf7IpsF1Nay7flqh6hQERm/alEMB2KcikjpXIzC/sDH3FwGhgCSk8PTQ9HUz9coqQTELtTLLvTzw5Li+w07HEIVm+eRb5MaFCpVNVKqE5XnYqSEIWGktDGmLWwopTAyMACT1QwimmQtFagOO+wwnHDCCY3uBhFNgsI9b9TEAaWae954yhtn3k5997yxpBUOIxM2XKstsQKaLcPXPU4PdkqdZ2PDkRYcacIRFhxhwBUmHGnAESZcIWFDwhUGHAg4woCtdDgsqVB1qFTViK0y5fuAygLBaOWqRenStfFVplLmeSSrIuOEpemYr1FhqJNOGdJUVvkwTGizvKqhpYmsF8Bt76hctYhVPtKODSMl7CSOEfVx3KoG52sQETWDlgpUADAyMoK2tjaYZsv90agFbN68GZs2bpzRSwkrrRDoAL72EWgffvQ6/8hvK90XFNqE20zHQluXm74c9FTc8wYiCigW3HxIkSYckQ8oBtqFRB8MOELChQNHunANGQYWLeAAcDVga8AF4GoFRwOOUnC1hqMUHK3gBgEcrWD4PnTWR+BlYMoxQI0kw0iFqko4hGo652tUqmqkL11bnK/hAM5EVYv04VKp8zUqzucoD0U6vl2ktal8v6HtpZTC8MAADFYyiIioCi2VOj75yU9idHQUhmHgsMMOw6pVq7BkyZJGd6suW7M+RrMBzIwPKWfuxTdVQSto38Mrr67D7373P9g2NgIIH1ooaBFAQwHChyq8Dwr7lFDQUFAi3KaEhka4vfjQUCi+DoSK3kevhUYAjUDoaFvxff7hQyMQiNps/x9ZaMDSOgouAo4Og4qjNRyto9cKXUrD1UG4PQjCABP4cLUOA0y+vdJhkCl8Ptqniq+tak+HKF1xykhMxtbRsKjybfG2FpRhIZDhvAzPV7Dc9miVqSgkiFiVxDCh48+lczdSf4Y5Th/LQ0sioLTifA2N8KaPAQCo6DE1lFIYyfowxnIMVC2E57X18Jy2llyueG89paZuKPVUaIlAZds2jj/+eBx99NGYM2cOnn76aaxevRqHHXYY7r//fhx00EGpn8tms8hmi0N8hoeHAYS/oEpN3f9ZV+OU6x/Gc6+PNrQPU0/DgIKJACYCGAhgIYABBQs+DBE9Q0Xbg2LbxL6SNqLYrvhQ4fFF2EbAB2QOEH4UbnxoGUBLPwomAQIRQMkAgVDhQyr4QsGXCr4AfKGQExo5AeRk+OxFj6wEPCGQFUBWCGSFgBYC2Kn+b8vUGpbWMDVgQUfvw+BiIdxnacAtvA/3mSr8jKEBE6L4WgsYGjAgIPOvtYCh8+9l+AwBoQWEljCiZwkJoWT4WofPgITUBrSWAAQUTPgw4GsjfIaEDzN6Ngr7AhjIwcAYDIzE2xQ+V2xTeNb59+XHDGAgp+OfkcjBjNoaAJrhHygKyYGIiGiHYCLAaW3h69eGxrCb6zS2Q0DVeUBorZsrAlbpxRdfxAEHHIDly5fjzjvvTG1z8cUX45JLLinb/uxzz6Orq2uquziuP/11AFsGh9DuWjCgIHQAqXxIHUBoH1KHQ4akjrZF++Lb858J36fvKx6v+s8kfm7+s6qkXXy/KraL/ywZDXlSKIaOTPxZpmwTAploe36bV9gnC/syQiAjJLIyehb5zwBZAQQ1DLmTGrAhYEMWHhaMwnP42oQlDFgwYQkTFixYwoQpbFiwYAoLfsbH6Mg2dLV3w7XbIIUJCQMSZvgQJiQsSGEBifcmhAgndGshoRA+a0goEYUXIaGR3y/D/dHrRlQrto6O4m/r12PvxXtj7k7bkSKbgVYYy2TQ5rqtWRnaEfGctiae19bDc9pSVODjr/f+AgBw8imnobujvcE9CqcS7bP3YgwNDaG7u7tiu5aoUKVZtGgRjjvuOPziF79AEAQwjPLx9hdeeCHOO++8wvvh4WH09/ejt7d33C9tOvz9L/4ecvMzU3LscH5F+gRqLQ3kpImMtJA1JLLSREZKbJNGMbBIA1kIZKREVjjFKgyAjNDhMxSyALJQyEIho8PnrA6Q1QEyOkBW+8jqALka55LY0oIj7dSlnMPlml30xm7G6ZSsiGbHl2wu+3zx4UbbTGlOypynp558Ev/7v/fggN0PwLz587f7eDPZG69nkVu3Cct3X4J37LtHo7szpZRSGBwcRG9vL4ectAie09bE89p6eE5bi+d5uOre8PW8ObPhum5jOwSk5oc0LRuoAKC/vx+e52Hr1q2pAclxHDhOeTlRStnwX8zcYV/Eti2vwensCoeQQUdhRSMDHQYTaGS1QhZBLKj4yKowrGRUDlmVQ1b5yCoveu2VLQEdv0dNNshCwwcwzupc+ZpmEN6jxjUcODJ5Y834Es6dhovZ0U05K92jJhFwSpaAjocd27Cb7x41kXwoE0LM6EUpJkP8z9ro36XpkP9z7gh/1h0Fz2lr4nltPTynrSN+DmfKOa22Dy0dqNatWwfXddHZ2dnortTszFd+imcGnkFQQ/VGQBQDipmsyCTvUdOTrMSYaRWaWMgxwyWgJ/0eNURERERETa4lroY3b96MuXPnJrY9/vjj+NWvfoWjjjpqRiTcWp2018l4Y3gz+jp74Vpt5RUbMx6SwoBjSavlKx9ERERERDNJSwSqk08+GW1tbVi2bBl22mknPP3007juuuvQ3t6Ob3zjG43uXl0+vNtRGBgYQB/vg0JERERENGO1RKD6+7//e9x888248sorMTw8jLlz5+LjH/84LrroIixatKjR3SMiIiIiohbVEoFq5cqVWLlyZaO7QUREREREOxiOJSMiIiIiIqoTAxUREREREVGdGKiIiIiIiIjqxEBFRERERERUJwYqIiIiIiKiOjFQERERERER1YmBioiIiIiIqE4MVERERERERHVioCIiIiIiIqoTAxUREREREVGdGKiIiIiIiIjqxEBFRERERERUJwYqIiIiIiKiOjFQERERERER1YmBioiIiIiIqE4MVERERERERHVioCIiIiIiIqoTAxUREREREVGdGKiIiIiIiIjqxEBFRERERERUJwYqIiIiIiKiOjFQERERERER1cmsptGVV165XT/kpJNOwsKFC7frGERERERERDNNVYHq/PPPhxACWuuaf4AQAgceeCADFRERERERtZyqAhUAfPvb38Zxxx1X08G3bNmCd7/73TV3ioiIiIiIqBlUHajmzJmDt73tbTUdvLOzs+YOERERERERNYuqAtXAwAA6OjpqPvjs2bMxMDDAYEVERERERC2pqkDV09NT9w/Yns8SERERERHNZFw2nYiIiIiIqE5Vz6Eq9eMf/xjXX3891q1bh4GBgbIVAIUQGBoa2u4OEhERERFRa/KVj2yQxWh2tLAtUH4De1S7ugLVF7/4RaxevRq77LILlixZwmF9RERERERNTmkFL8giE2ThBR6yQQbZ6H02yCLrh++L24rvs374vtA2yMJLtI2194vbAx2GJ0MZ+Bg+BgB4M/MWOtqbZw2GugLVD3/4QxxzzDG47bbbICVHDRIRERERTSatdVS9SYaUQsjxS0JKScjJB6Jiu7S20baojae8mvpoSxu2YcMxXLiGA8dw4JjRs+HCMRz0OL2YF3sf35//jG04MJWJh/72ZwBAn9M3FV/plKl7yN/RRx/NMEVEREREO4RABYlgkhZIMrGqTGoVJ6rypAWkwmf8LDwVvlZaVd0/QxhRUEkGGtcsbuuwOjHLnR1uj9qEgciBY8ZCUfzzhaDkFva5UQiSYvKygOd5eAhhoLINe9KOOx3qClTHHHMM/vCHP+Ccc86Z7P4QEREREY1La42Mn8Fwbhi5bTnktBcFEi9ZhfFTAk08DJVUeUoDUTwU+TXO60lUbUpCSX57l92VCCmFKk6hklMh5MSqPLZhwzUcmNKaom+bJlJXoPrud7+LY489Fp///OfxqU99Cv39/TAMo6zdrFmztruDRERERDRzFYamqfSAUjp3JrVqEw1N85SXmKtT9vnYoxaWtFKGmdmJYWg9Tg92igeaeHszvWpjl4ahqJ0tbQghpugbp5mmrkDV0dGBZcuWYdWqVbjmmmsqtguCoO6OEREREVHtlFaJkFI296bCAgNeacApGaaWOvcmqH1omhSy8rCyqIrTZrWj1+0rr9rkqzzShi1t5DI+ZnfPQpvVljhesYrjwpY2DFn+D/9Ek6WuQPX5z38eP/zhD3HIIYdg6dKlXOWPiIiIKIXWOlZ1SZl7UximVmUVJ2WYWulQt5zK1dTHZEUmfe5MZ1tnSrvqqjjxKtBkDk1TSmFgYAB9fX2c108NVVeg+u///m+cdtppWLNmzSR3h4iIiGjq+MoPVz8rrGo2wWpp/jhVm6iqk1bxiVd9NPTEHYuY0kyfe1OovNjotrsTq6WlVnEMN7EYQTzk2CXH5tA0ou1TV6CyLAuHHHLIZPeFiIiIdiDxe96UDi1LG1aWKQktZZ8tW4yg9POZ7RyaZqcEHBc9dk9iBbTSuTqJFdKkXVhsIC0McWgaUfOpK1B94hOfwK9//Wt85jOfmez+EBERUQNorZFTuQqroJWHHC/wksPS/EpVnPIbedY7NM2W+eWdK8y9MVz0OR2J+TP5fba04WcDzOrqg2u6qaulla62ZkqT1RuiemkNKD/5CHKADsJn5UMU9uUgsrGFRoIsALdhXa9VXYHq5JNPxooVK/CRj3wEn/rUp7DrrrumrvL3rne9a7s7SEREtCMKb+hZspiAX6zMVLzHTdlCBOmLEeTn9cSXla5laJohzIo38iwsCW11YY47p7Csc3wVtPGqOGVzb6IV2bbnnjecb0MzilbFgKECQOUSwUPkt+v0NmKcz+a3i7LPxtoG+TBTvj3/M4UKCmEncYyUMFR2DOVD6FoXpzMBsRIAILa+CXQ0zxoNdQWqww47DADw2GOP4c477yzbr7WGEIKr/BERUUuID03zYpP/K62Wlgg5ZQsRlAai9CpOoKu/542AqDBvJpwvkw8o3XZPYl9pFacs5BT222UBx5R1XUIQjU/rKGwkL87Di/x8mIgCg5+FNTQAua0NovCZINqf/tliEEiGA5SEAxHkyj6XCDzjBRoVhZHCscsDjahh6GnNX6E0gcTDAqQBGBYgzfL9hgWI+H4DMGxoK71N+fGj/dKIPp9/bUX7TEAU2+j89pLPeoEAfnR7+GfomDdl389UqOtvwxtuuGGy+0FERFSVwj1vKgwtG3eBgVggSltOOvx8BmO5MeR0rhiAlFdTH/ND0+JhprSK0+P0Yl7JCmhpVZvEMWIVnvjcG0taHJq2I9A6MVwqbTiVGKdiAR2rfFSqaqRt18EExy8JEpV+flmblKpGjcNAax0UpqUVu/hPXtjrkgv/RBiJ2mrDBAwH2u6ovL9SoJFRGDHKt+eDR2pYKbRNO34yLEEYQJP+XaA9D0AYqGA01z/Y1NXbM844Y7L7QURETSpQQYVV0DKJikv8HjepQ9X8CnNvYosMeKr2e94YwkhdLS1eyemwOjHLnR0tGuBA+xo9HT2FYWil83RKl5SOz72xDWe7hqZRnbQur2rELtqFn4M5+BZErh0CqqxNWVUjbYiULg0QKVWNlO2FqkRqRSQWhlLDUrGSUvsQqhq+PiFTKgqxsJF2AR9rk9+vLSd5gR8PEpVCQOnPyAeaRLgpOYZhQUFieOsYunv6IE07CiulYankNdEUaK74N45sNouvfvWruOmmmzAwMIADDjgAl156Kf7u7/6u0V0jIpo2WuvUuTPxe9SUzptJDUNlVR6vPOBE+31V/dA0AOlLQpfMnem2u2FHw8zKloQ2U+bepCwwkJ+3U+s9b1pyrk3pXIj8cKb8hXqFC/iKQ6Rin03OpSitSFQ4RkqbwjFiczjS98fnlsQqI1WE7HqnuBcv5MurGjAsaFEeDhL780OhzLYKlZH0ikkhrCTCTcpwqkrDrGLt9TifDSsbzfffulYK/sAAdF8fdKv8rlJTqjtQvfLKK7jxxhuxbt06DAwMQOvkRFYhBH75y19udwerdeaZZ+LWW2/Fueeei7322gtr1qzB0UcfjbVr1+K9733vtPWDiCivMDRNlQeUtLkzlRYYKN70c/wlpfOPWljSSp03Y8vi6x6np/I8mwqLEeTvc1O6EIEt7Zk1NC0/hCp+oe5nIbe+BSFHASiIRMWiZJiTzs+lGKeqkbY9Mfl8nIndepz9sXAjKlRMCoGnhsUmav4KK1zAhxWFChfvsUpFOF/DgbY6Utrk98eGM5VVNdKrHYUgEVVStAirGV1RNSP1+JXmlsyk/2aJaMapK1D95Cc/wRlnnAHf99Hb24uenvJVOKbz/zAffPBB3HLLLVi1ahXOP/98AMDpp5+O/fbbDxdccAHuv//+aesLEc1cSqsKq6BVXmCg/JEclpbxM9iW3QpfBGXHq3VoWvk9b5yyFdDarHb0un3pN/KMhqbZ0h53tbT8QgS2tMe/501hydv0ydsi7QLfzwHeGKBGkm3KJniXztdIHwpVmPhdYSiUiFc7UtqUVTVKV9KqUF1rq/U/rrSvT8iUioJRUrVIDwHxid/aakte4EdDoSpXNSoNkYqGcdVU1bAqfhbSCqsaTRI2lFLIsZpBRFOgrkB14YUXYp999sGtt96KxYsXT3afanbrrbfCMAycffbZhW2u6+Kss87Cl770Jaxfvx79/f0N7CERldJaF5ZtLl8FLT7MrLoqTiZ1mFpyqFqt97xJVmRSQo600GH3YI7sRrfbAdewYQsTjjThCgOOMOEIA44wovcGHC3gSAOuBlxIOBDRQ8PSSFz8l08O94GcD2RygBqDUMMp8zCKw6Vqmzw+GUveVk8LI/UCvjDxOiUcpE381oZboTJS6dhRWBFmxaqGEhKj2zLo7O6FiFUyEvNG8pWPcSeH86KdiGhHUFegevPNN3HBBRfMiDAFAI8++igWL16M7u7uxPb3vOc9AMLl3RmoaEektUaAAL7y4WsfgQ7ga7/wCFT+dXF7oH34KtnO137sGMX2QWx7vN22zCg277QZT770OIxXjWLQUfm5Nx48lavpnjcmJFxploQUCQcGHCHhQKKnEE4EXAg4MODqNjhogyM1XAE4WsHRgKsCuEqF75WCq3zYSsENAjgqB1cFEMFWQA2lhJbcFA+hmnjid2m1I7nkrRkteVvFxG8RO0aFid+lVRCd9vMrhaFKc0tmcFVDKYXswADaW2kOFRERTZm6AtXSpUvxt7/9bbL7UrdNmzZhwYIFZdvz2zZu3Jj6uWw2i2zsrszDw8MAwv8zVWrq7g9Qja3ZHJ59fSu6tsmZNd9gR6N1tKpTWC0QOoBQ4UpPIhouJHQAHXjIBRn4wRi8IINcMAZPZZELxpBT4cpkm7e8gS1iAx5+5TFYr1vwEUBF4SRAAF8rBPARaAUfAQJEz1rBh4reK/iJ9xo5KATQ8IUO90NH2zX8SfpPx9QapgYsAJYOKykmdPQ6fNjRswmNPg3M0xrOGxqu1nCUhqOj11pFz+H2wmsdb6PhquR7A4CGgI4u2LUwC68hjNi2cJiSTmwrBoFwe7TfKDmWMJCVJrLSxFBp25Sfq4UBLUxsy+bgtncWJqfraF5G8tj5fhjQonR/8ec05XwNFT3GFUSP2uZ4NYLWGiMj/Pu31fC8th6e09bi54qjSLZ5Pmy7sdfiAKrOA3UFqquuugpHHXUUlixZghNOOKGeQ0yqsbExOI5Ttt113cL+NF//+tdxySWXlG0fHBxs+E2Jn319FJ+65bmG9mEiAgomFAwEsBAknk0RwET+oWDCLz4LVdhnpLVJfLbYzkIAQ+R/hoIFHwZix4r2SfiQCBDIABA+AqGgZAAlAwRCIRDRs1RhCJEavghf54RGTgCe0MhJwBNARghkpUBWiPC1EMgIiWz+tRTIVfsX+ezou8uFocSKQompEYYUrWECMDVg6PA5fC9gaMDWxdcSAkb0OnwWkFpCQkKq8LUBAaElhJaQOnwtIaNtRvisJAAJqSWgDSDarrUBoQ1oSCgYUJAItEQAGb6OPZe+1hDwtYFRGBiEAR8GfEj4MBFAIqcNBDCQQ/LZh4SvzahteRuNZqsW+NGDiIiIxmMiwGnRBNYnX34d++7S29D+AMDIyEhV7eoKVPvvvz8uu+wyfOITn0BHRwcWLlwIw0hObBZC4PHHH6/n8DVra2tLVJryMplMYX+aCy+8EOedd17h/fDwMPr7+9Hb21s2fHC6vWvLk/jV4a+h3bHCqkhJRSRZJYnmWqRVTwrti9UVpGwrfi6tbYVjVTnZ3geKYUQWQ0l+m1e2T2JMGshKiYw0kBES26SMQoxERgpkBaJjAFnk32tkAWShoSfMNzJ6AEY0NMwWRjj/JXoOH1b4kBZ6hIU50oYtbVjSgi0c2IYNS4aT+y3DDR/ShW20Fd8bHTANF5s2bMaTTzyLRXvsjdlz5kUTy5stIFRny1tv4bHHH8fhhy3H7nvs0ejuTKnwX0hH0NXVxX8hbRE8p62J57X18Jy2Fj+Xw29veRQAsN9u89Db2d7gHqEs31RSV6D6/ve/jxUrVsB1Xey5556pq/xNpwULFmDDhg1l2zdt2gQA2HnnnVM/5zhOamVLStnwcfPd93wFB2x+OnVf7UvUFuc6KMNExpLISgdZ2YaslFGVRUbhRCIjdBR2wnCShUYGQBYKWShkdPic1QpZBMjq6KF8ZLSPrPKR1bnwvfIQ1LDKmYAoLslspi0IEN5XpqdkdbP8qmWpyzrH7lsTbrcTbU1Z990DavJk8ARef/YF7DarA/N26pyWn9kob/gGXpXbsOcsG/su7G10d6ZUeM8ihb6+nob/vUGTg+e0NfG8th6e09bieR5+G71ut80ZcU6r7UNdV5KXX345li1bhttvv73hYQoADjzwQKxduxbDw8OJytKf//znwv5m89hRX8emgddgtrvw4CMbBZVM4BUm9nvR6mVpyz+X3afGHw0/o7wq5zuEbGkX7ilTHk7CUNJTeuNNMyXQlB4jdl+a+GctafFfmYiIiIioadQVqIaGhnDKKafMiDAFACeccAJWr16N6667rnAfqmw2ixtuuAFLly5tyhX+/u3//h0vDr2Q2GYII30J51glp8PqxCx3diKo2IaduEdNxSWgzdh9aqIAJFt0SBoRERER0WSoK1AdfvjheOKJJya7L3VbunQpTjzxRFx44YV44403sGjRItx44414+eWX8Z//+Z+N7l5drjjsSgwNDWHurLlos9rgGg5MaTW6W0REREREFFNX+eGaa67B//7v/+Jb3/oW3nrrrcnuU11+9KMf4dxzz8VNN92ElStXIpfL4fbbb8fy5csb3bW6LOhYgHlt8zDbnY1Oq5NhioiIiIhoBqqrQvWOd7wDSilceOGFuPDCC+G6buoqf0NDQ5PSyWq4rotVq1Zh1apV0/YziYiIiIhox1ZXoDr++OO5cAAREREREe3w6gpUa9asmeRuEBERERERNR8u4UZERERERFSnqgLVI488gsHBwZoPHgQBHnnkEWzdurXmzxIREREREc10VQWqgw8+GHfccUfNBx8cHMTBBx9cuMEuERERERFRK6lqDpXWGs8++yzuvffemg4+NDQErXVdHSMiIiIiIprpql6U4tJLL8Vll11W08G11lwNkIiIiIiIWlZVgWrt2rXb9UPe+c53btfniYiIiIiIZqKqAtXhhx8+1f0gIiIiIiJqOlw2nYiIiIiIqE4MVERERERERHVioCIiIiIiIqoTAxUREREREVGdqg5Uhx56KJ588smp7AsREREREVFTqTpQvfzyy3j3u9+NL33pS8hkMlPZJyIiIiIioqZQdaB67rnn8OlPfxrf+ta3sP/+++Puu++eyn4RERERERHNeFUHqu7ubnzve9/DAw88gO7ubnzoQx/Caaedhs2bN09l/4iIiIiIiGasqm7sG3fwwQfjoYcewne/+1185Stfwe23347+/v6ydkIIPP7445PSSSIiIiIiopmo5kAFAL7vY/Pmzchms5g9ezZmz5492f0iIiIiIiKa8WoOVHfffTc++9nPYt26dfjsZz+Lyy67DF1dXVPRNyIiIiIiohmt6jlUmzdvxqmnnooPfehDaG9vx/33349///d/Z5giIiIiIqIdVtUVqr333hue5+Eb3/gGzjvvPBiGMZX9IiIiIiIimvGqDlSHHHIIvv/972O33Xabwu4QERERERE1j6oD1R133DGV/SAiIiIiImo6Vc+hIiIiIiIioiQGKiIiIiIiojoxUBEREREREdWJgYqIiIiIiKhODFRERERERER1YqAiIiIiIiKqU9XLphMREREREdXCVzlkgiyyfhbZIItskEE2yIbbYu/HMmOFz4z5Y3DhNrDXtWGgIiIiIiLaASitCiEmUwg4KSHHD99nlVd8HWubib+P7S8NSV7gIdBBVX0zlIGP4WMAgCFvCH3om8qvYlIxUBERERERTTOtNTzlRaGkNKjkQ4qXfO/nQ0uFkOOXB5p4+5zK1dRHW9pwDAeO6cAxXDiGA9dwwm1GuK3DnQ3HsAv7w7bhvtK2juHANZPv8w8ZCHz3qn8HAMxvnz8VX/mUYaAiIiIioh1e+tC0kkATxAKNP07VJl+5KQSmZADKBFl4QRYauur+GcIsBpSyUBIGny67C3OMObHg48bapoQcM/q8tIuvo8/ahgMppm+5Bc/zpu1nTTYGKiIiIiKaUYpD08qHluWDS8Yfw5bhLTC2mPB0+tC01EBUUsXJP6odmgYAAqIYUEwnVskpVnFc00WP0ZuowrhmeWUmfG9PWMUxJS/bZyqeGSIiIiKqSGuNnMqVV2L8ygsM5IemeSpZ8cmUBZ7i/u0ZmmZJq7wCUxJKep2+YtWmbH9JoImHHdNBouJjOLCkBSHEFH3j1GwYqIiIiIiaiK/88sUEKlRdyubZ+OXbUhcjKHnUNjTNSKnAxKsuDjqtTsx2ZyeGl8WHoaXOvSkZpmYJC2MjY5g3ex5Mg5e01Dj8r4+IiIioTkoreIkKTeUV0soWEyhbiKA0EHmpVZxA+zX1sXxxgOTQtHDuTXdi/kxiWJo58QIDtgzbuYYDU1pT9G0nKaWgt+lpnedDlIaBioiIiFpC6dC0+PyZsVwGbw69CXubVVxZrTTklAxN8+KBpnRYW9TWU7VNpE8bmmaXrJDW6/SmzrNxU4axFY9REoYKQcfm0DSiKcZARURERFMiUEGFVdAyqfNmSoemebEV0ipXcfLD3TLwlAelVdX9iw9NSwaSYhWn3epAnzurvGoTG5pmx1ZIS8y9KVmIwJY2DGlM4TdORI3AQEVERLQD0FpXPXcmH3K8WIUnuRDB+IsR1D80zSmrypTOnemyu1KHpuWrPJWqOJa0kRnNYKdZO6HNapvWoWlETUkrIMgBygdUAKj86/AhglzqdgQ5QAcQ+deV2qgAIrbdyMUWIskOA67buD97jRioiIiIppnWOlpYIL3ykikMJ8uOfyNPP71qkz+mV7KwQC1MaabPvYkNTetxerCT4UZhJmXuTWxZ6fSQNH1D05RSGAgG0Of2QUrOuaHtoHUYNvJhIMgHhWJ4EPntOi1UxIJE4CeDRnQMEeSiz5Yeu5o2sf2q9PjFtkIFscBU8ghyEDUsRFLzVygMwLAAaQDSAqQJQzgATg4beFun7GdPBQYqIiLa4cWHpo3lxvDG1jewGW8gp3MTVnFK75OTFmbKqjhBtqahaVLIylWbaLham9mOPqcvcXPO8W7kGR+aZht2WRji0DSqi9apF+fQxYt3oVJCQlASRkrbxC78RbRdBj46t47AtE0IqJTj+2XHTt0/XpuUUCRUbZXXmr/CKGDAMMNnUXytZbRNRmHEiNrGtmtpAIYDbXWktikcw7AAkbY/H3TMstBT/PwEP3+c44d/pvJ/PPE8D7hidfima8GUfseTjYGKiIhmlPzQNE95Kaugld6cM6VqUwg0XvF9hSWl86HIr/ECqXRoml0698Zw0Wl1JubPjLfAgC3Tb+SZDzmmNLmwQCvQKvXivfIQqmSb2oZQFSsV8UpKPoyUbs+HBlFSBSkNNOVhKFlpETXcHLfmr0/IZJiQJjqEAWFYEEb+Qr78Aj9/4Z8PEtpqT4YEIwwtOiU8lIaK8BhpbUrDSHooSoSR0jbSAoRMDRs0szFQERHRuHyVSw0llW7kmX+fCDQlVZxKVZu6h6bJ9Bt55kNOd35J6JQbdJYGIlva8LZ5mNM7B21WW1nIsQ2byzRPtlqHUKW0mXAIle+hY+sITNeKhYZahllNEGgqDqGKVT1qqErW/BUmhlCVX7TrlHCQ3B+FDrMteYEfDxIp2/M/T49TsSgNNKWhKP9aj/PZMJQkf++UUhgYGEBfH4dxUmM1faBas2YNPvnJT6bu27RpE+bPnz/NPSIimjpKq3Hnz8SHpnnKi4JQ5SpO+jC25IIEQQ3/4iwgKsybid+3pi1cFjoxNM1GxSpOIQi5ZWHINmyYcnL/r2zGXaRVNYSqcsVi4iFUyYnh4w/RKj12LEiM8/NTh1DFqxoqN/H3sD1fYXRxbgoJYdglFYWJhlBFbQy7jiFU8apGWqAZbwhVhTBUwxAqIpoeTR+o8r72ta9h9913T2zr7e1tTGeIaIeQH5o2khuBP+Yjlw8wsUAyURWnLOT45YEm3j5X44WnLe0KgaQYWjrc2clAY6YEmkQgKh+aln9Y0preoWlaAYFXeQjVuBPD0ysOIsihfWQYRpsNoQKIss+ON4SqfCiUqDBhvGJYKQk9UzqECiL94jy6eE8fQhULElE40FYbIDurGEJVyzCrlPkc8dBR4xCqGReUiahltEygOuqoo7BkyZJGd4OIGqh0aJqnsrEqTspiAv44VZtoUYG0xQjyx/CCLHQNqyAZwiypuMRDSRh8uuwuzDHmpK6CNt4CA07sPjiO4cCVNmxpQeoA8UpAfDiTqDAHomwIVdYH1FZADyWGU4mSC/9xh1BVWE2qqiFUZW2mfgiVjWgIVcVhTmlDqNImhlvQhjvxECoR/zklQWKiIVSpFYsJhlAVqh0MFkRE26tlAhUAjIyMoL29HYbBlYmIGk1DI6uyGMwOVjV3Jn1oWoUloSssMFDf0DQHrhGGD0facKQFR1pwpQ1HmuiWFhyrDa5twhEGHGHCERKuMOAICVtLiKyHLseFKyRcCDhawAXgaMCFhqMBRymY0OVDtAIfyOWHP20F1FAVQ6hKh1mlTAyfpiFUpdWC1CFUKUOVqh5CNe7E8EpDqIziKlkV2ow3REvBwMDQMPpmzWYlg4iIJtQygeqII47A6OgobNvGhz70IVxxxRXYa6+9Gt0tokmltIKv/cIjUD58HYSvC9sD+MpPtPO1D1/5CHQOvsohUDn4OnqOXof748fNFT4XHj+IHU8VfxaCqA/RAwo5HSDYTeHnT/0ceKq6P5sFGQYVhEHFgYCL8NkB4EKgQyN8rQFHa7haw1EajtZwtAVHGXBUgDal4SgfjgrgBgEc5cMNcnCCAE7goS3wYQGYioFpVQ2hEunzKKoZQhW2Sa+YTDiESsaHSKXMGxlvCFViYrjR2vM1lGLlhoiIqtb0gaq9vR1nnnkmjjjiCHR3d+Mvf/kLrrzySixbtgyPPPII+vv7K342m80imy2uJjU8PAwAUEpBqalbiaca3777BfztzRHY9oaG9qPZCR3A0AEkwmdD+9FrH1IHMBA+SygY2g/bah9Gok0A6By0ziKAB40sAu1BiRyUziEQOSjtIYwWOQTww/+JAAH8whZP55B1cvi/F/4b6iUggIISGj40gsQz4AuNQCDaBuQA+AJQk3QNaysNCxqWDh8mUHht6eg1wtem1mjTGhbC14U2sc/H35vR522ti6Enera0iB4GLAhYMGFpCQMGIAwEMBAIE0oYCGBCCSAQEqpsu4FAGIXt8dcqOs6oMDAkTSiZ3B5+1ky8Dj9bcozC9vjxi9vjbcZyCqbtIhBmuKzvZNAAgugxLTTC/9KmtrLVLDzP49+/LYjntfXwnLYQ5WN29HLL1izm23ZDuwOg6jwgtNZTdxvkGimlwpt6VcFxnIoTn//whz9g+fLlOPvss/GDH/yg4jEuvvhiXHLJJWXbn33ueXR1dVXX6Sly2V1/xStvbYuGL07BvwRrjegyFSZ8SK1gIh8kwhBRfO3DgIIZhRETxZBiFtqFbQyEocREtL9wLB+GjvZH22X0WRMBpK58rHxf8p+RyCGARiCi0CJ0GFqEQk4o5IQuPDwBZIRAVorwOXqEryUysrgtuU8k9vk1/mu8ozRsDdhawNaIQgRgKsCEhKkBQwtICBhawIAMn7WA1BIS0bOWkJCJ10JLCEgIbUBqAQkDQhvhdm1AIHwNbQII30MbEDChtQGN8KEgoaJvVEFCQxReKyHL9scfxW2i0D7eLlDA1mwO7Z29MNyOMLxATl7YmFE0giCYut9VagCe09bE89p6eE5bidQBDhy8DwBw7EmnYH5vZ4N7FE4n2mfvxRgaGkJ3d3fFdjMqUN1zzz044ogjqmr7zDPPYJ999qm4/9BDD8XmzZvx4osvVmyTVqHq7+/Ha6+/Me6XNh2MP34buc0vwbaMcNK2jiZ3p9zob7wlbcuWwo23nwQagI9kaMkIiaxhIWOYyBomMtJAVhqxZ4mskFF7CS8fdiCQEToMMdDICCALHb6GQlZrZKHgobbqoZWf9yItuNH8GEda4SIA0oFtWNGk/pIbcJpt0YIAbcWH1Q7HbI/2lSwKELuHTVrYf/XVV/GrX/4/jI6OTsp33wxOOfU07LLLLo3uxpRSSmFwcBC9vb2cb9MieE5bE89r6+E5bS2e5+Gqb18JAFj5hXPhum6DexRmg/nzdpowUM2oIX/77LMPbrjhhqraLliwYNz9/f39eO6558Zt4zgOHMcp2y6lbPgvpnzzGVhvvQhpuxApq0bBdBKrRuWXtvWFEQYVGQaUrACyAsgg9gwVBhet4UGF77VCVgfI6gAZBMgqP3yvfGS0j6zKxR4eMoGHrPLgBTmoGgKOIYwK96Up3lyzzXDQm3LjzXx4SVvGufQeNvlgZEsbhpwZi5QsXLgQR/7dB+HnctO7rHSD9PT2YuHChY3uxrQQQsyIvzdo8vCctiae19bDc9o64udwppzTavswowLV/PnzceaZZ07KsdatW4e5c+dOyrEa4Uf7vA8vb9kNsFC4F03pjTu9YDjcnisuA+3XWHkqv89MVHGRdlSVcdEZ21cWcszyZZztxH1uive1cQ0HprSm5gtrEnPnzuU9UIiIiIhayIwKVPXYvHlzWXC644478Je//AUrV65sUK+230NvPIS/Df0N7XZbIpT0OD3YqexmmlGgqXBfm+TNPIv3tKk0NI2IiIiIiKrT9IFq2bJlOOigg7BkyRL09PTgkUcewfXXX4/+/n586UtfanT36nblYd/mHd2JiIiIiGa4pg9UJ598Mv7nf/4Hv/vd77Bt2zYsWLAA//AP/4CLLroI8+bNa3T3iIiIiIiohTV9oLr00ktx6aWXNrobRERERES0A+JYMiIiIiIiojoxUBEREREREdWJgYqIiIiIiKhODFRERERERER1YqAiIiIiIiKqEwMVERERERFRnRioiIiIiIiI6sRARUREREREVCcGKiIiIiIiojoxUBEREREREdWJgYqIiIiIiKhODFRERERERER1YqAiIiIiIiKqk9noDhARERER0Y7Nsiyc+0/nYXBwEJZlNbo7NWGFioiIiIiIGkoIAdu2YVkWhBCN7k5NGKiIiIiIiIjqxEBFRERERERUJwYqIiIiIiKiOjFQERERERER1Ymr/MVorQEAIyMjDe4JoJTCyMgIDMOAlMy9rYDntDXxvLYentPWxPPaenhOW89MO6f5TJDPCJUwUMXkv7Q999i9wT0hIiIiIqKZYGRkBD09PRX3Cz1R5NqBKKWwceNGdHV1NXy5xuHhYfT392P9+vXo7u5uaF9ocvCctiae19bDc9qaeF5bD89p65lp51RrjZGREey8887jVsxYoYqRUmLhwoWN7kZCd3f3jPgPiiYPz2lr4nltPTynrYnntfXwnLaemXROx6tM5TV+cCIREREREVGTYqAiIiIiIiKqEwPVDOU4Di666CI4jtPortAk4TltTTyvrYfntDXxvLYentPW06znlItSEBERERER1YkVKiIiIiIiojoxUBEREREREdWJgYqIiIiIiKhODFQzzKZNm/Cv//qvOOKIIwo3GL7nnnsqtr///vvx3ve+F+3t7Zg/fz5WrlyJ0dHR6eswTSibzeKLX/widt55Z7S1tWHp0qW46667Gt0tqtLo6CguuugifPjDH8asWbMghMCaNWtS2z7zzDP48Ic/jM7OTsyaNQunnXYaNm/ePL0dpgk99NBD+PznP499990XHR0d2HXXXXHSSSfh+eefL2vLc9ocnnrqKZx44onYY4890N7ejjlz5mD58uX49a9/XdaW57R5XXbZZRBCYL/99ivbx+uh5nDPPfdACJH6+NOf/pRo20znlDf2nWGee+45fPOb38Ree+2F/fffHw888EDFto899hg+8IEP4O1vfzuuvPJKvPrqq1i9ejVeeOEF/OY3v5nGXtN4zjzzTNx6660499xzsddee2HNmjU4+uijsXbtWrz3ve9tdPdoAm+++Sa+9rWvYdddd8U73/nOiv/A8eqrr2L58uXo6enB5ZdfjtHRUaxevRpPPPEEHnzwQdi2Pb0dp4q++c1v4o9//CNOPPFEHHDAAXjttddw9dVX413vehf+9Kc/FS7WeE6bxyuvvIKRkRGcccYZ2HnnnbFt2zb8/Oc/x0c/+lFce+21OPvsswHwnDazV199FZdffjk6OjrK9vF6qPmsXLkSBx98cGLbokWLCq+b7pxqmlGGh4f1W2+9pbXW+mc/+5kGoNeuXZva9qijjtILFizQQ0NDhW0//OEPNQD929/+djq6SxP485//rAHoVatWFbaNjY3pPffcUx966KEN7BlVK5PJ6E2bNmmttX7ooYc0AH3DDTeUtfvHf/xH3dbWpl955ZXCtrvuuksD0Ndee+10dZeq8Mc//lFns9nEtueff147jqNPOeWUwjae0+bm+75+5zvfqffee+/CNp7T5nXyySfr97///frwww/X++67b2Ifr4eax9q1azUA/bOf/Wzcds12Tjnkb4bp6urCrFmzJmw3PDyMu+66C6eeeiq6u7sL208//XR0dnbipz/96VR2k6p06623wjCMwr+OAoDrujjrrLPwwAMPYP369Q3sHVXDcRzMnz9/wnY///nPccwxx2DXXXctbDvyyCOxePFi/j7OMMuWLSurROy1117Yd9998cwzzxS28Zw2N8Mw0N/fj8HBwcI2ntPmdO+99+LWW2/FVVddVbaP10PNa2RkBL7vl21vxnPKQNWknnjiCfi+jyVLliS227aNAw88EI8++miDekZxjz76KBYvXpz4CwEA3vOe9wAIS9rU/DZs2IA33nij7PcRCM81fx9nPq01Xn/9dcyZMwcAz2mz2rp1K95880289NJL+Pa3v43f/OY3+MAHPgCA57RZBUGAFStW4NOf/jT233//sv28HmpOn/zkJ9Hd3Q3XdXHEEUfg4YcfLuxrxnPKOVRNatOmTQCABQsWlO1bsGAB7rvvvunuEqXYtGlTxXMEABs3bpzuLtEUmOj3ccuWLchms0135/cdyc0334wNGzbga1/7GgCe02b1z//8z7j22msBAFJKfPzjH8fVV18NgOe0Wf3gBz/AK6+8grvvvjt1P6+Hmott2zj++ONx9NFHY86cOXj66aexevVqHHbYYbj//vtx0EEHNeU5ZaCaQkopeJ5XVVvHcSCEqPrYY2Njhc+Vcl23sJ8aa2xsrOI5yu+n5jfR72O+DS/UZqZnn30Wn/vc53DooYfijDPOAMBz2qzOPfdcnHDCCdi4cSN++tOfIgiCwv8P85w2n7feegtf/epX8ZWvfAVz585NbcProeaybNkyLFu2rPD+ox/9KE444QQccMABuPDCC3HnnXc25TnlkL8pdO+996Ktra2qx3PPPVfTsdva2gCES3KXymQyhf3UWG1tbRXPUX4/Nb+Jfh/jbWhmee211/CRj3wEPT09hTmPAM9ps9pnn31w5JFH4vTTT8ftt9+O0dFRHHvssdBa85w2oS9/+cuYNWsWVqxYUbENr4ea36JFi3Dcccdh7dq1CIKgKc8pK1RTaJ999sENN9xQVdu0smY17fNl0bhNmzZh5513rul4NDUWLFiADRs2lG3Pnzeep9Yw0e/jrFmz+K/eM9DQ0BCOOuooDA4O4r777kv8PvKctoYTTjgB55xzDp5//nme0ybzwgsv4LrrrsNVV12VGB6fyWSQy+Xw8ssvo7u7m9dDLaK/vx+e52Hr1q1NeU4ZqKbQ/PnzceaZZ07Jsffbbz+YpomHH34YJ510UmG753l47LHHEtuocQ488ECsXbsWw8PDiYUp/vznPxf2U/PbZZddMHfu3MSk2rwHH3yQ53kGymQyOPbYY/H888/j7rvvxjve8Y7Efp7T1pAfGjQ0NIS9996b57SJbNiwAUoprFy5EitXrizbv/vuu+MLX/gCLrnkEl4PtYB169bBdV10dnY25TUuh/w1qZ6eHhx55JH48Y9/jJGRkcL2m266CaOjozjxxBMb2DvKO+GEExAEAa677rrCtmw2ixtuuAFLly5Ff39/A3tHk+n444/H7bffnlgK//e//z2ef/55/j7OMEEQ4OSTT8YDDzyAn/3sZzj00ENT2/GcNo833nijbFsul8OPfvQjtLW1FQIzz2nz2G+//XDbbbeVPfbdd1/suuuuuO2223DWWWfxeqjJbN68uWzb448/jl/96lf44Ac/CCllU55TobXWje4EJV166aUAgKeeegq33HILPvWpT2H33XcHEI4nznvkkUewbNkyvOMd78DZZ5+NV199FVdccQWWL1+O3/72tw3pO5U76aSTcNttt+Gf/umfsGjRItx444148MEH8fvf/x7Lly9vdPeoCldffTUGBwexceNGXHPNNfj4xz+Ogw46CACwYsUK9PT0YP369TjooIPQ29uLL3zhCxgdHcWqVauwcOFCPPTQQxxKNIOce+65+M53voNjjz029V86Tz31VADgOW0iH/vYxzA8PIzly5djl112wWuvvYabb74Zzz77LK644gqcd955AHhOW8H73vc+vPnmm3jyyScL23g91Dze//73o62tDcuWLcNOO+2Ep59+Gtdddx0sy8IDDzyAt7/97QCa8Jw29r7ClAZAxUep++67Ty9btky7rqvnzp2rP/e5z+nh4eEG9JoqGRsb0+eff76eP3++dhxHH3zwwfrOO+9sdLeoBm9729sq/k7+9a9/LbR78skn9Qc/+EHd3t6ue3t79SmnnKJfe+21xnWcUh1++OFV/z3Lc9ocfvKTn+gjjzxSz5s3T5umqfv6+vSRRx6pf/nLX5a15Tltbocffrjed999y7bzeqg5fOc739Hvec979KxZs7RpmnrBggX61FNP1S+88EJZ22Y6p6xQERERERER1YlzqIiIiIiIiOrEQEVERERERFQnBioiIiIiIqI6MVARERERERHViYGKiIiIiIioTgxUREREREREdWKgIiIiIiIiqhMDFRERERERUZ0YqIiIiIiIiOrEQEVERC1NCFF4rF69utHdSTjwwAMLfTvmmGMa3R0iIqoDAxUREc1Y8TBU6XHxxRdPeJyPfexjuOmmm/CRj3xk6jtdg8svvxw33XQT5syZ0+iuEBFRncxGd4CIiKiSm266qeK+iy++GC+99BKWLl064XEOOOAAnHrqqZPZtUlx9NFHAwC+/OUvN7gnRERULwYqIiKasSqFoP/4j//ASy+9hBUrVuCoo46a5l4REREVccgfERE1laeeegorV67EQQcdhFWrVtV9nDVr1kAIgT/84Q9YuXIl5s6di97eXpxzzjnwPA+Dg4M4/fTT0dfXh76+PlxwwQXQWhc+//LLLxfmZX3ve9/DHnvsgfb2dnzwgx/E+vXrobXGv/3bv2HhwoVoa2vDcccdhy1btkzGV0BERDMIK1RERNQ0tm3bhpNOOgmGYeCWW26B4zjbfcwVK1Zg/vz5uOSSS/CnP/0J1113HXp7e3H//fdj1113xeWXX4477rgDq1atwn777YfTTz898fmbb74ZnudhxYoV2LJlC771rW/hpJNOwvvf/37cc889+OIXv4gXX3wR3/3ud3H++efj+uuv3+4+ExHRzMFARURETWPFihV4+umnceONN2Lx4sWTcsx58+bhjjvugBACn/3sZ/Hiiy9i1apVOOecc3DNNdcAAM4++2zstttuuP7668sC1YYNG/DCCy+gp6cHABAEAb7+9a9jbGwMDz/8MEwz/L/azZs34+abb8Y111wzKUGQiIhmBg75IyKipvBf//VfuP7663HaaaeVhZrtcdZZZ0EIUXi/dOlSaK1x1llnFbYZhoElS5Zg3bp1ZZ8/8cQTC2Eq/3kgnP+VD1P57Z7nYcOGDZPWdyIiajwGKiIimvFeeOEFfOYzn8HixYvx/e9/f1KPveuuuybe58NRf39/2faBgYHt+jyA1GMQEVHzYqAiIqIZLZvN4uSTT4bnebjlllvQ2dk5qcc3DKPq7fFFKer5fKVjEBFR8+IcKiIimtHOP/98PProo/jOd76Dgw46qNHdISIiSmCFioiIZqzbbrsNV199NT760Y9i5cqVje4OERFRGVaoiIhoRtq0aRPOOussGIaBD3zgA/jxj3+c2m7PPffEoYceOs29IyIiCjFQERHRjPTcc88VFnD4whe+ULHdGWecwUBFREQNIzRnxxIRUQsTQuBf/uVfcMEFF6CjowNtbW2N7lLB4OAgfN/Hu971LhxwwAG4/fbbG90lIiKqEedQERFRy1u1ahXmzp2L733ve43uSsL73vc+zJ07F+vXr290V4iIqE4c8kdERC3trrvuKrxevHhxA3tS7tprr8XIyAgAYO7cuQ3uDRER1YND/oiIiIiIiOrEIX9ERERERER1YqAiIiIiIiKqEwMVERERERFRnRioiIiIiIiI6sRARUREREREVCcGKiIiIiIiojoxUBEREREREdWJgYqIiIiIiKhODFRERERERER1YqAiIiIiIiKq0/8HVf52Hj6O+7YAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "problem.info()\n",
+    "lens.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02465ebe-5427-4f35-8589-5273fb1eff1c",
+   "metadata": {},
+   "source": [
+    "The optimization struggles to converge to a good solution. This happens because there's no continuous path from a concave to a convex surface when using the \"radius\" directly.\n",
+    "\n",
+    "### Approach 2: Optimizing with \"reciprocal_radius\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af939f57-77a8-4a33-8ed1-5ac068fc375d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lens = Singlet()\n",
+    "\n",
+    "problem = optimization.OptimizationProblem()\n",
+    "\n",
+    "# Add requirement for spot size\n",
+    "for field in lens.fields.get_field_coords():\n",
+    "    input_data = {\n",
+    "        \"optic\": lens,\n",
+    "        \"Hx\": field[0],\n",
+    "        \"Hy\": field[1],\n",
+    "        \"num_rays\": 5,\n",
+    "        \"wavelength\": \"all\",\n",
+    "        \"distribution\": \"hexapolar\",\n",
+    "        \"surface_number\": 3,\n",
+    "    }\n",
+    "    problem.add_operand(\n",
+    "        operand_type=\"rms_spot_size\", target=0, weight=1, input_data=input_data\n",
+    "    )\n",
+    "\n",
+    "# Use reciprocal_radius instead of radius for optimization\n",
+    "problem.add_variable(lens, \"reciprocal_radius\", surface_number=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "350d2910-de1b-4091-9bc2-c3723a49ef0d",
+   "metadata": {},
+   "source": [
+    "Let's run the optimization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13912949-1a8d-44e8-bb07-0b61a31e4b9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RUNNING THE L-BFGS-B CODE\n",
+      "\n",
+      "           * * *\n",
+      "\n",
+      "Machine precision = 2.220D-16\n",
+      " N =            1     M =           10\n",
+      "\n",
+      "At X0         0 variables are exactly at the bounds\n",
+      "\n",
+      "At iterate    0    f=  6.95755D+01    |proj g|=  2.79464D+00\n",
+      "\n",
+      "At iterate    1    f=  5.63264D+01    |proj g|=  2.50605D+00\n",
+      "\n",
+      "At iterate    2    f=  4.71862D-02    |proj g|=  7.42588D-02\n",
+      "\n",
+      "At iterate    3    f=  5.95316D-04    |proj g|=  4.07913D-03\n",
+      "\n",
+      "At iterate    4    f=  4.55029D-04    |proj g|=  1.49063D-05\n",
+      "\n",
+      "At iterate    5    f=  4.55027D-04    |proj g|=  3.39355D-09\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " This problem is unconstrained.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "At iterate    6    f=  4.55027D-04    |proj g|=  1.81604D-09\n",
+      "\n",
+      "           * * *\n",
+      "\n",
+      "Tit   = total number of iterations\n",
+      "Tnf   = total number of function evaluations\n",
+      "Tnint = total number of segments explored during Cauchy searches\n",
+      "Skip  = number of BFGS updates skipped\n",
+      "Nact  = number of active bounds at final generalized Cauchy point\n",
+      "Projg = norm of the final projected gradient\n",
+      "F     = final function value\n",
+      "\n",
+      "           * * *\n",
+      "\n",
+      "   N    Tit     Tnf  Tnint  Skip  Nact     Projg        F\n",
+      "    1      6     10      1     0     0   1.816D-09   4.550D-04\n",
+      "  F =   4.5502738477963967E-004\n",
+      "\n",
+      "CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH             \n"
+     ]
+    }
+   ],
+   "source": [
+    "optimizer = optimization.OptimizerGeneric(problem)\n",
+    "res = optimizer.optimize(tol=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b27c6e22-eabd-4fe0-881e-ef7e544b6dbc",
+   "metadata": {},
+   "source": [
+    "And check the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d634712a-58f1-4ff0-aa73-3d8657326fec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "╒════╤════════════════════════╤═══════════════════╕\n",
+      "│    │   Merit Function Value │   Improvement (%) │\n",
+      "╞════╪════════════════════════╪═══════════════════╡\n",
+      "│  0 │            0.000455027 │           99.9993 │\n",
+      "╘════╧════════════════════════╧═══════════════════╛\n",
+      "╒════╤════════════════╤══════════╤══════════════╤══════════════╤══════════╤═════════╤═════════╤════════════════╕\n",
+      "│    │ Operand Type   │   Target │ Min. Bound   │ Max. Bound   │   Weight │   Value │   Delta │   Contrib. [%] │\n",
+      "╞════╪════════════════╪══════════╪══════════════╪══════════════╪══════════╪═════════╪═════════╪════════════════╡\n",
+      "│  0 │ rms spot size  │        0 │              │              │        1 │   0.012 │   0.012 │          32.21 │\n",
+      "│  1 │ rms spot size  │        0 │              │              │        1 │   0.012 │   0.012 │          31.48 │\n",
+      "│  2 │ rms spot size  │        0 │              │              │        1 │   0.013 │   0.013 │          36.31 │\n",
+      "╘════╧════════════════╧══════════╧══════════════╧══════════════╧══════════╧═════════╧═════════╧════════════════╛\n",
+      "╒════╤═══════════════════╤═══════════╤═══════════╤══════════════╤══════════════╕\n",
+      "│    │ Variable Type     │   Surface │     Value │ Min. Bound   │ Max. Bound   │\n",
+      "╞════╪═══════════════════╪═══════════╪═══════════╪══════════════╪══════════════╡\n",
+      "│  0 │ reciprocal_radius │         1 │ 0.0396763 │              │              │\n",
+      "╘════╧═══════════════════╧═══════════╧═══════════╧══════════════╧══════════════╛\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1QAAADNCAYAAAC/4DFLAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdB1JREFUeJzt/XmYJFd15w9/b+y5Z1Vl7ZnVaqm1t/a9LbXQYoHEZkBI/plNoBlgMBKLGRj5Neuw2EhgeFhkxAwSFgyMkYfXtgaDwa/0Y5HYhQzaW63urn3PPTMiI+K+f0RkZORWW1dXVmWfj554MjLiRtStuqrq+OY553sY55yDIAiCIAiCIAiCWDdCpydAEARBEARBEASxUyFBRRAEQRAEQRAEsUFIUBEEQRAEQRAEQWwQElQEQRAEQRAEQRAbhAQVQRAEQRAEQRDEBiFBRRAEQRAEQRAEsUFIUBEEQRAEQRAEQWwQElQEQRAEQRAEQRAbROr0BLYTtm1jamoKkUgEjLFOT4cgCIIgCIIgiA7BOUcul8PIyAgEoX0cigSVj6mpKaRSqU5PgyAIgiAIgiCIbcL4+DiSyWTb810hqB5++GFcddVVLc89+uijuPTSS9d0n0gkAgB4/uAL3n6nsG0b6XQa8Xh8RUVM7BxoTbsTWtfug9a0O6F17T5oTbuP7bamuVwOJ524e1Vd0BWCqsrtt9+Oiy66qO7Ynj171nx9Nc0vEokgGo1u6tzWi23bsCwL0Wh0W/wPRRw9tKbdCa1r90Fr2p3QunYftKbdx3Zd09VKgbpKUF1xxRW48cYbOz0NgiAIgiAIgiCOE7aP9NskcrkcTNPs9DQIgiAIgiAIgjgO6KoI1Zvf/Gbk83mIoogrrrgCd955Jy688MK243Vdh67r3vtsNgvACTfatn3M57sSf/f/HsT4QhaKOkOOg5sB5xBgQeDuBgsiNyHwhld3TPWYgOo5C4yb4LwMGwZsrsPmBiw4m7NfgckrsFGBCRMWTPe/CkznLCrchCnYqMCCCRsVZkO3TVjchsRFyLYIiYuQbBkSlyByGRKXIXMZAlTA1gAeALgKiTtjJC5B5jJELoJh+/y/cs455+Dqa67t9DSOObZtg3Pe8b8ZxOZBa9qd0Lp2H7Sm3cd2W9O1zqMrBJWiKHjNa16DG264AYlEAk8++STuuusuXHHFFXjkkUdw3nnntbzuU5/6FD760Y82HU+n07As61hPe0X+MLGEQ4sliGLh2H8xziHCggQLIiyIMCFyGxJMiLDd9xZEVI9Z7vvaNZLvmPPeuYeIVsfMNtdYdfde6b4CKuCwYTMLJrNgMQsms72tAhsVgaPCOEzmvOqMQWcMZcagC85ryX+MMZQFVj+OMZSZAJ0xGML6xIrMORQOKDacV86gAJBtBpkzyFxAmDNEbUDgAizBhMnKqIg2ShJHWQCKAkORCSgJDOYahLVqM6icQeUiVIhQIEGB7P6nQoIKiWkQoEFkAchQIUOG4hvV+F7E+oVaNpvFwYMHcd75y+u6bifCuY1cLg+Ag7GuC/ofl9Cadie0rt0HrWn3sd3WNJfLrWkc45zzYzyXjnDgwAGcffbZ2L9/P77//e+3HNMqQpVKpTAzO9dxUwrhF3fDWHgBmiKB2SZgW4BdAdx95u27m+W8OserY/3XmLX7WBWA+67hRy8eLaBOhOiuaCkJInRBgi6KKAsSdEFEWRBRFkXoTIAuCI5gERpFDKAD0Bmgg3tbGRw6bOiwsZ7PLkQwqIIElcnOqyC7m+K8iqqzL6p1myZpUCUNqqhBkYLu+yBUKQBVDkKVglCkAFRJhSaqUEUNqqhCERSIglg3h3bONZ/9zF3o7e3FH11+OQBAN23kDRt5vQK9VIBRzMEq52CUM9CNDAwjA8vKwLQKsHkBnBdg8zI408EEHZxVYAsVWIIFU7BQFhiKjKHkijO/SCsyBr6KUBPAEGASNKZAExRoguZ+nwGoYgiqGIQmalAF1X3VcPi5Q4AO3Pwn/w9iShRRJYaoEkVACnRdxHW7ORIRRw+taXdC69p90Jp2H9ttTbPZLIYGB5DJZFbUBl0RoWrFnj178MpXvhL/5//8H1iWBVEUm8aoqgpVVZuOC4LQ8UWUjvwMwuJzEGUNECRAEAFB9r1K4KIEiDIgB73jXJDAmQhDEBzhwlATOIyjDOdVZ0CZc5QZh85t6OAwYKPMbejcgg4LOrdQti3o3ITOTZRtE7pd8W0GynYFumXA5OurW2sULlUholXfSxrCfmHjG6OKKpTqManN9dWxrtCRBPkYrdT6YIzV/f9lGAZM00Q8HveEhiaL0GQRiZAMIAigf033tjlHscKR1y3kDRs5w0Zet1Aul1Ap52GV8uBGDszIgxkFCJUCJCsPwcpBZAUorAhZLEIUyhCFMgRBB4QKuFCBySwUhaoYYygKAkqMoSgwLDMRBUF0jgkMJQboAQAB4McP/7hujhITHYGlxhBV4oiqUcRcsRVVYoipUUTkKGKq+94dG5bDELbBJ1XtaFxXYudDa9qd0Lp2H7Sm3cd2WtO1zqFrBRUApFIpGIaBQqHQ8YjTevmH81+DQ0uHIMgCdFuHbvk2swzd0lG2dBiWDt3KOscrtWMcaw88SoIEVdR8YsQnSmQVqhRFVFTRL2pQRKWlwKmO16R2IknzxI8iKF0XpdgoBw4cAAD09vYe9b0ExhBWGMJK4y9/GKuJsorFnaiYYSPnCjJn33kt6gascgG2ngOMPASjAMEsIGwWMIQiIighwoqIoIgwKyGEAoJiDppSBFgBZaGCjCA4m7iIrCAgIweQkVVMSJLzHjYy3ITZIvbIwFzR5Qgsf9SrKr6iiiPOInXHIttGTBMEQRAE0Z10taA6ePAgNE1DOBzu9FTWzb8d+Tcczh6CJgV8IsUVKFIAcTXupqI1CBr/e6kmaBwhpLUUQ42pacTW8cILBwEAif61RaGOFbLI0BMQ0RMQAaxdgHDOUarwuojYjGHjN79/ChndxomnXoDZrI5MJg0zNw+htIA+ZNDHskggi5PFLEblPAaFHHpZBjE7A2ZlkROAjCjURJisIqPZyCg6MnIWWVHCgsDwPGxkeQUZS0fZNlrOMSSFEPVHvJSYGxnzi7JYTbC5xzRJ26SfLkEQBEEQ3UxXCKr5+Xn0NzyQPv744/jnf/5nXH/99dsiZLhevnzV3VheXkZPT8+OnD+xNmZnZqEoChRF6fRUNgRjDEGFIagIGPAdrxzMoSSU8K6Xn1E3vmLZWMgbmM2WMZfTMZvV8ctsGbM5HXNZHbO5MuazJSilDBKsKrwySCp5pEoFnCTnMMCy6OEZROw0AsYSJKsEwKm3ywoC0oKITCCOTDCGjBpGBgFkbBWZioWMuYxccRGT3ETWKiNjFpCv5Ft+b6qo1lIRvTTFaIMoiyEsR8DKDKPKKOJaHCEpRBFYgiAIgjiO6ApBdfPNNyMQCGDfvn0YGBjAk08+iXvuuQfBYBB//dd/3enpEURbMpn0joygbhRZFDAc0zAcWzn6ky+brshyxNZstownczoeyuqeGJvPG7BsjgDK6GNZDAlZ7A4UsUstIinmMGjmkLKyiOWXETYXoOpLEMtLYA3psBU5iFwogXSoB5lADBklhIwSQEZSkBFFZAQgCwsZI48XSgvIGFlkjQyyRhY2b05PFJmEqBLxasJai7JYXfpiRIkiIkcoWkwQBEEQO5CuEFR/8id/gm9+85v47Gc/i2w2i/7+frz61a/Ghz/8YezZs6fT0yOIlti2DcMwMDQ83OmpbDvCmoSwJuGk/lDbMZbNsVioj3bNZss4mNPxczfaNZvVkS3XDFNEWBhVizg5WMbuYBFjSh7DUh79Qha9PIPd5TQC2WnI5UWw4jyYWa77mhwMCPaBh/phB5PIB3uR0aKYhYRyJIasrCIjiMgwjiwsZM0iMkYWU4VJPL30FLKVLDJ6BhW70vJ7isgRX41Y1CfKfEKsMX1RiUIWqU6MIAiCIDpFVwiq22+/Hbfffnunp0EQ62J+fh6cc8RjsU5PZUciCgwDERUDkWanTj8lw3IFVy3aNZfTMZHV8Zusjrll533FqkWuBAb0hRTs6uE4KVjECWoBo0oBQ2IWfSyLuJ1ByFxCpLCI6PwzSOZnIZbTTV+byyEglAAP9YMHE0AoCTvWj3Iw7kbCNCcSJgjIMtuNfjkRsIyRxVJ5EYeyLyBjZJEzsiiaxZbfY0AK+ERWK+OOWFOkLKZEoYoapScSBEEQxFHSFYKKIHYiVUOKzXD4I9oTUETs6gtiV1+w7Rjb5kiXKk3RrtmcjpmsjseXnPfLxfrIUkAW0B9R0RcSkUoGsCtYwphSwIiUw4CYQw9PI2KlIZUWgcIc2OwfIBUWEC7MI2LpSPruxZkABBOu8OoHDyXAg/1A7EzwUAIIJmAEepBRAsiKEjK27qQe6llk3BTErJFBRndeZwrTjkDTM8hX8i2dP2VB9omsVsYdsaZIWUyJIiSHSYgRBEEQhAsJKoLoEFOTU2CMIUYRqo4jCAy9IQW9IQWnr5CBaZh2XbRrzhVe4wtZTOUq+N2Uhdksg26G4djVOzfrDckYjGgYiKgYTKkYjKhIhkyMyHkMiXn0IYOItQxWXAArzAOFBbDcNNjMfzjHSssAHP/FEIARAFwJAaEB8GDCFVz9biTsRKCnv+6YpUaQN4te5CurOwLME2J6xqsNO5w77ImyrJGF1aLxt8hEhOXImmvEqoIsLEcgCfTPDkEQBNFd0L9sBNEhFhcXoKoqhBZNp4ntiSIJSPYEkOwJeMds265z5OScI1s2G6JdTk3XXE7HE9M5PPTMPBYKBrgXNApAFoMYiJyIwaiGwaiKgT4Vgyc4+0NhAUNSAQNCDqqxBFaYByu6wqswDxQXwGYeh1Ddt+ot5DkTEQj2IREacFIQg04aIqqpiLHdtYhYKAG4lvGccxSrQswnsjJuZMwTaEYWs8VZPJt+zh2bgdHGxj4sh91+YZHVa8R8ph2quHJqJ0EQBEF0ChJUBNEh8vn8ceXwd7zAGEMsICMWkHHKYKTtuIplY9G1kJ91hZcX/crqeHomh7mcjoJeHyGKBSQMRpIYiJyEgajqCLAhp5ZsMKphMKygV9IhlVxxVVgAivOOCCssOMeyE2DTv3OiX61qv9SIm3o4ADmYQCyUQDKYAPcE2TAQP8eJgmlxoEX6X9ksu2mIPiGmZ+pqxLK6c+xIbtxLXyyYhZY/L03UEFNjDcYdK9eIRZUYAlKA0hMJgiCIYwoJKoLoEIZhkKA6jpFFAUMxDUOrWcjrpiO2Gvp1zeV0PD9fwCPPL3oW8lUkgSERVtxolyO+BiMaBoZUJ/oVcSJfYVUCLAMoLrqphvO+tMPq/gIw9VsIxQUnItbgUMgFyan9CvV7rzyUQCiYQDA0gKFqRCx6KhDsA6SVI02mXUHWyHkirHWNmLN/IHPAS1/MGtmWdWKSINXVglUt7VeqEQvLkZaW+ARBEATRChJUBNEB0uk0OOeIRNpHMAgCAMKqhHD/6hbySwXDczH0R7vmsjp+sbCEuZyOTMmsuy6kirXarqiKwegYBqMnO5GvUSfilQgrkES3uTjnQDnTnG5YmK/tp4+ATf3GOaZnm+bK1agrvtw6LzftsJqCKAcT6Asl0BvsByIntIx+tcLmNvKVvFcPljOyXl1YY7riRH4C2aXae9M2m+7HwBCpNnL2pR6uVCNWFWySQDb2BEEQxxMkqAiiAxw+dAgAEI/HOzoPojsQBYb+iIr+iIq9I9G24/wW8l59lxvtGl8u4deHl5ss5BkDEiEFA9XaroiKwYhWE19JR3hFNak5tc7U3ejXHFg1wlWY81IRWWEeSB+u1X41CBsuyF7NF0IDbp1X1QWxv25fCPa50aZonXvianDOUTJLdYYdGT2D6fQMTKmCXCXnpSsulBZwMPO8975slVveMySFmlwTI0qkbY1YNXVRk1aOVhIEQRDbExJUBNEBZmZmAAAxElTEFrIWC3nOOZaLlbp6Lv/+78YzmMvNYqlQn/qnyUJdtGsg6ggv53UXBntPxcAuFYoktPnCthP9Kiw4FvM+AebtL78ANvFLJxVRzzXfQou7Isut93IdEJsjYv2AGgEYA2MMQTmIoBzEUMhxZbRtG8vhmtFIO3RLr0XCWkTG/OmKk4UJ732+km95P1VUW7om1rb61MRq6mJIClGdGEEQRAchQUUQHWBhYR6iKEJVybmM2F4wVrOQP22ofUqq30K+LtrlCrDfT2YxmyujXKmvReoJyk5tV6QqutSas2FExWB0F3r69qwuEColJ/pVdM023JovuOmHrLgALB2EUJhzxjXYv3NRbe14GEqABfqg2gEw4wQg7AgziM1pfKqoQg30IxHoX/PPFwBM20S+kvNSEf1W9tWtKsReyBysCTQj27K2S2Rig+Cqia5IY2qiT6hF5AhEgVxGCYIgjhYSVATRAbLZLAKBwOoDCWKb0spCvhHOOXJls2Vt12xOx5PTOTz87AIW8rrPQh6QRYaBSM08Y7Au2uUIsIGIikAsCR5LtrCiaJyIDZTSbp1XvQDzji0egDD+c6AwD8nIo6/xFoGeWoqhay/fmHZY3YcSXrH2SxIkxNUexNWeVX/Ofmxuo1gptK0Nyxk5z0lxujCFp5ef9mzsKw1mIlXqXRPro2BeDVmDvX1UiUIRlXXNnSAIopshQUUQHaBUKlFDX6LrYYwhGpARDcg4eaC9o6Vp2VhwLeTncrpnI199/+xsHrO5cpOFfFST6sTWQFO0S0NfSIEoCECwFzzYC+DUVQWYreeRnT6ImFyBWFyo2c+76YessAAsPuc4HxYXwBqiRlzSVkg3bIiIBfuANTY7FpiAsBJBWIlgFKNrugZwhK1uletSE5ut7J1tWV/Coewh73zRLLa8Z0AK+FIPm+vBWh2LqTFookbpiQRBdB0kqAiiA1QqFQRD7V3bCOJ4QlqHhXxjbVfVRv75+QIePbiE+ZwO02chLwoM/WGlTmz5o11Vs42w6vvnUA7CioyC9/TAXqGGCoAT/SouNacbFhbAinPO6+KzEI78zNmv1PfZ4mBAoNcRXJ4Iq9V/VSNi1X3IoTU7H1ZhjEGTAtCkAAaDg+u6tmJV6nuHNdSGOcIrh6yewUxhxhNiOSPX0sZeFmRf6mFzPVjML8h8x0JyCAJbZS0IgiA6BAkqgthiSqUiOOcIkaAiiHURViWEVQknJtr/7tg2x6JrIT/na5pcjXb98oVlzObKTRbyQUWsia2IgqjMsWsgh6FYwBNjibACWWx4qGeCm/6XAPpPWz390CjUXA7b2M+zhWdrTZgb7silQMt0Q0+MBQdqzojBPuAoa6RkUUZfoA99gcYkyJWxbMuxsW+oEfOEmC9Sdjh3xCfUsrB4s429wARE5GhTjVi1HsxvZV/tNRZz3RWlNUYACYIgNgr9lSGILWZycgoAEKGmvgSx6Qg+C3msYiE/n2+s7XKiXRPLJcxkSpj/3VxrC3lfZKu+tmsFC/kqSghQQuDxXauLL9sCSku+mi+3/qvo6/s1/xSEQz9xzpuluss5GBDs8wmvhFv/1e+LiNUEGZTN+5BHFETE1BhiagypdVzHOUfRLLasEcv6TTyMLGaLs3gu/Zx7Pgu9nY29HPZSEwMsiL5QH2J+IabWm3hUj6kimQYRBLE2SFARxBYzNzsLANTUlyA6SEARMdYbxFhvs4W8bdtYXl5GPB5Hptyid5e7//h4BrNtLOSr/brqjDS82i7nXFsL+SqCWItA4fQ1RL/ybqqh2+/L3fdSEQvzYHNPOqKstNQc/ZKDvjovnwGHJ7wSbj1YPxDoOeroVysYYwjJIYTkEIZDI+u6tmyWHWMOI9OiRiyDtJ7BQn4BGSOD8fy4l65YaGtjr7WtEYt5lvb+SJkTGQtKQaoTI4jjDBJUBLHFLC8vAQDCFKEiiG3NeizknWhXQ8TLtZF/YiqL2WwZpRYW8vW1XW7kyxftigdkCMIaH86VMKCEwXtOWEP0y3Rrv9y0w2rUyxNhc2CzTzjGG4V5MLM++sOZAAT6XIONVvbzDc6H8rF3NdUkDZqkoT/Y2sa+KpQb+4uZdgU5I18TYg01Yk6kzNk/kDngpi/mkKu0s7GX1lAjVt9TLKJEEZbDZGNPEDsUElQEscVkMhlIkgRBpH84CaIbUCQBo/EARuNrs5CvGmn4o11PuRbyi3kd9goW8gM+seWPdgWUdf49ESQgPAAeHnDmt9JYzp3ol1fnVUs79PbzM2Czf3CiY6Wl5lsoIS+6VUs3HKg1Yg4mgNCAcy7Q49SmbRGSIKNH60GPtn4b+0Kl0CIdsTldcSI/gexS7b1pN9eJMTBElMiqNWLNVvYRSEJznzSCILYOElQEscXk83lq6EsQxxnrsZBfLBi1aFeDAHt2No+5nI68Xv9AHtWkJtv4AVdsVQWYYyG/gVQ0xgA1AqgR8J7dq0e/rApQWmxR++UacBTmwWZ/D6G6bxl1l3MmOrVfoTbphl5EzDHggLSyO+SxQmACIkoEESUCrCPhgHOOslWuS0dsZ2m/UFrAwczz3vtymzqxoBRsiny1qhFrTF3UOvSzI4hugwQVQWwx5XKZHP4IgmiJJAquKNIAtO9VV9Cbo11zWR1zuTIOrmAhnwgrdc2RW0W7wtpRPhqIMhAeAg8PAVhb9Ku+5mvOdUF0BVl2EmzmcSciVk4330IJN6cbtkhBRKDPsbnvMIwxBKQAAlIAQ6GhdV1rWIavb1gtEtbK0n6qMOm9z7etE1PdqNgKNWItUhdDUojqxAjCBwkqgthiKpUKRagIgjgqQqqEE9dgIb9UbBXtct7/6tAy5nI60qV6U42gItaJrcEW0a6WFvIbwY1+cTUC9J60huiXARQXfVbzrgGHtz8PTD8GoRodsxsMQwTJjX4N+KzmG+3nfc6H0vb6W62IChKBBBKBxLquM20T+UoOGT2LnOuK2M7S/lD2hbpIWes6MRFRzxVxldRE3/mIHKE6MaIrIUFFEFuMZVnQNEqzIAji2CIIDImwikRYxZkrWMiXK1Zdk2RHgDnGGpPLJfz2SBpzOR2GWXuwZgzoCymekUY7ARYLrGAhvxFEBYgMg0eGAawh+qVnPfHFc7MoLRxBCEXXbGMBLDMONvVbp/arnGm+hRqtTzdcofkytNi6my5vFZIgIa72IK6uv06sWCn4BFauuUbMFWQzhWk8s/yMez6DSoOYrRKR3TqxlVITG1IXo0oUiqhsxo+CII4JJKgIYgvRdSf/PRA49o5XBEEQa0GT21vIV+GcI12q1Blp1Pp3lfEfExnM5XQsFurroVRJaBZbPhv5waiKgbAKVT4GUQvGAC0GrsWAvj2wbRvF5WWoDS5/HqbuRL98DZfr9xeAqd84tV/FBbAGYwkuyD6DDb/LYaMBh1MHhh0gEAQmIKxEEFYiGMXomq/jnEO3yrUIWCVXXyPmS01M68s4nD3sCbSiWWx5z4AUqHNF9ISWrWAgOoC4Gm9pb6+JGqUnEsccElQEsYVkMs4noCSoCILYSTDG0BNU0BNcu4X8XEO0azZbbmshHw/Kq9R2qegJKmu3kN8IkgpER8CjTv+rVaNf5Ywb/fKbbszV9pcPgU3+yklF1LPNt9Bivpov12yjwXa+moIINbpto1+tYIxBkwLQpAAGg4PrurZiVerNOqqRsYbUxKyewWxxBsulNApTeeSMHHiLVZMF2Zd66GvevEKNWEyJISSHIGyh2ySxsyFBRRBbSDbj/KMaDLb/JJggCGKnslYL+bxuemKr2q+rWtv19EwOP35uAQstLOT7w25UqyHaNViNdkVUBJUteLRhDAjEwQNxACevXvtllr3ar1r9l+ty6NZ/YfkFCNWIGLfqLueismK6YW3fsaSHuHNt1GVRRl+gD32BvlXH+nuLcXDkK/mm2rDq5re3P5I74ouUZWHxZht7gQmIyFFXcNWnH7Z3UowhokQgCfR4fbyxphX/7Gc/e1Rf5KabbkIymTyqexBEN5AvFABQhIogiOMXxhgimoyIJmPPGi3kqxEuvwA7MJfHbLbZQj6iSU3RroGoiv6QggAMnCwG0R/VNmYhv1EkDYiOgkdHVxdf3AZK6ZrLoU+AefvLB8EmfuEcM5od/HigxxNXfrdDR3gN1KUiQgnvqOhXO0RBREyNIabGkFrHdZxzFM1iy/5hWT0Lv6viXGkOB9LPueez0NvY2IfksBvxqkXBPAOPVk6KrihTxe1lgkKsnTUJqve9731gjIHzVf8MNMEYw7nnnkuCiiAAlEpObjhFqAiCIFam3kK+PQXd9Gq6/NGuuWwZLywU8IsXljBXZyH/NAQGJMKtarvqe3mF1U021VgLTACCveDBXiBxyuoCrFJyo19zrghbqEtFZIV5YOl5t/ZrsUX0S10h3bAhIhZMOE2huwjGGEJyCCE5hOHQyLquLZtl5Iycm4ZYb9LRaOIxnhv3hFihrY29VhNidfVgkbp0xMZ0xaAUpDqxDrPm34q//du/xStf+cp13XxpaQkXXHDBuidFEN1KuVSCKIpgrQqiCYIgiHUTUiXsViXsXsVCfiFfxoHJBZSgYD7v2sm7wutXh5cxl13ZQn4gUkstHIzUol/9EXVzLOQ3ihwAYknwWHKN0a9lt+lyvQBjRTf6tfgchCOPOoLMKDTfItDrE141B8Tm/UTXRL/aoUkaNElDf7B/XdeZdgU5I18TYj6TjqoAq9rbP5854Aq1LHKVdjb2klcj1lgP5qUptrC0D8thsrHfJNYsqBKJBHbt2rWum4fD62gdThDHAbphQJK669M9giCI7U7VQl4cCKKnncsfAN21kG+u7dIxlS7hd+NpzLawkO8NKp55RpONvBvtigfkzkcRmOD04Qr2Af2nriH6VfQaLvtrvqqpiKy4ACw850S/SotgDQ/7XAp4zof1jZarEbH+mvNhsLfrol/tkAQZPVoPerT129gXKoW6erCMkW1KV8waWUwWJvDUkiPKMkYapt1cJ8bA3MbOzT3DYr6asSahpkQh7+A6vWPBmv7PXV5eRijU/pOfdvT19WF5eZmEFUG4VEhQEQRBbFtUWUSqN4jUGi3k/bVdc2606/eTGcxmV7aQ96JdjbVekWNkIb9R5CAQHwOPj60uvmzLjX41pBsWF1z7+Xmw+afdHmDzYJV6e3QOBgR6XeFVFWEDbazo+wFl/c+lOx2BCYgoEUSUCLCOR2vOOcpWuS4dsWrc4W/inNEzWCgt4IXMQe94ySy1vGdQCjalHtabdESbhFpMiUJdwcaecw7DMFCpVDZUZtRJ1vRkF4vFNvwFjuZagug2KpUKZJk+1SEIgtiprMdCfiHvi3ZVI19uL68np7OYy+koGvU1TfGA7DZGbraRr4qu3mNtIb8RBNGNPCUAnL66ADMKzWYbBdflsCrI5p92omDFRbCGO3I5CB5MIKH2QIwO1Uw2vNqvfjcFMQEEep35HacwxhCQAghIAQyFhtZ1rWEZdcYcmYbIWDVdMaOnMZ4fR07PIlvJolBpThcFnPTEgKRBFVUoggLGBHDYsGwbtmnhRc+9CADwsje/HHuHzjrab33LoI/KCWILsSyLBBVBEMRxgCIJGIkHMLJGC/l6J0Pn/TOza7CQj9Rs5OsF2BZZyG8UJQQoIfD4rrVFv4qLtZqvotPvixfmUVmagGjmwOafgnDox070y6x33+NMAAJ9Xm0Xb+zz5aYdVvch72zjKJvb0C29fjPL0C0dZe9Y2TtX9p3X684bzWPN5ut1S4fVYHbSDoubyFfyyLcw5hDtmuhd1tOb9ePYEjb8m/aNb3wDX/va13Dw4EEsLy83heYYY14TU4IgHDjnJKgIgiAIABuwkM/pTl1X1h/xKuP5+UXM5nTkys0W8gOR1tGuahQsEVa31kJ+IwgiEB4ADw8AqDVdtm0bmeVlCP66OM6BSsGt8/KlG3rNl+fB8rNgc084x0pLLaJfIc90Y9Xmy4EepzatDZxzVOyKJ0I8QWPWREmTyDF16LZ/XMO1jWO9ezjHKnal7XxaoQgKVFGFKqlQRSd6pImqc0x0jvWoIee4b0x1Y0xA0cgjV3GMNpbLS1gqL2G+NI+F8oL3dWQmIxlOIhlJIVXdwikkw0kMhYZgmxyf/cxdAIALBnaWqd2GBNUHPvAB3HXXXRgdHcWFF15IaX0EsUZs26YaKoIgCGJd1FnIj7YfVzT80S434uVGuw4ttrKQR52FvNcouYWzYUcs5DcCY467oBIG79ndFP0ybbNelFSKKBdmYRTmoBfnoRcXYJSXoZeXoZez0I0F6AsvQK8UoZtF6NyGLjCUGYPOGMpMgC4pKIsSdEFEWRBgMAYdHGVuQecW+OoxOA+RSTUxI9UEjV/kROQIElrCOS8oznmpXgDVCSKpUSTVBJEiKhBWEIRVskYWE7kJjOfHMZEfx0Ru3N2fwEKpJppCUgij4SRSkRQuGboUyUgSybAjnvoD/St+LQO1usO1zGk7saEnu69+9at42ctehu9+97ttnXIIgmiGIlQEQRDEsSKoSNidWN1CfrloeO6FjdGu3xxexmxOR7rY2kJ+oEVq4WDEiXj1h1Uo0tqfC21uw6iL0Oj1782GtDR/mpmpo2yWkS1lwUUOwzagW2UYltE64uPew+LNbnftYGCO8Ahp0CSn8a4qyFAhQAWDyjlU20bUNqFZFagVA5pZhlopQTOK0IwiVG5D4xyqzaFxDkXUoGlxKFocaqAPSqAParAfSngQamgIYnig1nw5EF8x+rWZcM6xVF7CRN4VTbnxuv2MUcs6iylxpFyhdNHgRUiGU55o6lF7dobw3mQ2/FH5DTfcQGKKINaBbTt2siSoCIIgiE4hCAx9YRV9YRVnDNeOc87d6I2TWpbTi5jO5jCdy2Mul8d8PoeF4gyWSkU8nS/gFwsl5IwSLG4AQgWMVQBmQlNsaIoFWbYgSxZEwQQTKgCrwEYFJjdQcdPZDNtoP9EW1KWmCSoUUYUEEUElBM2NwsTUOAb9URipTdRG1KCKSm3fHaf5rpWFo7S6tyqOnXyd2ca8Z0WPwjzY3DNgxZ85+1b9z4MLkmtz3ybdsK75ch8grdwE2+Y25opzToQpP4HxapQpN4GJ/DiKZs15sT/Qj2Q4iROjJ2L/6H6kXMGUDKccl0Gijg0Jqpe97GX46U9/ire97W2bPR+C6FpKJcd6lFL+CIIgiNWwbKsuNa0u6tKibqYWmWkwFzDb1N7UmQyUYdhGy6axLVEBURMRFVUoggqRKRCZDHAZ3JZhWxJMS0KhJEGvqNANAdw9By5BhIKwGsCgGkBcC6InEEJfKIT+UAiD4QgGo2GMRCKIaEFP5Cii2pQGZts2lpeXV+wt1lFEGQgPgYcdZ70VE/84B/RcQ82X2++rWv+VGQebeszpC1ZON99CjcAIJTAT7MURLYQjioxxgWEcBsbNPCaNNAw3QicwAUPBISTDSexN7MX1J1zvCqYkRsNJBKT2ZipEMxt6svvCF76Al7/85XjnO9+Jt7zlLUilUhDFZjvK3t7eo54gQXQLhYJjIUqCiiAIYmfBOW/hgFZLTTMaxEnj2HojgtZmBIbrqFYVRa0asa5EcwSmuXYmqkS9uhmtoZamakjQHMWpGhH4xyuQhLVnW1QsG/M5va5pst/Z8LlZHT/zLOTz7jbjWcg313Y57/vDMtgO61fUFsYALQquRYHek1YUX7qlYzJzCBNLT2Fi+TmMZw9hojiDifICpsw8LMwD1jykIjBqcYwZOi6rVDBmVpCqmEiZJkYsQAmWwUMFILQEHpwEDx1oYcDR70a/1C37UexENvRkFwqFsG/fPtx55524++67246zrLVZKBLE8YAXoaKUP4IgiA3jT01rtHVuVTtTFShls4xMIQMmMxh2zf7ZsI0VLaWr23qQBbk5zcwVJYrg7MfUGAYa3NK88W3MCFRRqxdD3j2VbV23Iotrs5Av6JYntupqu3I6np3N4acHFjCfq7eQFwVgIOzv0+U6GPpquwYjKkLqzvows1ApeGl5E3knJa+6P1ec9YwuVFFDKpxEMn4CXhS+HEk3LS8VTmEwOAhREN3oVxasMFeXbmgV5muph+kjYFO/cSJierZpPlyLOemGPnt57tnOV1MR3fRDNeoIxOOIDf3f9c53vhNf/epXcemll+KSSy4hlz+CWAPlsiuoWkRzCYIgdiq1njdlX4+aFiKnhcGA4RNEdWlpTWPrRc6aU9MAiEz0BIvEJATkALS6yIyGgBxEXOtpjtq456uCRhHVJoFTHVe1k1YExXmIJdYFYwxhTUJYC+Ok/vYW8pbNnYbJOR2zmRJemFlG3hIxnzcwm9XbWsiHVckX3XLEVp2zYVRFX0iBJG6dCUTGyNSZP3jiKTeOJX2pNnc57NUvnZ0422c3nkIikFhdTDMGaDFwLQb0nby656CpO32/CnO13l+FOdd23m3AnD4EodqQuSGaygXZi3BVmyv7+37V9QALJpzUyB3OhgTV//7f/xtveMMbcN99923ydAiie9HLziecZEpBEMSxgvOq21mtz03LRp6mDsPX56Zl7U312jaNPKvbenve1EdkWkRhJA3hQLgmVHyRmbVGcaoRIU1UvdS0bV9vQ6wJUWCehbw9HMHyoNxyTYuG6XMv1DGXqzVNPrxYxK8OLWMup6Ni1VvI94VVL7Wwzs3QF+2KaGuzkOecY7G8UDN/8CJOjhFErpLzxvaqvZ7F+GXDlyEZTjqiKZJCTIkdXQSSc8CuALYJWKbzalechsl2xRFElglw0zHScI/DNsEFGSyUAA/EAetE8IZrYVWc2i89A5QzYHrOiYYZecDIA8sHIcw9AVSKQKUE1uLvBWeC42bIZQD/xTk4/gvg5Cs3/j1vMRsSVLIs49JLL93suRBEV2NUHPeeVvWGBEF0J6ZdaSNKjHqB02A20LqRpy9y40tT89/DsPR19byRBKl17Y1PlMTUqJem1uiCVpeqJrUTSU5qWtWhbTunphHdQ1CRcEKfhBP6VrGQz5cwly1gIVPAfLaIxWwBS7kSlnNpTL5QxBP5IoplAxIsbwtJNhIhCYkAQzwAyFoRppJDUcwgw7JY5BnMmGlMVDIo+2zaB8UgUmIYp4pBXKsmkQoEkGIqUkxBmHNAt4DiPDAzDdiPuMLHdATPCqKndt5/3PKEE1tHRHe9cEECWm1MBBgcMQcAogIwAdwyANMA89vXcxsAcyJp1T9f4s5K0dzQbP/0T/8U//Iv/4K3v/3tmz0fguhaKobzqQwJKoLoDLXUtGaB4o/ilCtlLOWWIM6LtWhPXZTHQGPEptwmimPxtdcSC0xoKUicyEzVHCCAuBr3zAbW0siz7voGMUSpaURbOAe45T6km3UP8N6Dfl20o3a8+uDPGh786/atqhBoHFMTB2yFa6vCok8vQxIAxhvOV8WEJywaIjPu9zUCjpFVfhQVFZiUJByRJYzLEsYlGUdkCb+QJEzIEkzOAB0QOcewaWKsYuIC08QrKjZGTBujJjBsM2gsDwhLEEQZguRsoig74kGQAEEGBNF9lcAFERBVcDnkG1Mb65yXm44795Cc1LsVxnBRBpjU4t4r3d8VS5UCWHYKLDsBlhkHMuNgmQmwrPtaqqUsckECIiPgsZS7JZ3XqLOP6CggqTAMA/jMXc5FIxccu/+3jwEbElQ333wzbrvtNrz0pS/FW97yFoyNjbV8SDz//POPeoIE0S1UTOfTGBJUBOGkwlTsShsXtPYGA7rtH9cqitPcyLN6bCOpaYqgeO5n9WllzrEeNVRXP9Mc5VHqBVKTW1pN5EjC2tKIiG0A5y0fzmsRhUqzALDN1mOsiisO6h/42QrXelEJq9IgehqERNPxhuubohoN54/Vj48JLQRE7eG9ddSjNsY7LwVgMw1cCzgREPdebaMmotx6jCihxDkmzRzGK2mM62mMG8uY0BcxXl7EjL4E2w2dyExCMjiIZHAYl4VGkAqPIhlOIhkeQ0gcxGIZmM1bmM1VMJvT8bTrZjiXLWM2p2Mxa8BvTKhIgq9hcmNtVy3tUJO38NmB20BhzhFGmXF3mwAyR2qiySjUhksaeDQJxFLgQ+fAPvVlPvGUAsJDzs+9i9mQoLriiisAAL/73e/w/e9/v+k85xyMMXL5IwgfJgkqYhvjuKY1mAn4REvbHjdNRgTtzQgM26izlV5PaprIpCa3tEaRE5EjSGiJ2nnBP3blKI7/fjKTUcgW0NfbR7U2G4HbLR/wq+KBtYl2VMUBW+HaOiHQIiJSFQes1b1tEz3lIhRJaIh8+O5RF9VojIb4xMY6Io/r/vExse7B33no90ctmsVB3Xk32sClgBep8I/hgtQmIuKKFdbqfBtB03C8Gu3gK1zrRDg25/dqvXVxeSNXV8s0njuISdcQYr40740LSAGnfimawrUjl/ma2ibRHxhYMbLbB+CUFeZQsWws5A3MZuut42fd16dncpjNVi3ka8QCklfH5TfSGIyoGHAt5ftCCgRhDR/K2CaQm/aJJZ9oyo6DZSbBfM6WXI040aR4CnzX5bCrEaZYyhFSof7jztWvkQ0JqnvvvXez50EQXY/lCiqBBBWxCja3YVgtetys4JZWS2FrHbWpCaLWURzLn8++CgysTd1MfeQlqsTqzrWL4tQLJX+qWm2cJGxdPr1t2yix0ubfuJpCVRcVWHtxeC0q0Sri4AqJNtEOr9ai6XjjmFUEDfffo5WwqYCtQyiv+0fY5gG+PqrROs2JMxGMwxEVcqj1GL9YYSucbxI0/vPt0qxWv78jNo7vB9OjgXOOtJ7GeP5InWNeVUSl9bQ3NqbEMBpOIhVJ4fyBC5wok+ue16v1HrNosSwKGI5pGI5pK47Ll03M5sqYc400/ALswFweP3t+EQt5A5bPQ14SGPojKkbDDKcFMtijLCMlLmCIz6PPnEW0PA21MAkhP1P3oQAPJpw0vGgKfM+LnUiTP8KkkZv3amzoX6g3velNmz2Po0bXdXzoQx/C/fffj+XlZZx99tn4+Mc/jj/+4z/u9NQIAgDA3aJQ+sR7Z+HvedMqtaxUKWExswg5J3v1NuUG0eLvedNUe+M/5uuLsx6qxf6eIPHS1GoCJabGMdhgNtAyauNr3Onvc+OvvZEFefMfNrwUKt9mVoCK3iIy0Zhm5RMjbcc01GtUj/PmyAe3KoiXi5AbIhl1KVJtaktWKh4/pilUYK0fzt2Hd94m2uE96FfFgaSBK6HaeVECmO98izqP5jEN8/AET5uIRcuohlx3LQTZiWocxf935PLXHdjcxnxpHhP5CRzJHsaBhQNYMBc88VQwa6lofVoCqUgSJ0R34/KR/V6UKRlOIqZub5GwooW8ngPLTMBOH0Fp/hD0hUOw0+OQcpMIlqYQXlz0htpgmOU9mOAJTPAEJvkFmBcHUAqMwoyMQogn0RPvqUW73OhXIrx1FvLdwM6y0FiBW265BQ888ADe/e534+STT8Z9992HG264AQ899BAuv/zyTk+PIGC7nyIJ9OnjUWHZVhsXtHLLupm2qWpmm9qbOpOBMgzb2HDPm9a1MypCchi9Wl+TC1q1z02TwBFkaIIElYlQmQyVCVCZCI0JUCBAtC3noX3FqEaLOomKCZQNwC45jktNDlGrFI9XRUPLyEe7NK3WtSXHPIWqZZqTr/Da9wDPmAjRZmCKBibWCrO5qLYs3uZtIiYtz68kaFpGLHzF4yvVhWxSChVBbAdM28RMcabWo8kXZZrMT6DaaJmBoV/rx1h0F87oPQPXjV3n9WgaDScRlIMd/k42AOdAaclLwWPZcSAzAVatX8qMg5XT3nBVkIHoqBNhOmEvePQlqMTHwKNOWh6iI9AsAZGcjr6sDjOnA260K5PTMZvWMTc+3dZCvlbb1WAj76YZrtVCvtvZsKA6fPgwvv71r+PgwYNYXl4G5/UhfsYY/umf/umoJ7gWfvnLX+Lb3/427rzzTrzvfe8DALzxjW/E3r178f73vx+PPPLIlsyDIFai+lC+0//w2NyGyU1Y3ILJTWezTfeY8zonzqEoF/Ho9CN14qRlj5sWltKNqW5+kWSu81N+VVCgiQpUQXY2JkMVJFegyFCZiJggQoUMRdSgSgI0CI5ogbsPOK+cQ+XMec+5897mYHoJUVmBxgHJHyUxqoKmAljFZkHTsni8WdBsreXtKsXhDQ/+VTHi1Gs0j2lZHO6LdvA20Y7qGN4U7WiuLVl5jLhusUGRDII49hiWganCpFvL5Kbnuc1tpwrTXhqyyCSMhkeQDCdx4cCFeNVJr3J6NEVSGAoMo5At7KzfVW4D+VlXHNVEErITNRFV8Rs+BBwnvFgKfOR82Ke/spaeF0sB4UGsZvgQFLEmC/l0qdKmtkvHY+MZzGZnsVysN/cJyAIGqkYa1fquhqbJAxEVirRD1meDbEhQfetb38Kb3vQmmKaJeDyOWKw5bLqVD40PPPAARFHEW9/6Vu+Ypmm49dZb8Zd/+ZcYHx9HKpXasvkQREvalBVwzmHDrhMmzn4Fpm3Atisw7Qos24BpG7B49X0FJnc2y65dY1Wvde9j+e7piKCqEPK/WqjAebW4DRMWTG6jwi2YsGFyGyZsVGB7TkcrEnK2f3v43+oOy2CuSGFQ3U3jgApA5c4W59wnVmxonEOzLai2DdW2nH3Lgmab0GwTqu0b723OdQp32mBseMkEuWWdhFf4zZx9kzNIsto0louSY3mrhFqmSvE2VrWrF4/7UqRaWt62u39jYbhI9RoEQRwzipVinVCa8BlCzBZnPWMaVVSdeqZwCvtHr3RT81JIRpIYCg61raG0bRsFFFqe6xhWBchN1cRRZtyxFk8fActOANlJMKuW1s21mGcfbp+wH4glwWNjnmhCsG9L/k4LAkNvSEFvSMHpw+3HGaZdV9s1l3WE11xOx2xGx39MZDCb1aGb9R8E9oZkR3i1aprs7oek2vNFY6Bmu7MhQXXHHXfgtNNOwwMPPIBTTlnJy2RreOyxx3DKKacgGo3WHb/44osBOG6ErQSVruvQ9ZqLSTabBeD8gtr2sftEeC0U9Aqeni0gUhR2fERjU+AczK6AcctLHWLcSSOqHmP+Y95xt8i67nj9eeZLlTJsA4ZdRsU23H0DBjdQsU0Y3IBhmzB4BTo3YbibDgsVbkHnFgxY0GHDgA2d29BhQ2ccOjjK3IYRB/7lN/eiwgATgMmACgC+CWsscQ6Zc0gckOHsN7+H8wpHbISqYwBvvH9M9b0IQOIMEpxNBiBxATJqx5xNhAgGSzcgcoa+SA8UQYQCGbIgQRBkcOZEFJzXWqE2Z5J3jPuPuQ/+3E3N8h/n/uNMgi5I0NuOrd634esz/9erXbNWi1fOOXK5HCKRSOd/V213WxHL3Yh2OGtKf3+7DVrXY0OhksNseRJzpUnMlacwV5rCXHkSc6UpZCq1XkSaGMSANoLBwCgu6LsaA6MjGNBGMRgYQUzpg9AYSbaA5TSwnM63/dqdWFNmlqEUpqAWJqHkJ71XpTDlvJZm67IKKlof9NAo9PAojOFroJ88AiM0CiM8CiM0CkuJtP5CFoBlAMuZLfm+1osiMqTiGlJxDUB9YIVzjoJhYalgYKlgYLFQwXLRwFKhgvm8joMLBSwXDeT1+n+LJFh4Q8DZ/934Mi7Zo27Rd9OeteqBDQmqhYUFvP/9798WYgoApqenMTzcLKerx6amplpe96lPfQof/ehHm46n0+mOW74/PZvHW779zJrGMtiQYUGE5b063bxtSMx0Xn0dvqXqWGZBhA0JLcawFuPhjJeZ6V7XZgyzIcMZUz+fxvvabc+JsGAzCxbjMJkFU2AoMwadMZQF99V9798az5VbnhNqxxiD7h6vrPOPsSM8GGQOSDaDxAVHdHABki1C5DJELkCwRWhcQJCLEGwRDAKYLYBxEYwLAJx9cBHgzj733ovgXPLecy4BXILtHuNcAofovIcIiwuwIMBG7bUCAWUIsMFgVY+74+rHsrrrquc5jiJMn9v4pZsHhyNb19eDiCAIggAADibmISiLYMoiBGURguy+KotgYs0R0zZD4EYf7EofbOM82EYCttEHXulFzgphHgxP1N1bB/CCu20PIihilC1glM27r86WdN/3s6w31uIMM+jF8zyBSZ7AJL8YkzyBCd7vvk9ALytAutVXyrob0YrZpSyWlzsvqHK5tT3IbEhQXXLJJThy5MhGLj0mlEolqGrzD13TNO98K+644w68973v9d5ns1mkUinE4/GmaNdW80f//h480f8URPC66Aqq0Rh/xOUYWtTa7if5huB8+l8WRZQFyd1E6KKIMhNRFgTnPWMoCALKcIRKTdCI0JmIMjh0AIYbtXGiObwW1YENw430rOe7EiFCEWQoTHZeBQWKoEBmChRRhSyoUAQVIVFDXFAhi5p7PABZdM45YxRn323oWb2ubl9UIbH1u5z97Kc/xdTUJC6++OKut07/za9/DV3XcfOf/j+dnsoxZ1tFqIhNgda0O6F1bY/NbSzr85gtT2K+NIXZ8pQv4jQJ3S57Y3uUBAa0EQwEzsJAYNTdH8GANoKg1MKR7hiy7jXlHJK+BCU/BaUwCTU/4UWW1IJzTDJqIscWZBihYRihUejh82GERvFCeBRGaAR6aBSV0BC4IEMAkHK37oMjr1tYLlawlDewWDTcyJMTdVp0o1DpUn19syQAPUEFfSEFPSHntTcoe2mFvSEZPUEFqq+2yqxU8INvPwYA2H9GEvFw501F1to7dEOC6nOf+xyuv/56XHjhhbjxxhs3cotNJRAI1KXuVSmXy975Vqiq2lKICYLQ8eJGIXkBeGAAYjAM1lCXYQsidMCJuIBDB0O5KlC4k2JW5jbKsKFzyznGLejcRJlb0G3T3a/AsE3odsXdDJStCnRbh24ZdQYCVlsHrub0IYEJDS5n1Z4yiud4FhZVJHyNNdfaeFMRmy2cVVFdscneduFwGDBlHXv61K4XVBOKgZJVxlnJeKencsxxDAxs9PTEOv53g9gcaE27k+N9XU27gunCdJ1jXrVH01R+ymvXIDABw8FhJCMpXNxzHlLhVyDp2Y2PQpNaP1N1gqY1tS3X8GEcLOurYcqMA5lxsOwkWKXoXc/lkFOrFEsB/ZeAx1KoeP2XkkB4EIw5xkSdj5VsPoZp15lPOHVRbn1U1ZgiV0a50lwPVTWe2J0IeU2G/SYUPcH1f/BsGAZ+4O4HFWlb/J6udQ4bElRnnXUWPvGJT+BP//RPEQqFkEwmmxQcYwyPP/74Rm6/boaHhzE5Odl0fHp6GgAwMjKyJfPYTP4/mMcBYRxm2fI1+HQc0Cr2+lKXVDfa0tg00xMtcgg9qzTedHrStLKAro2tihxJIAvNVohu93KbH1USHUEQBEG0pGyWMek651UF00R+HOP5CcwUpr0PR2VBxkhoFKlIEpcNXYZR12o8FUlhODgMWZQ7/J20wTKA7JQnkoT0EcTnD0Ipz0GoGj74npG4FvfEET/xasfwwTWA4LEUEOjtSmMezjmWi5WaWYTfOMLXKLjRsU+TBU8oDcZUnJ2M1dukR1X0h7vfsW8jbEhQffnLX8Ztt90GTdNw0kkntXT520rOPfdcPPTQQ8hms3Wper/4xS+88zuN0fAomMUQDUShSZqvCefqURy/yFFEpbnQk+gIzF0H27IAqWtawBEEQRBbSL6Sx0TO75w34USccuOYK8154zRR8xrZXp282ttPRVIYCAxuz8yOShEsM+FEk6rueNX9zDiQm6krc+ChAfDQMHjvCbBGznVc8eIpTzRBbWP4sIMpGVbLqNKsF1Uqt+0pVXXYOy8Vw2B0sC6qRD2ljo4NPdV98pOfxL59+/Dggw92XEwBwI033oi77roL99xzj9eHStd13Hvvvbjkkkt2pGX6W/e+jfqgdBmi23G80w6SBEEQxPaFc46Mka6JJTctb9LdX9aXvbEROeJZjJ/bf64XZUqGk+jTEtvv4bicqRdIvua1LDMBVlzwhnImAJERJ5oUPwH2ritqkaVo0rEZF5SueVaybI7FgtEyquQXTdlyfa1SWJW8KNKuvgAuPqEHA75GvINRFX0hBZK4s38+250NCapMJoPXve5120JMAY5Jxmtf+1rccccdmJubw549e/D1r38dhw4dwv/8n/+z09MjCACAKDq/bhYJKoIgiOMazjkWSgsYzx9pamo7kZ9AvlKzCu/T+tweTWPYN/xHTi2Tm6IXU7fHcxgAgHOgMN8QVZoAsuNgabemSa85pnFRcaJI0RT4wJmwT36Jm57nNqyNDDv98lZih/x7mtdNJ3rUMqrkiKb5vAHLrkWVJIGhP+IIo4GoiksTfY5QaogqhVTKeNkObGgVrrzySvz+97/f7LkcFX//93+PD37wg7j//vuxvLyMs88+Gw8++CD279/f6akRBABAkp1fN7vDlvwEQRDEsceyLcwUZ7wok7+p7UR+ArpVc84bDA4hFU7itN7Tce3YdV6UKRlOIiSHOvhd+LAtID9TF2HyRFPV8MGsuSpzJVSrV0pdCjt2o08wJYHQALDDSxIqlo2FvOEJpeZaJUc0FY36f/fjARkDrlA6eTCCy/ckmqJKvUEFgrDNIoxEWzYkqO6++25cf/31+PSnP41bb70VfX19mz2vdaNpGu68807ceeednZ4KQbRElpwi3073OCMIgiA2B8MyMFWYcs0fnFqmqmCaKkzCtJ30LJGJGA4NIxVO4fyB8/GKE1+BlBtlGgmPQhW3gYecqTumDl4KXtUl74gjmnJTTvsWFx7odcRSNAV+0jWAL7rEYylAi+9YwwfOObJl06lTck0c/FGlOVc0LRQMcF+PF1lkXuRoIKritKGIa+hQ74Cnyduwfo04KjYkqM444wzYto077rgDd9xxBzRNa+nyl8lsz+7OBNEJZEUBAJimucpIgiAIYrtQMkte/VKj3fhscRY2d9LOFEFBMpzEaCSJy0cur5lAhFMYCg1BEjrsnGcUPLGEhggTy4w7duN+w4fwoCOOoknYoxeCR5M+0ZQElK3tObVZGKZdE0ZVodQQVZrL6Stahe8drbnfHa1VONEdbEhQveY1r6H/YQhinSiuoKIIFUEQxPYiZ+S8tLyqY1414rRQqhklBKUgkq7xw3VjL/YMIZLhJAaCA51z1eXcNXw4UhNI2foIEyst1YYzEYiOOhGm3hNhn7C/ProUHQWkbRA1Wwe2zZEuVRqiSs2peI1W4QFZ8ARR1Sq8FlUiq3BibWxIUN13332bPA2C6H40zfnHiSJUBEEQWwvnHEvlJTyZfhKZdBpTxUmM56p24xPIGGlvbEyJIxlxIksXDl6I0XCtR1OP2tOZD5Q5Bwpzvka1R2qGD9VjRs3IgksaeHTUiSgNnQ371JfV0vNiKSAytLrhwzaiZFh1UaWqaJrLljG5XMBi0cJ8fmWr8At29dR6KkVqjWjJKpzYDHbObxNB7HACAae7PAkqgiCIzcfmNuaKc02OedXIU9EsemMTgQRS4RROjO7G/tH9SIXdSFMkiagSXeGrHKvJm0Buui4Fr2oljswRsMwkmKV7w7kSBo+NOSJpbB/sqliKjzmpeaH+HVG/5LcK99LtPNFUiyq1sgqvCqJkXMVlJ0UxFNNq7ndkFU5sMWsSVL/97W9x4oknIh6Pr+vmlmXh8ccfx6mnnopQaJu41BBEhwgGggAAk1L+CIIgNoRpm5gpTHu1TF6PptwEJvITMGwDACAwAUPBISTDSexN7MVLTngJRkNJxOwYTh85HSFli59JTB0sOwFkJppd8rITQHYKjNf+beCBPq/nEt/zYrd2yX0fTQFabNsLpnzZbB1V8jWlXVjBKnwwquLEk/paRpWqVuG2bXdNHypiZ7MmQXXRRRfh/vvvx5/92Z+t6+bpdBoXXXQRfvjDH+Lqq6/e0AQJolsIBF1BVamsMpIgCOL4Rbd0TOUn6xzzqiYQ04UZWNyJVkiChJHQKJLhJC4auhivDr8GSdcIYiQ0AkVU6u5bffgOSIFjMOmcz/ChhWgqzHlDORgQHvSiSXbyYsfkIZZyok7RUWCrBd86qFqFN0aVZhtEU0urcNcavGoVXtdTiazCiR3MmgQV5xxPP/00fvzjH6/r5plMBtzvJ0kQxzFVU4oKCSqCII5zCpWCm5rn69GUG8d4fgJzxVlw121OFTXHKS+SwouSV3mGEMlwEoPBQUhbUQfEOVBa9lLwWKbBJS87AVZarg0XJMfwIZoE7zsZ9olXe854nuFDg9jbDnDOkSm1jypVDR4WG6zCFUlwRJErjM4YjjZFlfrJKpzoctb8l+jjH/84PvGJT6zr5pxzKvQjCJdqOkKFaqgIgjgOyOiZese8anpefgKL5UVvXEgOY8wVSWclzvbZjY8hEUgc++cIbjuW4V7tUqNomgCrFGrDJc0RRrEU+PB5sE97hSuWxpzj4UFA2F7iQa9YmMvrrpGDzya8QTTpZr1VeF9I8aJIe0djuLrBKnwwqiIeIKtwgliToHrooYeO6oucc845R3U9QXQLjDFK+SMIoivgnGOxvFAnliZyNUOIXCXnje1RezyL8UuHLvWa2iYjScSU+LF9ILdNIDsFIX0EgelnIFUWIeQma6IpOwlmGbXvS43WIkq7roAdT7nueG6EKZjYNvVLts2xXDQ8a3B/VMkvmtIrWIUPxwI4NxVviiolyCqcINbMmgTVlVdeeaznQRDHBYIgUMofQRA7Bsu2MFeabXLMq+6XrbI3djA4iNFwEifHT8HVqWuQDCc957ywfAybwFZKDYYPE256nrMhNw3mNt9VAfBgotZzaXCvY/IQS7o1TSlA64DLXwuKhulzu6sXSHOuaGplFZ4I16JIF+zq8Qweqj2VBqMqwipZhRPEZkK26QSxhYiiSIKKIIhtRcWqYLo47XPMG3cNISYwVZhExXb+ZolMxFBoGKlwEuckzsVLd7/cizKNhkahSdqxmaCeq4kjf6Paak1To+FDZNiLMNmpSz3xZEdGsWyFEB8Y6agjnGVzLOSrwshn6tDggJdrsAqPaJJXq3RCXwiX7O71Uu+qZg9kFU4QnYEEFUFsIaIoQtf11QcSBEFsImWzhIn8pGv+MOHZjk/kxjFdnIbtRnBkQcZoeBSpcAr7Rva5tUyOEcRwaBiSIG/uxDgHSks1kVQVTZ4BxBGwcqY2XJAdw4dYCjxxGuyTrnWtxJ0IEyIjgNh6jty2wZeXW57bnG+FI6+bdT2UPJHkS8VbyOvwOYVDEpiXbjcQcazCqwYP/uNVq3CCILYf9NtJEFuILMsoFAqrDyQIglgneSPnpOL5RZMbbZovzXvjAlIAqXAKo+Ekrhm71m1q6zjp9QcGIG6moYJn+OAzeHDFE6oGEJVaw10uB53GtLEU+Mj5sE//k1r/pVgKCA10xPChYtmYrwqlXLkuFW8ut4JVeFD2okqnDkaw/+REnaHDQISswgmiiizLePd73ot0Og1Z3uQPb44xJKgIYguRZZlS/giC2BCcc6T1NMbzR5qiTOP5caT1tDc2qkQ9i/HzBs53U/Mc4dSn9W1e/YxVAXJTYOkjnjue3y0PmQkwu/Y3j2sx1w0vCb77RU7tkmcpPgYEerfU8IFzjnSp0jKqVLUJn83qWCo2W4X7a5POGI62jCqpZBVOEGuGMQZFUSDLO885cs2C6rLLLsNXv/pV7N2791jOhyC6GlXTYJJtOkEQbbC5jYXSgtfUdtKtZaqKp0Il743t0xJIhpPYFT0BfzRyhRdlSoaTiKmxzZlQpQiWmQSyDY1qq+l5+RnP8AEAeGjAEUfRFOyhsx2R5I8wqZHNmdca0CtWTSjlypjNlHF4PoOMMeEIptzKVuGDERVnjcZwzWmu+50vqkRW4QRB+FmzoDp06BAuuOAC/MVf/AU+9KEPQdOOUfEpQXQxwUAAnHOYpglJogAxQRyPmLaJmeJMncV4NVVvMj8B3XLqLBkYBoODSEVSOKP3dFw3dp1nPZ4MJxGUg0c/mXLWqVdKH2moXXKFU3HBG8qZUDN8iI/BHvujmpV4LOmk6smBo5/TKtg2x1LRaF2r5EaV5rI60qX6bICgLCIRkjAcD2IkHsB5Y/FaTyWyCicI4ihY8xPdM888gzvuuAOf/vSn8Z3vfAd33303rr322mM5N4LoOoLBEACgWCggGtukT5AJgth2GJaBqcJkS7vxyfwULO5EqkUmYSQ0jFQkhQsHLsSfnPgnTo+mSArDoRGoorrxSXAOFBfqrcTT4260yRVNerY2XFTAo6NO/dLAGbD3XOdaibuiKTLc1vBhsygaZs0mvOp+56bfVQXUSlbhg1ENF+3qqfVU8kWVgrKAdDqNnp6ejrr8EQTRfaxZUEWjUXzpS1/CLbfcgre//e148YtfjD/7sz/DZz/7WfT39x/LORJE1xAKO71YiqUSCSqC2OGUzJJXv1QVTtWI02xxFhzOQ78qqhgNJ5EMJ3HFyH4vLS8ZSWEoOARJ2GC02rZcw4cjLWqX3PdmyRvO5VDN4CF5MewzX+OJJR53DR/YsREapmVjsWDUrMJbRJVmszryerNV+GDEEUSeVbjbfLZqFZ4IqxDXYOpg2/aqYwiCIDbCuv+KX3TRRfjVr36FL3zhC/jgBz+IBx98EKlUqmkcYwyPP/74pkySILqFmCuiSsXiKiMJgtgOZI1siyiTU9e0WK6lw4WkEJKRFFLhFPaesBejriFEMpxEf6AfwkaEimUA2cl6sVTdshPOObsmQHigpyaQTrzaiTRVDR+iKSDQs+mGD1Wr8FZRpVlfVKnRKlwWGfqrDWijGvYMhOvc77yokkKp0QRBbH829JfKNE3Mz89D13X09fWhr69vs+dFEF1JNBoFAJRKpVVGEgSxFXDOsVRe8izGJ/ITOJI7gkPpQ5gpzyBr1HogxdW415fposGLvaa2qfAY4mp8/SYFRgEsOwmWOVKLKFWtxNNHnOgTairEMXxwm9SOnO+rXXJE02YbPhimjfl8rfnsbEPz2eprqVIf+YkHZS+qVLUK97vfDUZU9JBVOEEQXcS6BdWPfvQjvOMd78DBgwfxjne8A5/4xCcQiWydaw9B7GREUQRjDKVyudNTIYjjBpvbmCvOelGmRrvxki8trj/Qj2Q4hd2R3bhm1zUYi4456XnhFCLKOv6t4xwoZ1yTh3G379IRX6RpAqy0WBvORCA64jaoPQH2ritqznixpFPbJG2OGVTVKrxq6FCNIs3l6lPxFgtG3XV+q/DBqIa9I1EvqlRNvyOrcIIgjkfWLKjm5+fxnve8B9/61rdw1lln4ZFHHsHFF198LOdGEF2JJEnQSVARxKZi2hVMF6brHPOqEafJ/CQM2xEHAhMwHBzGaDiJsxJn44YTXopkJOk6541CkwKwbRvLy8srmxdwDhTmvWhS1R0P/ua1Rs3inIsqeGwUiI2BD50F+5Qb6vsvRYaAjdZS+Si7VuHtokqzrlW44bMKZ8y1CncF0dnJmCeaalElDbGARFbhBEEQLVjzX+9TTz0VhmHgr//6r/He974XokifQBHERpBlGWUSVASxbspmGVOFKS/KNOkaQIznJzBTmIbFLQCAJEgYDSWRiiRxydClXm1TMpzESGgE8lqc6mzLEUa5SZ+V+JGaaMpOgpm132OuhGsCKXUp7L03ug1s3XS8UP9RGT5UrcI9m3BPNNWiTC2twhXRE0WjPQGcPxb3TB2qdUr9ERWySK53BEEQG2XNgurSSy/Fl7/8ZZxwwgnHcDoE0f0Eg0Hk84VOT4MgtiX5St7tz1Tfo2ki7zjnVdFEzWtke3XyareWyTGCGAgMQhRW+dDP1H2GDzWjB5YZBzITGM5OgrkCDQB4oNeLJvE9fwxEU/URJi22YcOHgm76BJKbcpfVMVeNMOV0zOd0mD5XB1FgSITdqJJrFd4qqhTWyNSBIAjiWLPmv7Tf+973juU8COK4IRwOY2lpqdPTIIiOwDlHxsh49Ut17nm5CSzptd+NsBzGWGQMo+Ekzuk/x4sypSIp9GmJldPPjLxXrwSf0UNVNLF8TZxxMCA86Akke+QCFKReBIZPA4uPOal6Snjd36tnFd4UVfJbhjdbhUc1yatNOrE/hEtP7G2KKq3VKpwgCII49tBHVwSxxcTjcRw6dAiGYUBRlE5PhyA2Hc45FkoLToSpRY+mfKVWW9Sr9ropeWO4bHif65znCKeYEmstmjgHyum66BL8zWsz42Cl5dpwQQIiI040qXcP7N0vcsRT1R0vOgpItQa6tm2juLwMtU0NFeccuXJzVMlv8DCb07HYwip8IKJiwO2hdPJAuCmqRFbhBEEQOw/6q00QW0zCbYSdy2bRl0h0eDYEsTEs28JscdaNMo27EacJzwiibNXqiwaDQ0iGkzi15zRck/pjL8qUDCcRkkPNN+c2UJgDWzjgE00+l7zsOJhRS5vlkgYeTTp9l4bOgX3qyzyHPB5LAeEhYLUUQBfDtDGbLeH5qTyKUwbmcoYjkqr9ldxUvHZW4YNRDacPR3DlKY5V+KBPKJFVOEEQRHdCgoogtpjBwSEAQC6XI0FFbGsqVsUxgfA55lUjTlOFSZhuU1mRiRgODSMVTuG8gfPw8hNf4QqmFEZCI9Aa7b5tE8hNg00/Xl/DlJkAsuNgmUkwS/eGczXiRJPiKfBdl8OOJWuCKVo1fFhZqHDOsVysNPRQaowqlbFUqDd1UCXBq0caiKrYOxL1bMK9qFKYrMIJgiCOZ0hQEcQWMzg4CAAoFMiYgug8ZbPkpuP5ejTlnPS8meIMbO5EYhRBwWh4FMlICpePXO5FmVLhFIZCQ5AEn3OeWXbE0dIRsBd+5nPIc0VTbrre8CGYcNLxoinwPS92Ik3+CJMWW/l7cK3Cqz2UvPqkhlS8ilXLv6uzCo9qOCcVw0BkwBFLYQUa17FntB89IYWswgmCIIgVIUFFEFuMJEkQBIEEFbFl5IycV7/kF0zj+XEslBa8cUEp6PRjiiTxx2PXeWl5yXAKA8EBCFXbbz3niSRM/ltd81qWGQcrzHn35GBAZMgTR3bqUqd5bSzlCKfoKKC0SPuDYxW+WDAwu5TFnGvq4BdI1fqlTKne1CGoiF6aXbIngAvG4vXud1ENibDS1iq82ocqHpRJTBEEQRCrQoKKIDqAoigoFoudngbRJXDOsawv19zy8uMYr4qm3AQyRtobG1NiXl+mCwYurOvR1Kv1ggFAaakmkA7/Gsj8f70eTCwzDlau3Y8LMhAddSJMiVNgn3h1fXQpOgKIzeYred10okgTZcxmM65NeL0D3kpW4YNRDRfv7vHc8KqRpsGISlbhBEEQxJZC/+oQRAcIh8PI5/OrDyQIF5vbmC/N11mMV+uZJvMTKJi1iGcikEAynMTu6G5cMbofybArmiJJROUwkJ+tpeFNPw+WeRio2olnJsAqfsOHgOOEF0uBj5wP+/RX1tLzYikgPFhn+GBaNhbyhpN+N61j7tmZlrVKBd3yf3uIapIbVdJwUn8Il53Y2xRV6gspZBVOEARBbDtIUBFEB4jF41hcXAS3bbAWtszE8Ylpm5gpTNeZP0y4znmThUnorlEDA8NQaAipcApn9p2Jl5zwEi/KlAwOIVBaromjpXGwQ7/3ejAhOwlmGd7X5FrMsw+3T9gPVJvXuqIJwT6AMXDOkS2btVqleR2zz5cxl3vGS8Wby5axUDDA21iFD0ZVnDIYbogqkVU4QRAEsbOhf8EIogP09w/g+QMHUCgUEI5EOj0dYgvRLR1T+UmvlsnvoDdVmIbFq855EkbDI0iGU7ho6GK8Kpx0RFOgH6OWDSU3W0vDm34ULPMdsOy4a/hQs/TmwX5HHMVSsIfOdmuXkl4fJmhRGKZd7363pGP2cBlz2SnM5V7wokrlBqvwnqDsRZHOGI7gKtcq3B9VigdksgonCIIguhoSVATRAUZHRwEA6XSaBFUXUqwU66JMk54hxATmirPgcEI4qqh5bnlXJl/kpOapvUhxhiG9CCk77USaDj8NlvmhI56K897X4UwAIsO1CNPYZa54GgNiSdiRUSxXpAYHvDLmJqupd09gNlvGcrG9Vfhgg1V4Nao0GNGgSBRdJQiCIAgSVATRAXbt2gUAyGQySKZSHZ4NsREyesYRTNkjeG7+OSxYC5jMT2IiP47F8qI3LiSHkXJF01mJs5FU4hiDhLGKif5iGiw7CTYzDpb5jeOWV85413JBdqJJ0ST4wBmw91znmj0kUQ6OYIb3YbZg1dUmzc665g7ZaczlDjVZhSdCCgbcKNK5qRgGI4OeI141qhTVJHK3IwiCIIg1QoKKIDqAoigQRZGMKbYxnHMslhc9u/FqnybHRW8CWSPrjY3JcYxFx5AMj+KSnjOQYipSlo0xvYSe3ByE9ARw+MeOeKrU3B25HPLS8fjohbDPeBWsaBJpZQizwgAmKhHM5io1m/CDjmiay+nIlA4AOODdq2oVPhjRkPJZhQ96UaWVrcIJgiAIgtgYJKgIokOoqkqCqsNYtoW50mydY57T5NZ5LZklb+xAYADJ8ChODg7jqvCJGLMZxnQdyWIagaVxyHO/B8v+AMyupc9xLe5FlPiJV0MPjWBJGsQs68c4T2CiFMBs3jV0GNcx+0QZ83kDll0A8AIAxyq8P6x4tUmX7O7FYMSffueIprBKf84JgiAIohPQv8AE0SFisRgWFhZWH0gcFaZdwVRh2mc37ja3zU9gMj+JiiuABCZgODiEpNqHc5QEXt4ziKRpYqyURyo3j8DCBJD7DRhqKXQ8NAAeS6GkDqA0cG4tsmT342ClBxNFyUnFmypj9mkdRaNqFa4DmPSswgcbrMKrqXcDEZWswgmCIAhim0OCiiA6xMDAAKanp2EYBhSlufEpsXbKZhmThUlHNFXT81zxNFOcgcUdISMLMka1BFJyFPtYBKngKRgrF5EqLGE0PQ2l+HPvno7hwwgqkVEUtFHMJC/EvDCACZ7AC2YvninHMZXnmJ0rYzFv+GQWIIsWBiI5TxSdOhT2DB6qluEDERUBRQRBEARBEDsbElQE0SGSqTE8/vjjWFpawtDQUKens+3JV/I1seSLMk3kxjFXmvPGBQQVSSWOlKDhj20ZSdaPsWIau7IzGCxmIeJ5AAAXFVTCoygGhpFWTsbjA3+ESZ7AIbMPz+g9eLoQxvSyifJca6vwwYiMM4dVvOjkPoQlC7sHezEcD2AgoqInKJOpA0EQBEEcJ5CgIogOcdJJJwEA0svLJKjgmEBkjLQjlhqiTBP5CSzry97YiKBiTAojxQVcUDExVhSRyi1gl15An2WDAbCkEIrBYWSUIcyLZ+GxyFU4FOjDc3oPnijEcKAQBC/UDBo0WXBqkyIqBntUXLVLratVqkaVGq3CbdvG8vIyenp6IFCTZoIgCII47iBBRRAdIhgMQhRFpNPpTk9ly7C5jYXSgs85zxdxyo2jYBa8sX2ChhRk7DYt7C8XkSosY5ehI2WaiNk2dDmGjDqMBXEA09iD37E+PCDE8WQ5jkNWAhmEgDyrswofjKoYHFFxQ6Rap1RLwSOrcIIgCIIgNgIJKoLoIIFAoKuc/jjnKNklpIU0FpVFPPDcAzXxlDuCifwEdNsAADAAQ0xB0uI4Uy/jJaUcxioVjJkmUhUTltSHRWkA0xjEYasPjxm9+I7Rg0nej0meQLGsIWSItaiSa+TwiqpIcoVSIqxAIqtwgiAIgiCOETteUN13331485vf3PLc9PQ0pVIR25re3l5MTk6C2zbYNk0Xq4qkTCXjbGYG6UrafZ9G1lhCprKEjJlF2syjAgsIO9f+v7/+dwzbAlKGgYuMEl5TMTFWqWDE5AjxHiwiiiN2AgcrvXjG7sP/jycwwfsxxxKIySEMhnxGDhEN13tRJbIKJwiCIAhie9A1TyMf+9jHsHv37rpj8Xi8M5MhiDUyMjKCI0eOIF8oIBKJbNnX5ZyjbJeRqWSQNtPIVjJIVzLIVJaR0+eRMRZd8ZTDsl2EgXpjBokDfZaNPstEwrKwy7LQ5202QqYIyQyhYvZj0nJE0iRP4Hc8gaw6BBYZRiIadOqT3FS8F7kRpcGIil6yCicIgiAIYofQNYLq+uuvx4UXXtjpaRDEuthz8sn4+c9/joX5+U0RVGWrXIsgGWlkjXlky3PI6ovImMvImDmkrSKWeRl6k0ji6LUsJFxRlHQFUo/FoZkKRDMAmCHYVgRFK4Y0oljkEaQRwbQUwyE5hooSg632IFNchmwbeMmVl2EwquIyN6pEVuEEQRAEQXQbXSOoACCXy3mF/gSxExgZGQVjDMvLy9jdZkxVJGX0ReTLM8iWZ5Epz2NJX0bazCJt5ZHlZaRZBTrjdddWRZITTbJwqmUhYgoIWDJkSwMzQ7DNMCpmDAZ6UBbjKMsxGEoceSWGbCCOI1oEYVVERBEQVgSEVQFxRUTS3Q9IrMnM4eGHnkWpVMKtl59wbH5wBEEQBEEQ24SuEVRXXXUV8vk8FEXBi1/8YnzmM5/BySef3OlpbZjxpSIWlktYMhUIlPq0M+A2mF0BbMt9NWFaJRhmERWzBN0sIpNdgKQKMG0dhlWCYevIhp/A45n/wDOP/SuyZhY52xFIOWYgI1goN5RWiT6R1GvZ2G0JCJgyFFOFaAUh8ggExCGyXjCxH5Yah6XGwUNxCFoMwYCGsCIirAiIqI5ICikCJPr/jCAIgiAIYt3seEEVDAZxyy234KqrrkI0GsVvfvMbfPazn8W+ffvw29/+FqlUqu21uq5D13XvfTabBeD0lbFtu91lW8Jt//s/8Mxst7i/cYiwIcGCBAsiLEi+9xKzavsNm8hsyDAhwv/q3oNV79d8TmbVr1PbGExAMMEFCzYzAWbCEixwZsF2N4txWIIFS7BhMRsm4zCZjYrAYTKOCuOoCBwGAyoMMBigM8AQAIMxlBmD7tv4Wmy4+wCBc/QaNuIWR9QSMGSJ2GUqUKwwRDMI0QoBVhjcjMK2ozBYAGWosJkEi9mowARjFjhsWI1fspgBkAFwGACgA1jGsYVzjnA43PHfo63Atm1wzo+L7/V4gda0O6F17T5oTbuP7bama50H45zz1YdtDbZtwzCMNY1VVbVtz5if/vSn2L9/P9761rfi7/7u79re4yMf+Qg++tGPNh1/+plnt9QgoBUHjxxGLr2MoCZD4DYYNyHYJhi3nM3dF7gJxs3ae2+MCcF2Xqvja2Ot2rW+Mc61tTGC79rGezv3a7y2YV7u/QRuNX1/NtAkPsqMQRd8+/5XoWEcE7zxZSZAFwTntWGszhh0OKKnSWisAOOAAgEqBChMgALR2ZgIGSIUJkGBBJlJUJjse5UhCwokJkNmCmRBgcwUSIIKiSngpoCQFoYkBiELKiQxgEy6iKWFPJgShiaJ0ESgG4JFe/fuRW9fX6encczh3EYul0ckEgZj29OpkVgftKbdCa1r90Fr2n1stzXN5XI47dRTkMlkEI1G247bVoLq4YcfxlVXXbWmsU899RROO+20tucvu+wyzM/P48CBA23HtIpQpVIpzMzOrfhD2wrU/3klhPmnjuoenAmAIPk2GRBEcFEGmAiIMiBI4ExARZRRFkSUBRG6IKIsCNA9ocLc96iJGjgiRQd3NgaUue2+t6BzG2XY0LnlbWVuQrdN6NxEpYXIWglFkKGKKlRBhSqpzr6oQZU097hSOya6571xznFN9L9vGNuwyYK86U1ebdtGOp1GPB6HsE0t0on1Q+vafdCadie0rt0HrWn3sd3WNJvNYmhwYFVBta1S/k477TTce++9axo7PDy84vlUKoVnnnlmxTGqqkJV1abjgiB0fBGz1/53LCxNQQqFoDNXtHjCxIbOTehwX+2aUCnbBnS74myWAd0qQ7d0lC0duqVDN5339VsRHG10dTXS6dM/IhNbChPNJ2BCooZed1/zxE+zwFFEpXa9J4RqQscZo0LYBp9SbAaMsW3x/xexudC6dh+0pt0JrWv3QWvafWynNV3rHLaVoBoaGsItt9yyKfc6ePAg+vv7N+VeneCWp76E5zPPr2lsy+iLVC9SokrMFS8+gVMXyWm8R6NIqo2XhG31vw1BEARBEARBdIwd/2Q8Pz/fJJy+973v4Te/+Q1uv/32Ds3q6HnXue/BYmYRfbE+V9RoLaM9iqBsemoaQRAEQRAEQRBrY8cLqn379uG8887DhRdeiFgsht/+9rf42te+hlQqhb/8y7/s9PQ2zKVDl2JZXUZPT8+2CHkSBEEQBEEQBNHMjhdUN998M/7v//2/+Ld/+zcUi0UMDw/jP//n/4wPf/jDGBwc7PT0CIIgCIIgCILoYna8oPr4xz+Oj3/8452eBkEQBEEQBEEQxyGUS0YQBEEQBEEQBLFBdnyEajOptuTK5XIdnonjw5/L5SCKItVQdQm0pt0JrWv3QWvandC6dh+0pt3HdlvTqiZYrW0vCSof1R/aSSfu7vBMCIIgCIIgCILYDuRyOcRisbbnGV9Nch1H2LaNqakpRCKRjluRZ7NZpFIpjI+Pr9iZmdg50Jp2J7Su3QetaXdC69p90Jp2H9ttTTnnyOVyGBkZWTFiRhEqH4IgIJlMdnoadUSj0W3xPxSxedCadie0rt0HrWl3QuvafdCadh/baU1XikxV6XxyIkEQBEEQBEEQxA6FBBVBEARBEARBEMQGIUG1TVFVFR/+8Iehqmqnp0JsErSm3Qmta/dBa9qd0Lp2H7Sm3cdOXVMypSAIgiAIgiAIgtggFKEiCIIgCIIgCILYICSoCIIgCIIgCIIgNggJKoIgCIIgCIIgiA1CgoogCIIgCIIgCGKDkKDaZkxPT+O//bf/hquuugqRSASMMTz88MNtxz/yyCO4/PLLEQwGMTQ0hNtvvx35fH7rJkysiq7r+MAHPoCRkREEAgFccskl+OEPf9jpaRFrJJ/P48Mf/jBe8pKXoLe3F4wx3HfffS3HPvXUU3jJS16CcDiM3t5evOENb8D8/PzWTphYlV/96ld45zvfiTPPPBOhUAhjY2O46aab8OyzzzaNpTXdGTzxxBN47WtfixNPPBHBYBCJRAL79+/Hv/zLvzSNpTXduXziE58AYwx79+5tOkfPQzuDhx9+GIyxltvPf/7zurE7aU2lTk+AqOeZZ57B3/zN3+Dkk0/GWWedhUcffbTt2N/97ne45pprcPrpp+Ozn/0sJiYmcNddd+G5557Dv/7rv27hrImVuOWWW/DAAw/g3e9+N04++WTcd999uOGGG/DQQw/h8ssv7/T0iFVYWFjAxz72MYyNjeGcc85p+wHHxMQE9u/fj1gshk9+8pPI5/O466678Pvf/x6//OUvoSjK1k6caMvf/M3f4Gc/+xle+9rX4uyzz8bMzAy++MUv4vzzz8fPf/5z72GN1nTncPjwYeRyObzpTW/CyMgIisUi/vEf/xGveMUr8JWvfAVvfetbAdCa7mQmJibwyU9+EqFQqOkcPQ/tPG6//XZcdNFFdcf27Nnj7e+4NeXEtiKbzfLFxUXOOeff+c53OAD+0EMPtRx7/fXX8+HhYZ7JZLxjX/3qVzkA/oMf/GArpkuswi9+8QsOgN95553esVKpxE866SR+2WWXdXBmxFopl8t8enqac875r371Kw6A33vvvU3j/st/+S88EAjww4cPe8d++MMfcgD8K1/5ylZNl1gDP/vZz7iu63XHnn32Wa6qKn/d617nHaM13dmYpsnPOeccfuqpp3rHaE13LjfffDO/+uqr+ZVXXsnPPPPMunP0PLRzeOihhzgA/p3vfGfFcTttTSnlb5sRiUTQ29u76rhsNosf/vCHeP3rX49oNOodf+Mb34hwOIx/+Id/OJbTJNbIAw88AFEUvU9HAUDTNNx666149NFHMT4+3sHZEWtBVVUMDQ2tOu4f//Ef8bKXvQxjY2PesWuvvRannHIK/T5uM/bt29cUiTj55JNx5pln4qmnnvKO0ZrubERRRCqVQjqd9o7Rmu5MfvzjH+OBBx7A5z73uaZz9Dy0c8nlcjBNs+n4TlxTElQ7lN///vcwTRMXXnhh3XFFUXDuuefiscce69DMCD+PPfYYTjnllLo/CABw8cUXA3BC2sTOZ3JyEnNzc02/j4Cz1vT7uP3hnGN2dhaJRAIArelOpVAoYGFhAc8//zz+9m//Fv/6r/+Ka665BgCt6U7Fsizcdttt+E//6T/hrLPOajpPz0M7kze/+c2IRqPQNA1XXXUVfv3rX3vnduKaUg3VDmV6ehoAMDw83HRueHgYP/nJT7Z6SkQLpqen264RAExNTW31lIhjwGq/j0tLS9B1HaqqbvXUiDXyzW9+E5OTk/jYxz4GgNZ0p/IXf/EX+MpXvgIAEAQBr371q/HFL34RAK3pTuXv/u7vcPjwYfzoRz9qeZ6eh3YWiqLgNa95DW644QYkEgk8+eSTuOuuu3DFFVfgkUcewXnnnbcj15QE1THEtm0YhrGmsaqqgjG25nuXSiXvukY0TfPOE52lVCq1XaPqeWLns9rvY3UMPahtT55++mn8+Z//OS677DK86U1vAkBrulN597vfjRtvvBFTU1P4h3/4B1iW5f07TGu681hcXMSHPvQhfPCDH0R/f3/LMfQ8tLPYt28f9u3b571/xStegRtvvBFnn3027rjjDnz/+9/fkWtKKX/HkB//+McIBAJr2p555pl13TsQCABwLLkbKZfL3nmiswQCgbZrVD1P7HxW+330jyG2FzMzM3jpS1+KWCzm1TwCtKY7ldNOOw3XXnst3vjGN+LBBx9EPp/Hy1/+cnDOaU13IH/1V3+F3t5e3HbbbW3H0PPQzmfPnj145StfiYceegiWZe3INaUI1THktNNOw7333rumsa3CmmsZXw2L+pmensbIyMi67kccG4aHhzE5Odl0vLputE7dwWq/j729vfSp9zYkk8ng+uuvRzqdxk9+8pO630da0+7gxhtvxNve9jY8++yztKY7jOeeew733HMPPve5z9Wlx5fLZVQqFRw6dAjRaJSeh7qEVCoFwzBQKBR25JqSoDqGDA0N4ZZbbjkm9967dy8kScKvf/1r3HTTTd5xwzDwu9/9ru4Y0TnOPfdcPPTQQ8hms3XGFL/4xS+888TOZ3R0FP39/XVFtVV++ctf0jpvQ8rlMl7+8pfj2WefxY9+9COcccYZdedpTbuDampQJpPBqaeeSmu6g5icnIRt27j99ttx++23N53fvXs33vWud+GjH/0oPQ91AQcPHoSmaQiHwzvyGZdS/nYosVgM1157Lb7xjW8gl8t5x++//37k83m89rWv7eDsiCo33ngjLMvCPffc4x3TdR333nsvLrnkEqRSqQ7OjthMXvOa1+DBBx+ss8L/93//dzz77LP0+7jNsCwLN998Mx599FF85zvfwWWXXdZyHK3pzmFubq7pWKVSwd///d8jEAh4gpnWdOewd+9efPe7323azjzzTIyNjeG73/0ubr31Vnoe2mHMz883HXv88cfxz//8z7juuusgCMKOXFPGOeedngRRz8c//nEAwBNPPIFvf/vbeMtb3oLdu3cDcPKJq/z2t7/Fvn37cMYZZ+Ctb30rJiYm8JnPfAb79+/HD37wg47MnWjmpptuwne/+1285z3vwZ49e/D1r38dv/zlL/Hv//7v2L9/f6enR6yBL37xi0in05iamsLdd9+NV7/61TjvvPMAALfddhtisRjGx8dx3nnnIR6P413vehfy+TzuvPNOJJNJ/OpXv6JUom3Eu9/9bnz+85/Hy1/+8pafdL7+9a8HAFrTHcSrXvUqZLNZ7N+/H6Ojo5iZmcE3v/lNPP300/jMZz6D9773vQBoTbuBF73oRVhYWMAf/vAH7xg9D+0crr76agQCAezbtw8DAwN48skncc8990CWZTz66KM4/fTTAezANe1sX2GiFQDabo385Cc/4fv27eOapvH+/n7+53/+5zybzXZg1kQ7SqUSf9/73seHhoa4qqr8oosu4t///vc7PS1iHezatavt7+QLL7zgjfvDH/7Ar7vuOh4MBnk8Hueve93r+MzMTOcmTrTkyiuvXPPfWVrTncG3vvUtfu211/LBwUEuSRLv6enh1157Lf+nf/qnprG0pjubK6+8kp955plNx+l5aGfw+c9/nl988cW8t7eXS5LEh4eH+etf/3r+3HPPNY3dSWtKESqCIAiCIAiCIIgNQjVUBEEQBEEQBEEQG4QEFUEQBEEQBEEQxAYhQUUQBEEQBEEQBLFBSFARBEEQBEEQBEFsEBJUBEEQBEEQBEEQG4QEFUEQBEEQBEEQxAYhQUUQBEEQBEEQBLFBSFARBEEQBEEQBEFsEBJUBEEQBEEQBEEQG4QEFUEQBNHVMMa87a677ur0dOo499xzvbm97GUv6/R0CIIgiA1AgoogCILYtvjFULvtIx/5yKr3edWrXoX7778fL33pS4/9pNfBJz/5Sdx///1IJBKdngpBEASxQaROT4AgCIIg2nH//fe3PfeRj3wEzz//PC655JJV73P22Wfj9a9//WZObVO44YYbAAB/9Vd/1eGZEARBEBuFBBVBEASxbWkngv7H//gfeP7553Hbbbfh+uuv3+JZEQRBEEQNSvkjCIIgdhRPPPEEbr/9dpx33nm48847N3yf++67D4wx/PSnP8Xtt9+O/v5+xONxvO1tb4NhGEin03jjG9+Inp4e9PT04P3vfz845971hw4d8uqyvvSlL+HEE09EMBjEddddh/HxcXDO8d//+39HMplEIBDAK1/5SiwtLW3Gj4AgCILYRlCEiiAIgtgxFItF3HTTTRBFEd/+9rehqupR3/O2227D0NAQPvrRj+LnP/857rnnHsTjcTzyyCMYGxvDJz/5SXzve9/DnXfeib179+KNb3xj3fXf/OY3YRgGbrvtNiwtLeHTn/40brrpJlx99dV4+OGH8YEPfAAHDhzAF77wBbzvfe/D1772taOeM0EQBLF9IEFFEARB7Bhuu+02PPnkk/j617+OU045ZVPuOTg4iO9973tgjOEd73gHDhw4gDvvvBNve9vbcPfddwMA3vrWt+KEE07A1772tSZBNTk5ieeeew6xWAwAYFkWPvWpT6FUKuHXv/41JMn5p3Z+fh7f/OY3cffdd2+KECQIgiC2B5TyRxAEQewI/tf/+l/42te+hje84Q1NouZouPXWW8EY895fcskl4Jzj1ltv9Y6JoogLL7wQBw8ebLr+ta99rSemqtcDTv1XVUxVjxuGgcnJyU2bO0EQBNF5SFARBEEQ257nnnsOb3/723HKKafgy1/+8qbee2xsrO59VRylUqmm48vLy0d1PYCW9yAIgiB2LiSoCIIgiG2Nruu4+eabYRgGvv3tbyMcDm/q/UVRXPNxvynFRq5vdw+CIAhi50I1VARBEMS25n3vex8ee+wxfP7zn8d5553X6ekQBEEQRB0UoSIIgiC2Ld/97nfxxS9+Ea94xStw++23d3o6BEEQBNEERagIgiCIbcn09DRuvfVWiKKIa665Bt/4xjdajjvppJNw2WWXbfHsCIIgCMKBBBVBEASxLXnmmWc8A4d3vetdbce96U1vIkFFEARBdAzGqTqWIAiC6GIYY/iv//W/4v3vfz9CoRACgUCnp+SRTqdhmibOP/98nH322XjwwQc7PSWCIAhinVANFUEQBNH13Hnnnejv78eXvvSlTk+ljhe96EXo7+/H+Ph4p6dCEARBbBBK+SMIgiC6mh/+8Ife/imnnNLBmTTzla98BblcDgDQ39/f4dkQBEEQG4FS/giCIAiCIAiCIDYIpfwRBEEQBEEQBEFsEBJUBEEQBEEQBEEQG4QEFUEQBEEQBEEQxAYhQUUQBEEQBEEQBLFBSFARBEEQBEEQBEFsEBJUBEEQBEEQBEEQG4QEFUEQBEEQBEEQxAYhQUUQBEEQBEEQBLFBSFARBEEQBEEQBEFskP8/afd2ISbNPugAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "problem.info()\n",
+    "lens.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16bb0170-76be-43e0-b52e-69366ae1f8f5",
+   "metadata": {},
+   "source": [
+    "## Conclusions\n",
+    "\n",
+    "- When using the \"radius\" variable directly, the optimizer often cannot find solutions that require changing from concave to convex or vice versa.\n",
+    "- The \"reciprocal_radius\" variable allows for smooth transitions between concave and convex surfaces, producing better optimization results in this specific example.\n",
+    "- Initial system conditions are still specified with \"radius\" in the lens definition, but the optimization works on \"reciprocal_radius\" internally.\n",
+    "- For fine tuning: after surfaces have reached the correct concavity/convexity, you can switch back to \"radius\" for final optimization if desired."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "imagepress",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/Example_Optimization_Using_Reciprocal_Radii.ipynb
+++ b/docs/examples/Example_Optimization_Using_Reciprocal_Radii.ipynb
@@ -13,12 +13,12 @@
     "\n",
     "The \"reciprocal_radius\" is defined as 1/radius (the inverse of the radius of curvature). You define initial conditions using the regular \"radius\" parameter, but the optimization operates on this proxy variable instead.\n",
     "\n",
-    "While the libary code attempts to handle edge cases, there are limitations. It's best to avoid setting the initial radius to exactly zero (which is physically meaningless) or infinity. Instead, use very large or very small values as starting points."
+    "While the libary code attempts to handle edge cases, there are limitations. It's best to avoid setting the initial radius to exactly zero (which is physically meaningless) or infinity. If you do create a system with a radius of ±infinity or if you manually set reciprocal_radius to zero, it is possible that the optimization stops prematurely. In this case, just re-run the optimization from where it stopped, using either the same algorithm or a different one."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "6403783e-b126-406d-8299-339780cfa1c6",
    "metadata": {},
    "outputs": [],
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "099b5744-2fa1-4a40-abf3-9d1220a7b897",
    "metadata": {},
    "outputs": [],
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "b9284227-b308-40b2-bcfc-2ed4d3449969",
    "metadata": {},
    "outputs": [
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "6714b791-563a-40ef-99b2-d404e315b219",
    "metadata": {},
    "outputs": [],
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "1ee03754-1b53-4cdd-9a20-c5794535d7f1",
    "metadata": {},
    "outputs": [],
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "12463866-f393-47b9-9148-08b5a8c563aa",
    "metadata": {},
    "outputs": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a27cb47b-dec8-4410-b205-39ace5477c01",
    "metadata": {},
    "outputs": [
@@ -255,7 +255,20 @@
       "At iterate    6    f=  4.76943D+01    |proj g|=  4.57275D-01\n",
       "\n",
       "At iterate    7    f=  4.69095D+01    |proj g|=  2.59918D-01\n",
-      "\n"
+      "\n",
+      "At iterate    8    f=  4.63210D+01    |proj g|=  1.48244D-01\n",
+      "\n",
+      "At iterate    9    f=  4.58757D+01    |proj g|=  8.44444D-02\n",
+      "\n",
+      "At iterate   10    f=  4.55399D+01    |proj g|=  4.81243D-02\n",
+      "\n",
+      "At iterate   11    f=  4.52863D+01    |proj g|=  2.74234D-02\n",
+      "\n",
+      "At iterate   12    f=  4.50949D+01    |proj g|=  1.56255D-02\n",
+      "\n",
+      "At iterate   13    f=  4.49504D+01    |proj g|=  8.90452D-03\n",
+      "\n",
+      "At iterate   14    f=  4.48414D+01    |proj g|=  5.07612D-03\n"
      ]
     },
     {
@@ -269,19 +282,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "At iterate    8    f=  4.63210D+01    |proj g|=  1.48244D-01\n",
-      "\n",
-      "At iterate    9    f=  4.58757D+01    |proj g|=  8.44444D-02\n",
-      "\n",
-      "At iterate   10    f=  4.55399D+01    |proj g|=  4.81243D-02\n",
-      "\n",
-      "At iterate   11    f=  4.52863D+01    |proj g|=  2.74234D-02\n",
-      "\n",
-      "At iterate   12    f=  4.50949D+01    |proj g|=  1.56255D-02\n",
-      "\n",
-      "At iterate   13    f=  4.49504D+01    |proj g|=  8.90452D-03\n",
-      "\n",
-      "At iterate   14    f=  4.48414D+01    |proj g|=  5.07612D-03\n",
       "\n",
       "At iterate   15    f=  4.47590D+01    |proj g|=  2.89049D-03\n",
       "\n",
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "36adbdf7-ec60-41c1-b930-d2239e221463",
    "metadata": {},
    "outputs": [
@@ -412,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "af939f57-77a8-4a33-8ed1-5ac068fc375d",
    "metadata": {},
    "outputs": [],
@@ -450,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "13912949-1a8d-44e8-bb07-0b61a31e4b9a",
    "metadata": {},
    "outputs": [
@@ -478,20 +478,7 @@
       "At iterate    4    f=  4.55029D-04    |proj g|=  1.49063D-05\n",
       "\n",
       "At iterate    5    f=  4.55027D-04    |proj g|=  3.39355D-09\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " This problem is unconstrained.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "At iterate    6    f=  4.55027D-04    |proj g|=  1.81604D-09\n",
       "\n",
       "           * * *\n",
@@ -512,6 +499,13 @@
       "\n",
       "CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH             \n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " This problem is unconstrained.\n"
+     ]
     }
    ],
    "source": [
@@ -529,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "d634712a-58f1-4ff0-aa73-3d8657326fec",
    "metadata": {},
    "outputs": [
@@ -579,10 +573,11 @@
    "source": [
     "## Conclusions\n",
     "\n",
-    "- When using the \"radius\" variable directly, the optimizer often cannot find solutions that require changing from concave to convex or vice versa.\n",
+    "- When using the \"radius\" variable directly, the optimizer often struggles find solutions that require changing from concave to convex or vice versa.\n",
     "- The \"reciprocal_radius\" variable allows for smooth transitions between concave and convex surfaces, producing better optimization results in this specific example.\n",
     "- Initial system conditions are still specified with \"radius\" in the lens definition, but the optimization works on \"reciprocal_radius\" internally.\n",
-    "- For fine tuning: after surfaces have reached the correct concavity/convexity, you can switch back to \"radius\" for final optimization if desired."
+    "- For fine tuning, after surfaces have reached the correct concavity/convexity, there is no problem in switching back to \"radius\" for the final optimization steps.\n",
+    "- If the optimization stops prematurely due to edge cases (e.g., initial radius equal to ±infinity), simply re-run the optimization from where it stopped, using either the same algorithm or a different one."
    ]
   }
  ],

--- a/optiland/optimization/variable/__init__.py
+++ b/optiland/optimization/variable/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import VariableBehavior
 from .radius import RadiusVariable
+from .reciprocal_radius import ReciprocalRadiusVariable
 from .conic import ConicVariable
 from .thickness import ThicknessVariable
 from .tilt import TiltVariable

--- a/optiland/optimization/variable/reciprocal_radius.py
+++ b/optiland/optimization/variable/reciprocal_radius.py
@@ -12,8 +12,9 @@ Daniel Miranda, 2025
 ALL rights ceded to Kramer Harrison
 """
 
-from optiland.optimization.variable.base import VariableBehavior
 import numpy as np
+
+from optiland.optimization.variable.base import VariableBehavior
 
 
 class ReciprocalRadiusVariable(VariableBehavior):
@@ -32,7 +33,8 @@ class ReciprocalRadiusVariable(VariableBehavior):
 
     Methods:
         get_value(): Returns the current value of the reciprocal radius.
-        update_value(new_value): Updates the value via the reciprocal, converting back to radius.
+        update_value(new_value): Updates the value via the reciprocal, converting back
+         to radius.
     """
 
     def __init__(self, optic, surface_number, apply_scaling=True, **kwargs):
@@ -75,7 +77,7 @@ class ReciprocalRadiusVariable(VariableBehavior):
         Returns:
             float: The scaled reciprocal value.
         """
-        return value * 1000
+        return value * 10.0
 
     def inverse_scale(self, scaled_value):
         """Inverse scale the reciprocal value.
@@ -86,7 +88,7 @@ class ReciprocalRadiusVariable(VariableBehavior):
         Returns:
             float: The original reciprocal value.
         """
-        return scaled_value / 1000
+        return scaled_value / 10.0
 
     def __str__(self):
         """Return a string representation of the variable.

--- a/optiland/optimization/variable/reciprocal_radius.py
+++ b/optiland/optimization/variable/reciprocal_radius.py
@@ -1,0 +1,97 @@
+"""Reciprocal Radius Variable Module
+
+This module contains the ReciprocalRadiusVariable class, which represents a variable for
+the reciprocal of the radius of a surface in an optic. The transformation is useful
+because a nearly flat surface (with a very large positive or negative radius) has a
+reciprocal near zero, which makes the optimization around a nearly flat surface
+continuous. The reciprocal radius provides a continuous transition when surface changes
+from convex to concave (when the radius changes sign).
+
+
+Daniel Miranda, 2025
+ALL rights ceded to Kramer Harrison
+"""
+
+from optiland.optimization.variable.base import VariableBehavior
+import numpy as np
+
+
+class ReciprocalRadiusVariable(VariableBehavior):
+    """Represents a variable for the reciprocal of the radius of a surface in an optic.
+
+    Args:
+        optic (Optic): The optic object that contains the surface.
+        surface_number (int): The index of the surface in the optic.
+        apply_scaling (bool): Whether to apply scaling to the variable.
+            Defaults to True.
+        **kwargs: Additional keyword arguments.
+
+    Attributes:
+        optic (Optic): The optic object that contains the surface.
+        surface_number (int): The index of the surface in the optic.
+
+    Methods:
+        get_value(): Returns the current value of the reciprocal radius.
+        update_value(new_value): Updates the value via the reciprocal, converting back to radius.
+    """
+
+    def __init__(self, optic, surface_number, apply_scaling=True, **kwargs):
+        super().__init__(optic, surface_number, apply_scaling, **kwargs)
+
+    def get_value(self):
+        """Returns the current value of the reciprocal of the radius.
+
+        Returns:
+            float: The current reciprocal radius.
+        """
+        radius = self._surfaces.radii[self.surface_number]
+        # Avoid division by zero
+        if radius != 0:
+            reciprocal = 1.0 / radius if np.isfinite(radius) else 0.0
+        else:
+            reciprocal = np.inf
+        if self.apply_scaling:
+            return self.scale(reciprocal)
+        return reciprocal
+
+    def update_value(self, new_value):
+        """Updates the surface radius based on the new reciprocal variable value.
+
+        Args:
+            new_value (float): The new reciprocal radius value.
+        """
+        if self.apply_scaling:
+            new_value = self.inverse_scale(new_value)
+        # Allow zero but handle appropriately
+        new_radius = np.inf if new_value == 0 else 1.0 / new_value
+        self.optic.set_radius(new_radius, self.surface_number)
+
+    def scale(self, value):
+        """Scale the reciprocal value for improved optimization performance.
+
+        Args:
+            value (float): The reciprocal value to scale.
+
+        Returns:
+            float: The scaled reciprocal value.
+        """
+        return value * 1000
+
+    def inverse_scale(self, scaled_value):
+        """Inverse scale the reciprocal value.
+
+        Args:
+            scaled_value (float): The scaled reciprocal value to inverse scale.
+
+        Returns:
+            float: The original reciprocal value.
+        """
+        return scaled_value / 1000
+
+    def __str__(self):
+        """Return a string representation of the variable.
+
+        Returns:
+            str: A string representation of the reciprocal radius variable.
+        """
+        return f"Reciprocal Radius of Curvature, Surface {self.surface_number}"

--- a/optiland/optimization/variable/reciprocal_radius.py
+++ b/optiland/optimization/variable/reciprocal_radius.py
@@ -96,4 +96,8 @@ class ReciprocalRadiusVariable(VariableBehavior):
         Returns:
             str: A string representation of the reciprocal radius variable.
         """
-        return f"Reciprocal Radius of Curvature, Surface {self.surface_number}"
+        s = "scaled" if self.apply_scaling else "unscaled"
+        n = self.surface_number
+        v = self.get_value()
+
+        return f"Reciprocal Radius of Curvature - Surface {n} - {s} value: {v}"

--- a/optiland/optimization/variable/variable.py
+++ b/optiland/optimization/variable/variable.py
@@ -18,6 +18,7 @@ from optiland.optimization.variable.decenter import DecenterVariable
 from optiland.optimization.variable.index import IndexVariable
 from optiland.optimization.variable.polynomial_coeff import PolynomialCoeffVariable
 from optiland.optimization.variable.radius import RadiusVariable
+from optiland.optimization.variable.reciprocal_radius import ReciprocalRadiusVariable
 from optiland.optimization.variable.thickness import ThicknessVariable
 from optiland.optimization.variable.tilt import TiltVariable
 from optiland.optimization.variable.zernike_coeff import ZernikeCoeffVariable
@@ -108,6 +109,7 @@ class Variable:
             "polynomial_coeff": PolynomialCoeffVariable,
             "chebyshev_coeff": ChebyshevCoeffVariable,
             "zernike_coeff": ZernikeCoeffVariable,
+            "reciprocal_radius": ReciprocalRadiusVariable,
         }
 
         variable_class = variable_types.get(self.type)

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -26,6 +26,34 @@ class TestRadiusVariable:
         assert np.isclose(self.radius_var.get_value(), 5.0)
 
 
+class TestReciprocalRadiusVariable:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.optic = Objective60x()
+        self.reciprocal_radius_var = variable.ReciprocalRadiusVariable(self.optic, 1)
+
+    def test_get_value(self):
+        # Expected reciprocal = 1 / radius; radius from TestRadiusVariable ≈ 4.5326
+        expected = 1.0 / 4.5326
+        assert np.isclose(self.reciprocal_radius_var.get_value(), expected, atol=1e-4)
+
+    def test_update_value(self):
+        # Update reciprocal value to 0.25, expect new radius = 1/0.25 = 4.0
+        self.reciprocal_radius_var.update_value(0.25)
+        assert np.isclose(self.reciprocal_radius_var.get_value(), 0.25, atol=1e-4)
+
+    def test_get_value_infinity(self):
+        # Set the surface radius to 0 so reciprocal becomes infinity (division by zero)
+        self.optic.set_radius(0, self.reciprocal_radius_var.surface_number)
+        val = self.reciprocal_radius_var.get_value()
+        assert val == float("inf")
+
+    def test_update_value_zero(self):
+        # Update reciprocal value to 0 -> new radius set to infinity, so reciprocal becomes 0
+        self.reciprocal_radius_var.update_value(0.0)
+        assert np.isclose(self.reciprocal_radius_var.get_value(), 0.0)
+
+
 class TestConicVariable:
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -51,6 +51,18 @@ class TestReciprocalRadiusVariable:
         # Expected reciprocal = 1 / radius; radius from TestRadiusVariable ≈ 553.260
         expected = self.scaling * (1.0 / self.radius_var.get_value())
         assert np.isclose(self.reciprocal_radius_var.get_value(), expected, atol=1e-4)
+        a=str(self.reciprocal_radius_var)
+        assert a.startswith('Reciprocal Radius of Curvature - Surface 1 - scaled value: 0.50')
+
+    def test_get_value_without_scaling(self):
+        self.reciprocal_radius_var = variable.ReciprocalRadiusVariable(
+            self.optic, 1, apply_scaling=False
+        )
+        expected = 1.0 / self.radius_var.get_value()
+        assert np.isclose(self.reciprocal_radius_var.get_value(), expected, atol=1e-4)
+        a=str(self.reciprocal_radius_var)
+        assert a.startswith('Reciprocal Radius of Curvature - Surface 1 - unscaled value: 0.050')
+
 
     def test_update_value(self):
         # Update reciprocal value to 0.25, expect new radius = 1/0.25 = 4.0

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -7,9 +7,9 @@ from optiland.geometries import (
     PolynomialGeometry,
     ZernikePolynomialGeometry,
 )
-from optiland.optimization import variable
+from optiland.optimization import variable, OptimizationProblem, OptimizerGeneric
 from optiland.samples.microscopes import Objective60x, UVReflectingMicroscope
-from optiland.samples.simple import AsphericSinglet
+from optiland.samples.simple import AsphericSinglet, Edmund_49_847
 
 
 class TestRadiusVariable:
@@ -29,29 +29,85 @@ class TestRadiusVariable:
 class TestReciprocalRadiusVariable:
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.optic = Objective60x()
+        self.optic = Edmund_49_847()
         self.reciprocal_radius_var = variable.ReciprocalRadiusVariable(self.optic, 1)
+        self.radius_var = variable.RadiusVariable(self.optic, 1, apply_scaling=False)
+        self.scaling = 10.0
+        self.problem = OptimizationProblem()
+        input_data = {
+            "optic": self.optic,
+            "Hx": 0.0,
+            "Hy": 0.0,
+            "num_rays": 5,
+            "wavelength": self.optic.wavelengths.primary_wavelength.value,
+            "distribution": "hexapolar",
+            "surface_number": 3,
+        }
+        self.problem.add_operand(
+            operand_type="rms_spot_size", target=0, weight=1, input_data=input_data
+        )
 
     def test_get_value(self):
-        # Expected reciprocal = 1 / radius; radius from TestRadiusVariable ≈ 4.5326
-        expected = 1.0 / 4.5326
+        # Expected reciprocal = 1 / radius; radius from TestRadiusVariable ≈ 553.260
+        expected = self.scaling * (1.0 / self.radius_var.get_value())
         assert np.isclose(self.reciprocal_radius_var.get_value(), expected, atol=1e-4)
 
     def test_update_value(self):
         # Update reciprocal value to 0.25, expect new radius = 1/0.25 = 4.0
         self.reciprocal_radius_var.update_value(0.25)
+        expected_radius = self.scaling * (1.0 / 0.25)
+        assert np.isclose(self.radius_var.get_value(), expected_radius, atol=1e-4)
         assert np.isclose(self.reciprocal_radius_var.get_value(), 0.25, atol=1e-4)
 
     def test_get_value_infinity(self):
         # Set the surface radius to 0 so reciprocal becomes infinity (division by zero)
-        self.optic.set_radius(0, self.reciprocal_radius_var.surface_number)
+        self.radius_var.update_value(0.0)
         val = self.reciprocal_radius_var.get_value()
-        assert val == float("inf")
+        assert val == np.inf
 
     def test_update_value_zero(self):
         # Update reciprocal value to 0 -> new radius set to infinity, so reciprocal becomes 0
         self.reciprocal_radius_var.update_value(0.0)
         assert np.isclose(self.reciprocal_radius_var.get_value(), 0.0)
+
+    def test_optimization(self):
+        # Add the reciprocal radius variable for the first surface
+        self.problem.add_variable(self.optic, "reciprocal_radius", surface_number=1)
+
+        # Run the optimization
+        optimizer = OptimizerGeneric(self.problem)
+
+        # this will set the radius of surface 1 to scale*(1/0.1) = 10*(10) = 100
+        self.reciprocal_radius_var.update_value(0.1)
+        optimizer.optimize(tol=1e-9)
+
+        # Check if the radius of the first surface is close to the expected value
+        expected_radius = 19.93  # Expected value from the initial definition
+        optimized_radius = self.radius_var.get_value()
+        # just make sure the final value is in the ballpark, and there were no exceptions thrown
+        assert np.isclose(optimized_radius, expected_radius, atol=5)
+
+    def test_optimization_with_flat_surface(self):
+        # Add the reciprocal radius variable for the first surface
+        self.problem.add_variable(self.optic, "reciprocal_radius", surface_number=1)
+
+        # Make the first surface mathematically flat
+        self.radius_var.update_value(-np.inf)
+
+        # Run the optimization
+        optimizer = OptimizerGeneric(self.problem)
+        optimizer.optimize(tol=1e-9)
+
+        # the optimization above stops prematurely, so we have to try again.
+        # TODO: understand the problem and fix it or at least properly document it.
+        # trying again:
+        optimizer.optimize(tol=1e-9)
+
+        # Check if the radius of the first surface is close to the expected value
+        expected_radius = 19.93  # Expected value from the initial definition
+        optimized_radius = self.radius_var.get_value()
+        # just make sure the final value is in the ballpark, and there were no exceptions thrown
+        assert np.isclose(optimized_radius, expected_radius, atol=5)
 
 
 class TestConicVariable:


### PR DESCRIPTION
This code adds the "reciprocal_radius" optimization variable so that the optimizers can use a continuous transition from a positive curvature surface to a negative curvature surface. No new attributes are created on the surfaces themselves.

A simple test case and an example are added.

This still does not work well on surfaces where the radius is set at exactly +infinity or -infinity, and I have no idea on proper "scaling values", so the code requires review. Also I do not have clarity whether this approach is the best one to make optimization continuous in near-flat surfaces - it works, but there may be a better way.

This pull request is proposed mostly as a suggestion, as this feature is useful to me.