### PR TITLE
Feature/remove distribution dx dy

### DIFF
--- a/docs/examples/Tutorial_2a_Tracing_&_Analyzing_Rays.ipynb
+++ b/docs/examples/Tutorial_2a_Tracing_&_Analyzing_Rays.ipynb
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we'll take a look at a few different pupil grids that we can trace through the system."
+    "First, we'll take a look at a few different pupil grids that we can trace through the system. Note that each distribution has `x` and `y` attributes, which are NumPy arrays containing the points of the distribution."
    ]
   },
   {

--- a/optiland/distribution.py
+++ b/optiland/distribution.py
@@ -18,10 +18,8 @@ class BaseDistribution(ABC):
         visualizing the distribution.
 
     Attributes:
-        dx (float): The step size in x calculated as the difference between
-            two adjacent x points.
-        dy (float): The step size in y calculated as the difference between
-            two adjacent y points.
+        x (ndarray): The x-coordinates of the generated points.
+        y (ndarray): The y-coordinates of the generated points.
 
     """
 
@@ -34,26 +32,6 @@ class BaseDistribution(ABC):
 
         """
         # pragma: no cover
-
-    @property
-    def dx(self):
-        """The difference between the x-coordinates of two adjacent points.
-
-        Returns:
-            float: The step size in x.
-
-        """
-        return self.x[1] - self.x[0]
-
-    @property
-    def dy(self):
-        """The difference between the y-coordinates of two adjacent points.
-
-        Returns:
-            float: The step size in y.
-
-        """
-        return self.y[1] - self.y[0]
 
     def view(self):
         """Visualize the distribution.

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -11,16 +11,12 @@ def test_line_x(num_points):
     d = distribution.create_distribution("line_x")
     d.generate_points(num_points=num_points)
 
-    assert np.allclose(d.dx, 2.0 / (num_points - 1))
-    assert np.allclose(d.dy, 0.0)
     assert np.allclose(d.x, np.linspace(-1, 1, num_points))
     assert np.allclose(d.y, np.zeros(num_points))
 
     d = distribution.create_distribution("positive_line_x")
     d.generate_points(num_points=num_points)
 
-    assert np.allclose(d.dx, 1.0 / (num_points - 1))
-    assert np.allclose(d.dy, 0.0)
     assert np.allclose(d.x, np.linspace(0, 1, num_points))
     assert np.allclose(d.y, np.zeros(num_points))
 
@@ -30,16 +26,12 @@ def test_line_y(num_points):
     d = distribution.create_distribution("line_y")
     d.generate_points(num_points=num_points)
 
-    assert np.allclose(d.dx, 0.0)
-    assert np.allclose(d.dy, 2.0 / (num_points - 1))
     assert np.allclose(d.x, np.zeros(num_points))
     assert np.allclose(d.y, np.linspace(-1, 1, num_points))
 
     d = distribution.create_distribution("positive_line_y")
     d.generate_points(num_points=num_points)
 
-    assert np.allclose(d.dx, 0.0)
-    assert np.allclose(d.dy, 1.0 / (num_points - 1))
     assert np.allclose(d.x, np.zeros(num_points))
     assert np.allclose(d.y, np.linspace(0, 1, num_points))
 


### PR DESCRIPTION
- Removes unused `dx` and `dy` attributes from distribution module. These attributes were never used and are also not logical for many of the distribution types. This keeps the distribution classes cleaner and lighter.