### PR TITLE
Feat/wavefront torch

### DIFF
--- a/optiland/backend/__init__.py
+++ b/optiland/backend/__init__.py
@@ -38,6 +38,27 @@ def array_equal(a, b):
         return _torch_equal(a, b)
     return _np_equal(a, b)
 
+# --- Add explicit type-dispatching functions ---
+# Add explicit implementations for functions that might receive
+# arrays/tensors created when a *different* backend was active
+
+def isinf(x):
+    """Checks if input is infinity (handles np.ndarray/scalars and torch.Tensor)."""
+    if _torch_available and isinstance(x, _torch.Tensor):
+        # Assumes torch_backend defines isinf (e.g., calling torch.isinf)
+        return torch_backend.isinf(x)
+    # Fallback to numpy for np.ndarray or Python scalars
+    # Assumes numpy_backend defines isinf (e.g., calling np.isinf)
+    return numpy_backend.isinf(x)
+
+def isnan(x):
+    """Checks if input is NaN (handles np.ndarray/scalars and torch.Tensor)."""
+    if _torch_available and isinstance(x, _torch.Tensor):
+        
+        return torch_backend.isnan(x)
+    
+    return numpy_backend.isnan(x)
+
 
 try:
     from optiland.backend import torch_backend
@@ -98,6 +119,9 @@ def __getattr__(name):
     Raises:
         AttributeError: If the attribute is not found in the current backend.
     """
+    if name in globals():
+        return globals()[name]
+    
     backend = _backends[_current_backend]
 
     # Direct attribute lookup in the backend module.

--- a/optiland/backend/__init__.py
+++ b/optiland/backend/__init__.py
@@ -46,18 +46,18 @@ def isinf(x):
     """Checks if input is infinity (handles np.ndarray/scalars and torch.Tensor)."""
     if _torch_available and isinstance(x, _torch.Tensor):
         # Assumes torch_backend defines isinf (e.g., calling torch.isinf)
-        return torch_backend.isinf(x)
+        return _torch.isinf(x)
     # Fallback to numpy for np.ndarray or Python scalars
     # Assumes numpy_backend defines isinf (e.g., calling np.isinf)
-    return numpy_backend.isinf(x)
+    return _np.isinf(x)
 
 def isnan(x):
     """Checks if input is NaN (handles np.ndarray/scalars and torch.Tensor)."""
     if _torch_available and isinstance(x, _torch.Tensor):
         
-        return torch_backend.isnan(x)
+        return _torch.isnan(x)
     
-    return numpy_backend.isnan(x)
+    return _np.isnan(x)
 
 
 try:

--- a/optiland/backend/__init__.py
+++ b/optiland/backend/__init__.py
@@ -38,9 +38,11 @@ def array_equal(a, b):
         return _torch_equal(a, b)
     return _np_equal(a, b)
 
+
 # --- Add explicit type-dispatching functions ---
 # Add explicit implementations for functions that might receive
 # arrays/tensors created when a *different* backend was active
+
 
 def isinf(x):
     """Checks if input is infinity (handles np.ndarray/scalars and torch.Tensor)."""
@@ -51,12 +53,12 @@ def isinf(x):
     # Assumes numpy_backend defines isinf (e.g., calling np.isinf)
     return _np.isinf(x)
 
+
 def isnan(x):
     """Checks if input is NaN (handles np.ndarray/scalars and torch.Tensor)."""
     if _torch_available and isinstance(x, _torch.Tensor):
-        
         return _torch.isnan(x)
-    
+
     return _np.isnan(x)
 
 
@@ -121,7 +123,7 @@ def __getattr__(name):
     """
     if name in globals():
         return globals()[name]
-    
+
     backend = _backends[_current_backend]
 
     # Direct attribute lookup in the backend module.

--- a/optiland/wavefront.py
+++ b/optiland/wavefront.py
@@ -12,8 +12,8 @@ Kramer Harrison, 2024
 """
 
 import matplotlib.pyplot as plt
-from scipy.interpolate import griddata
 import numpy as np
+from scipy.interpolate import griddata
 
 import optiland.backend as be
 from optiland.distribution import create_distribution

--- a/optiland/wavefront.py
+++ b/optiland/wavefront.py
@@ -13,6 +13,7 @@ Kramer Harrison, 2024
 
 import matplotlib.pyplot as plt
 from scipy.interpolate import griddata
+import numpy as np
 
 import optiland.backend as be
 from optiland.distribution import create_distribution
@@ -308,7 +309,7 @@ class OPDFan(Wavefront):
         )
 
         # assure axes is a 2D array
-        axs = be.atleast_2d(axs)
+        axs = np.atleast_2d(axs)
 
         for i, field in enumerate(self.fields):
             for j, wavelength in enumerate(self.wavelengths):
@@ -318,12 +319,12 @@ class OPDFan(Wavefront):
                 intensity_x = self.data[i][j][1][self.num_rays :]
                 intensity_y = self.data[i][j][1][: self.num_rays]
 
-                wx[intensity_x == 0] = be.nan
-                wy[intensity_y == 0] = be.nan
+                wx[intensity_x == 0] = np.nan
+                wy[intensity_y == 0] = np.nan
 
                 axs[i, 0].plot(
-                    self.pupil_coord,
-                    wy,
+                    be.to_numpy(self.pupil_coord),
+                    be.to_numpy(wy),
                     zorder=3,
                     label=f"{wavelength:.4f} µm",
                 )
@@ -336,8 +337,8 @@ class OPDFan(Wavefront):
                 axs[i, 0].set_title(f"Hx: {field[0]:.3f}, Hy: {field[1]:.3f}")
 
                 axs[i, 1].plot(
-                    self.pupil_coord,
-                    wx,
+                    be.to_numpy(self.pupil_coord),
+                    be.to_numpy(wy),
                     zorder=3,
                     label=f"{wavelength:.4f} µm",
                 )
@@ -428,7 +429,7 @@ class OPD(Wavefront):
 
         """
         _, ax = plt.subplots(figsize=figsize)
-        im = ax.imshow(be.flipud(data["z"]), extent=[-1, 1, -1, 1])
+        im = ax.imshow(np.flipud(data["z"]), extent=[-1, 1, -1, 1])
 
         ax.set_xlabel("Pupil X")
         ax.set_ylabel("Pupil Y")
@@ -480,17 +481,17 @@ class OPD(Wavefront):
             dict: The OPD map data.
 
         """
-        x = self.distribution.x
-        y = self.distribution.y
-        z = self.data[0][0][0]
-        intensity = self.data[0][0][1]
+        x = be.to_numpy(self.distribution.x)
+        y = be.to_numpy(self.distribution.y)
+        z = be.to_numpy(self.data[0][0][0])
+        intensity = be.to_numpy(self.data[0][0][1])
 
-        x_interp, y_interp = be.meshgrid(
-            be.linspace(-1, 1, num_points),
-            be.linspace(-1, 1, num_points),
+        x_interp, y_interp = np.meshgrid(
+            np.linspace(-1, 1, num_points),
+            np.linspace(-1, 1, num_points),
         )
 
-        points = be.column_stack((x.flatten(), y.flatten()))
+        points = np.column_stack((x.flatten(), y.flatten()))
         values = z.flatten() * intensity.flatten()
 
         z_interp = griddata(points, values, (x_interp, y_interp), method="cubic")

--- a/tests/test_wavefront.py
+++ b/tests/test_wavefront.py
@@ -8,7 +8,7 @@ import pytest
 from optiland import distribution, wavefront
 from optiland.samples.eyepieces import EyepieceErfle
 from optiland.samples.objectives import CookeTriplet, DoubleGauss
-from .utils import assert_allclose
+from tests.utils import assert_allclose
 
 matplotlib.use("Agg")  # use non-interactive backend for testing
 

--- a/tests/test_wavefront.py
+++ b/tests/test_wavefront.py
@@ -14,8 +14,9 @@ matplotlib.use("Agg")  # use non-interactive backend for testing
 
 
 class TestWavefront:
-    @pytest.mark.parametrize("optic", [CookeTriplet(), DoubleGauss(), EyepieceErfle()])
-    def test_wavefront_initialization(self, optic, set_test_backend):
+    @pytest.mark.parametrize("OpticClass", [CookeTriplet, DoubleGauss, EyepieceErfle])
+    def test_wavefront_initialization(self, OpticClass, set_test_backend):
+        optic = OpticClass()
         w = wavefront.Wavefront(optic)
         assert w.num_rays == 12
         assert w.fields == optic.fields.get_field_coords()
@@ -43,7 +44,7 @@ class TestWavefront:
         assert isinstance(data[0], list)
         assert isinstance(data[0][0], tuple)
         assert isinstance(data[0][0][0], be.ndarray)
-        assert w.data[0][0][0].size == 469  # num points in the pupil
+        assert be.size(w.data[0][0][0]) == 469  # num points in the pupil
 
     def test_trace_chief_ray(self, set_test_backend):
         optic = DoubleGauss()
@@ -80,13 +81,13 @@ class TestWavefront:
     def test_correct_tilt(self, set_test_backend):
         optic = DoubleGauss()
         w = wavefront.Wavefront(optic)
-        opd = be.linspace(5, 100, w.distribution.x.size)
+        opd = be.linspace(5, 100, be.size(w.distribution.x))
         corrected_opd = w._correct_tilt((0, 1), opd, x=None, y=None)
-        assert be.isclose(corrected_opd[0], 2.5806903748015824)
-        assert be.isclose(corrected_opd[10], 5.013823175582515)
-        assert be.isclose(corrected_opd[100], 24.08949048654609)
-        assert be.isclose(corrected_opd[111], 24.699015344473096)
-        assert be.isclose(corrected_opd[242], 52.123070395591235)
+        assert_allclose(corrected_opd[0], 2.5806903748015824)
+        assert_allclose(corrected_opd[10], 5.013823175582515)
+        assert_allclose(corrected_opd[100], 24.08949048654609)
+        assert_allclose(corrected_opd[111], 24.699015344473096)
+        assert_allclose(corrected_opd[242], 52.123070395591235)
 
     def test_opd_image_to_xp(self, set_test_backend):
         optic = DoubleGauss()
@@ -98,7 +99,7 @@ class TestWavefront:
 
 
 class TestOPDFan:
-    def test_opd_fan_initialization(self):
+    def test_opd_fan_initialization(self, set_test_backend):
         optic = DoubleGauss()
         opd_fan = wavefront.OPDFan(optic)
         assert opd_fan.num_rays == 100
@@ -109,7 +110,7 @@ class TestOPDFan:
         assert be.all(opd_fan.pupil_coord == arr)
 
     @patch("matplotlib.pyplot.show")
-    def test_opd_fan_view(self, moch_show):
+    def test_opd_fan_view(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         opd_fan = wavefront.OPDFan(optic)
         opd_fan.view()
@@ -117,7 +118,7 @@ class TestOPDFan:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_opd_fan_view_large(self, moch_show):
+    def test_opd_fan_view_large(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         opd_fan = wavefront.OPDFan(optic)
         opd_fan.view(figsize=(20, 20))
@@ -126,7 +127,7 @@ class TestOPDFan:
 
 
 class TestOPD:
-    def test_opd_initialization(self):
+    def test_opd_initialization(self, set_test_backend):
         optic = EyepieceErfle()
         opd = wavefront.OPD(optic, (0, 1), 0.55)
         assert opd.num_rays == 15
@@ -135,7 +136,7 @@ class TestOPD:
         assert isinstance(opd.distribution, distribution.HexagonalDistribution)
 
     @patch("matplotlib.pyplot.show")
-    def test_opd_view(self, moch_show):
+    def test_opd_view(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         opd = wavefront.OPD(optic, (0, 1), 0.55)
         opd.view()
@@ -143,7 +144,7 @@ class TestOPD:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_opd_view_large(self, moch_show):
+    def test_opd_view_large(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         opd = wavefront.OPD(optic, (0, 1), 0.55)
         opd.view(figsize=(20, 20))
@@ -151,28 +152,27 @@ class TestOPD:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_opd_view_3d(self, moch_show):
+    def test_opd_view_3d(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         opd = wavefront.OPD(optic, (0, 1), 0.55)
         opd.view(projection="3d")
         moch_show.assert_called_once()
         plt.close()
 
-    def test_old_invalid_projection(self):
+    def test_old_invalid_projection(self, set_test_backend):
         optic = EyepieceErfle()
         opd = wavefront.OPD(optic, (0, 1), 0.55)
         with pytest.raises(ValueError):
             opd.view(projection="invalid")
 
-    def test_opd_rms(self):
+    def test_opd_rms(self, set_test_backend):
         optic = CookeTriplet()
         opd = wavefront.OPD(optic, (0, 1), 0.55)
         rms = opd.rms()
-        assert be.isclose(rms, 0.9709788038168692)
-
+        assert_allclose(rms, 0.9709788038168692)
 
 class TestZernikeOPD:
-    def test_zernike_opd_initialization(self):
+    def test_zernike_opd_initialization(self, set_test_backend):
         optic = DoubleGauss()
         zernike_opd = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         assert zernike_opd.num_rays == 15
@@ -182,11 +182,12 @@ class TestZernikeOPD:
         assert be.allclose(zernike_opd.x, zernike_opd.distribution.x)
         assert be.allclose(zernike_opd.y, zernike_opd.distribution.y)
         assert be.allclose(zernike_opd.z, zernike_opd.data[0][0][0])
-        assert zernike_opd.type == "fringe"
+        assert zernike_opd.zernike_type == "fringe"
+        
         assert zernike_opd.num_terms == 37
 
     @patch("matplotlib.pyplot.show")
-    def test_zernike_opd_view(self, moch_show):
+    def test_zernike_opd_view(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         zernike_opd = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         zernike_opd.view()
@@ -194,7 +195,7 @@ class TestZernikeOPD:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_zernike_opd_view_large(self, moch_show):
+    def test_zernike_opd_view_large(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         zernike_opd = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         zernike_opd.view(figsize=(20, 20))
@@ -202,30 +203,30 @@ class TestZernikeOPD:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_zernike_opd_view_3d(self, moch_show):
+    def test_zernike_opd_view_3d(self, moch_show, set_test_backend):
         optic = DoubleGauss()
         zernike_opd = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         zernike_opd.view(projection="3d")
         moch_show.assert_called_once()
         plt.close()
 
-    def test_zernike_opd_rms(self):
+    def test_zernike_opd_rms(self, set_test_backend):
         optic = CookeTriplet()
         zernike_opd = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         rms = zernike_opd.rms()
-        assert be.isclose(rms, 0.9709788038168692)
+        assert_allclose(rms, 0.9709788038168692)
 
-    def test_zernike_opd_fit(self):
+    def test_zernike_opd_fit(self, set_test_backend):
         optic = CookeTriplet()
         zernike_opd = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         c = zernike_opd.zernike.coeffs
-        assert be.isclose(c[0], 0.8430890395012354)
-        assert be.isclose(c[1], 6.863699034904449e-13)
-        assert be.isclose(c[2], 0.14504379704525455)
-        assert be.isclose(c[6], -1.160298338689596e-13)
-        assert be.isclose(c[24], -0.0007283668376039182)
+        assert_allclose(c[0], 0.8430890395012354)
+        assert_allclose(c[1], 6.863699034904449e-13)
+        assert_allclose(c[2], 0.14504379704525455)
+        assert_allclose(c[6], -1.160298338689596e-13)
+        assert_allclose(c[24], -0.0007283668376039182)
 
-    def test_zernike_xy_symmetry(self):
+    def test_zernike_xy_symmetry(self, set_test_backend):
         optic = CookeTriplet()
         zernike_opd0 = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         c0 = zernike_opd0.zernike.coeffs
@@ -243,7 +244,7 @@ class TestZernikeOPD:
         c1 = zernike_opd1.zernike.coeffs
         assert be.allclose(c0, c1)
 
-    def test_zernike_xy_axis_swap(self):
+    def test_zernike_xy_axis_swap(self, set_test_backend):
         optic = CookeTriplet()
         zernike_opd0 = wavefront.ZernikeOPD(optic, (0, 1), 0.55)
         c0 = zernike_opd0.zernike.coeffs


### PR DESCRIPTION
## Fix: Resolve backend compatibility issues in wavefront tests for PyTorch

This PR resolves several issues that caused `test_wavefront.py` tests to fail when run with the PyTorch backend enabled via the `set_test_backend` fixture.

### Problem

- Tests instantiated optical systems before the PyTorch backend was fully configured, leading to type mismatches (NumPy vs. Tensor) in subsequent calculations.
- Assertions and utility function calls (`be.isclose`, `.size`, `be.linspace`) failed due to API differences between NumPy arrays and PyTorch Tensors.
- Plotting functions (`OPDFan.view` in `wavefront.py`) failed when attempting to plot PyTorch Tensors requiring gradients or when using backend functions (`be.atleast_2d`) on non-numerical Matplotlib object arrays.

### Solution

- Refactored tests in `test_wavefront.py` to instantiate optical system objects (e.g., `CookeTriplet`, `DoubleGauss`) *after* the backend is configured, ensuring correct type initialization (Tensor vs NumPy). Parameterization now passes the class type instead of pre-built instances.
- Updated assertions in `test_wavefront.py` to use backend-agnostic helpers (`assert_allclose`, `be.size`) for comparisons and size checks.
- Modified `wavefront.OPDFan.view` to:
    - Convert PyTorch Tensor data to NumPy arrays using `be.to_numpy()` before passing to Matplotlib plotting functions.
    - Use `np.atleast_2d` instead of `be.atleast_2d` for handling Matplotlib `Axes` object arrays.

These changes ensure the wavefront tests pass consistently across both NumPy and PyTorch backends without requiring modifications to the core ray tracing logic solely for testing purposes.

