### PR TITLE
Add biconic geometry

### DIFF
--- a/optiland/geometries/__init__.py
+++ b/optiland/geometries/__init__.py
@@ -1,12 +1,27 @@
 # flake8: noqa
 
 from .base import BaseGeometry
-from .plane import Plane
-from .standard import StandardGeometry
-from .newton_raphson import NewtonRaphsonGeometry
-from .even_asphere import EvenAsphere
-from .odd_asphere import OddAsphere
-from .polynomial import PolynomialGeometry
+from .biconic import BiconicGeometry
 from .chebyshev import ChebyshevPolynomialGeometry
-from .zernike import ZernikePolynomialGeometry
+from .even_asphere import EvenAsphere
+from .newton_raphson import NewtonRaphsonGeometry
+from .odd_asphere import OddAsphere
+from .plane import Plane
+from .polynomial import PolynomialGeometry
+from .standard import StandardGeometry
 from .toroidal import ToroidalGeometry
+from .zernike import ZernikePolynomialGeometry
+
+__all__ = [
+    "BaseGeometry",
+    "BiconicGeometry",
+    "ChebyshevPolynomialGeometry",
+    "EvenAsphere",
+    "NewtonRaphsonGeometry",
+    "OddAsphere",
+    "Plane",
+    "PolynomialGeometry",
+    "StandardGeometry",
+    "ToroidalGeometry",
+    "ZernikePolynomialGeometry",
+]

--- a/optiland/geometries/__init__.py
+++ b/optiland/geometries/__init__.py
@@ -11,17 +11,3 @@ from .polynomial import PolynomialGeometry
 from .standard import StandardGeometry
 from .toroidal import ToroidalGeometry
 from .zernike import ZernikePolynomialGeometry
-
-__all__ = [
-    "BaseGeometry",
-    "BiconicGeometry",
-    "ChebyshevPolynomialGeometry",
-    "EvenAsphere",
-    "NewtonRaphsonGeometry",
-    "OddAsphere",
-    "Plane",
-    "PolynomialGeometry",
-    "StandardGeometry",
-    "ToroidalGeometry",
-    "ZernikePolynomialGeometry",
-]

--- a/optiland/geometries/biconic.py
+++ b/optiland/geometries/biconic.py
@@ -1,0 +1,159 @@
+import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.geometries.newton_raphson import NewtonRaphsonGeometry
+
+
+class BiconicGeometry(NewtonRaphsonGeometry):
+    """
+    Represents a biconic geometry.
+
+    The sag is defined by the standard sag equation applied independently
+    to the x and y axes.
+    zx = (cx * x^2) / (1 + sqrt(1 - (1 + kx) * cx^2 * x^2))
+    zy = (cy * y^2) / (1 + sqrt(1 - (1 + ky) * cy^2 * y^2))
+    z = zx + zy
+
+    where:
+    - cx = 1 / Rx (curvature in x)
+    - cy = 1 / Ry (curvature in y)
+    - kx is the conic constant for the x-profile
+    - ky is the conic constant for the y-profile
+    """
+
+    def __init__(
+        self,
+        coordinate_system: CoordinateSystem,
+        radius_x: float,
+        radius_y: float,
+        conic_x: float = 0.0,
+        conic_y: float = 0.0,
+        tol: float = 1e-10,
+        max_iter: int = 100,
+    ):
+        # The parent NewtonRaphsonGeometry expects a single radius and conic.
+        # We can pass the x-axis parameters as the "primary" ones,
+        # or handle this differently if Newton-Raphson's _intersection
+        # method needs to be overridden or adapted for biconic.
+        # For now, let's pass radius_x and conic_x.
+        # The sag and normal calculations will use both x and y parameters.
+        super().__init__(coordinate_system, radius_x, conic_x, tol, max_iter)
+
+        self.Rx = be.array(radius_x)
+        self.Ry = be.array(radius_y)
+        self.kx = be.array(conic_x)
+        self.ky = be.array(conic_y)
+
+        self.cx = be.where(be.isinf(self.Rx) | (self.Rx == 0), 0.0, 1.0 / self.Rx)
+        self.cy = be.where(be.isinf(self.Ry) | (self.Ry == 0), 0.0, 1.0 / self.Ry)
+        
+        self.is_symmetric = False # Generally not symmetric
+
+    def sag(self, x=0, y=0):
+        """Calculate the surface sag of the geometry."""
+        x = be.asarray(x)
+        y = be.asarray(y)
+        
+        zx = be.zeros_like(x)
+        zy = be.zeros_like(y)
+
+        # Calculate sag contribution from x-profile
+        if not be.all(self.cx == 0):
+            sqrt_term_x_val = 1.0 - (1.0 + self.kx) * self.cx**2 * x**2
+            # Ensure root term is non-negative, avoid issues at exact boundary
+            sqrt_term_x = be.where(sqrt_term_x_val < 1e-14, 0.0, sqrt_term_x_val) 
+            denom_x = 1.0 + be.sqrt(sqrt_term_x)
+            # Avoid division by zero if denom_x is zero (e.g. x is too large)
+            safe_denom_x = be.where(be.abs(denom_x) < 1e-14, 1e-14, denom_x)
+            zx = (self.cx * x**2) / safe_denom_x
+
+        # Calculate sag contribution from y-profile
+        if not be.all(self.cy == 0):
+            sqrt_term_y_val = 1.0 - (1.0 + self.ky) * self.cy**2 * y**2
+            sqrt_term_y = be.where(sqrt_term_y_val < 1e-14, 0.0, sqrt_term_y_val)
+            denom_y = 1.0 + be.sqrt(sqrt_term_y)
+            safe_denom_y = be.where(be.abs(denom_y) < 1e-14, 1e-14, denom_y)
+            zy = (self.cy * y**2) / safe_denom_y
+            
+        return zx + zy
+
+    def _surface_normal(self, x, y):
+        """Calculate the surface normal of the geometry at the given x and y position."""
+        x = be.asarray(x)
+        y = be.asarray(y)
+
+        # Partial derivative dz/dx
+        if be.all(self.cx == 0):
+            dfdx = be.zeros_like(x)
+        else:
+            sqrt_term_x_val = 1.0 - (1.0 + self.kx) * self.cx**2 * x**2
+            # Clamp to small positive to avoid nan/inf for derivative at boundary
+            sqrt_term_x = be.where(sqrt_term_x_val < 1e-14, 1e-14, sqrt_term_x_val)
+            denom_sqrt_x = be.sqrt(sqrt_term_x)
+            # Avoid division by zero if denom_sqrt_x is zero
+            safe_denom_sqrt_x = be.where(be.abs(denom_sqrt_x) < 1e-14, 1e-14, denom_sqrt_x)
+            dfdx = (self.cx * x) / safe_denom_sqrt_x
+        
+        # Partial derivative dz/dy
+        if be.all(self.cy == 0):
+            dfdy = be.zeros_like(y)
+        else:
+            sqrt_term_y_val = 1.0 - (1.0 + self.ky) * self.cy**2 * y**2
+            sqrt_term_y = be.where(sqrt_term_y_val < 1e-14, 1e-14, sqrt_term_y_val)
+            denom_sqrt_y = be.sqrt(sqrt_term_y)
+            safe_denom_sqrt_y = be.where(be.abs(denom_sqrt_y) < 1e-14, 1e-14, denom_sqrt_y)
+            dfdy = (self.cy * y) / safe_denom_sqrt_y
+
+        # Normal vector components (Optiland convention: (fx, fy, -1) / mag)
+        mag_sq = dfdx**2 + dfdy**2 + 1.0
+        mag = be.sqrt(mag_sq)
+        # Avoid division by zero if mag is zero
+        safe_mag = be.where(mag < 1e-14, 1.0, mag) # if mag is ~0, normal is (0,0,-1) approx
+
+        nx = dfdx / safe_mag
+        ny = dfdy / safe_mag
+        nz = -1.0 / safe_mag
+        
+        return nx, ny, nz
+
+    def __str__(self) -> str:
+        return "Biconic"
+
+    def to_dict(self) -> dict:
+        """Converts the geometry to a dictionary."""
+        geometry_dict = super().to_dict() 
+        # Remove base class radius and conic as they are ambiguous for biconic
+        if "radius" in geometry_dict:
+            del geometry_dict["radius"]
+        if "conic" in geometry_dict:
+            del geometry_dict["conic"]
+            
+        geometry_dict.update(
+            {
+                "type": self.__class__.__name__, # Ensure correct type
+                "radius_x": float(self.Rx) if hasattr(self.Rx, 'item') else self.Rx,
+                "radius_y": float(self.Ry) if hasattr(self.Ry, 'item') else self.Ry,
+                "conic_x": float(self.kx) if hasattr(self.kx, 'item') else self.kx,
+                "conic_y": float(self.ky) if hasattr(self.ky, 'item') else self.ky,
+            }
+        )
+        return geometry_dict
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BiconicGeometry":
+        """Creates a BiconicGeometry from a dictionary representation."""
+        required_keys = {"cs", "radius_x", "radius_y"}
+        if not required_keys.issubset(data):
+            missing = required_keys - set(data.keys())
+            raise ValueError(f"Missing required BiconicGeometry keys: {missing}")
+
+        cs = CoordinateSystem.from_dict(data["cs"])
+
+        return cls(
+            coordinate_system=cs,
+            radius_x=data["radius_x"],
+            radius_y=data["radius_y"],
+            conic_x=data.get("conic_x", 0.0),
+            conic_y=data.get("conic_y", 0.0),
+            tol=data.get("tol", 1e-10),
+            max_iter=data.get("max_iter", 100),
+        )

--- a/optiland/surfaces/factories/geometry_factory.py
+++ b/optiland/surfaces/factories/geometry_factory.py
@@ -14,6 +14,7 @@ from typing import Any
 import optiland.backend as be
 from optiland.coordinate_system import CoordinateSystem
 from optiland.geometries import (
+    BiconicGeometry,
     ChebyshevPolynomialGeometry,
     EvenAsphere,
     OddAsphere,
@@ -39,8 +40,11 @@ class GeometryConfig:
         norm_x (float): normalization factor in x. Defaults to 1.0.
         norm_y (float): normalization factor in y. Defaults to 1.0.
         norm_radius (float): normalization radius. Defaults to 1.0.
-        radius_y (float): toroidal YZ radius. Defaults to be.inf.
-        coefficients_poly_y (list): toroidal YZ polynomial coefficients.
+        radius_x (float): radius of curvature in x for biconic. Defaults to be.inf.
+        radius_y (float): radius of curvature in y for biconic or YZ radius for toroidal. Defaults to be.inf.
+        conic_x (float): conic constant in x for biconic. Defaults to 0.0.
+        conic_y (float): conic constant in y for biconic. Defaults to 0.0.
+        toroidal_coeffs_poly_y (list): toroidal YZ polynomial coefficients.
                                     Defaults to empty list.
     """
 
@@ -52,7 +56,11 @@ class GeometryConfig:
     norm_x: float = 1.0
     norm_y: float = 1.0
     norm_radius: float = 1.0
-    radius_y: float = be.inf
+    # Biconic and Toroidal parameters
+    radius_x: float = be.inf  # Used by Biconic
+    radius_y: float = be.inf  # Used by Biconic and Toroidal (as radius_yz)
+    conic_x: float = 0.0    # Used by Biconic
+    conic_y: float = 0.0    # Used by Biconic
     toroidal_coeffs_poly_y: list[float] = field(default_factory=list)
 
 
@@ -195,6 +203,31 @@ def _create_zernike(cs: CoordinateSystem, config: GeometryConfig):
     )
 
 
+def _create_biconic(cs: CoordinateSystem, config: GeometryConfig):
+    """
+    Create a biconic geometry
+
+    Args:
+        cs (CoordinateSystem): coordinate system of the geometry.
+        config (GeometryConfig): configuration of the geometry.
+
+    Returns:
+        BiconicGeometry
+    """
+    if be.isinf(config.radius_x) and be.isinf(config.radius_y) and config.conic_x == 0.0 and config.conic_y == 0.0:
+         # If all radii are infinite and conics are zero, it's a plane
+         return Plane(cs)
+    return BiconicGeometry(
+        coordinate_system=cs,
+        radius_x=config.radius_x,
+        radius_y=config.radius_y,
+        conic_x=config.conic_x,
+        conic_y=config.conic_y,
+        tol=config.tol,
+        max_iter=config.max_iter,
+    )
+
+
 def _create_toroidal(cs: CoordinateSystem, config: GeometryConfig):
     """
     Create a Toroidal geometry
@@ -209,8 +242,8 @@ def _create_toroidal(cs: CoordinateSystem, config: GeometryConfig):
 
     return ToroidalGeometry(
         coordinate_system=cs,
-        radius_rotation=config.radius,
-        radius_yz=config.radius_y,
+        radius_rotation=config.radius, # Toroidal uses the main 'radius' for rotation
+        radius_yz=config.radius_y,     # Toroidal uses 'radius_y' for its YZ radius
         conic=config.conic,
         coeffs_poly_y=config.toroidal_coeffs_poly_y,
         tol=config.tol,
@@ -233,14 +266,15 @@ def _create_paraxial(cs: CoordinateSystem, config: GeometryConfig):
 
 
 geometry_mapper = {
-    "standard": _create_standard,
+    "biconic": _create_biconic,
+    "chebyshev": _create_chebyshev,
     "even_asphere": _create_even_asphere,
     "odd_asphere": _create_odd_asphere,
-    "polynomial": _create_polynomial,
-    "chebyshev": _create_chebyshev,
-    "zernike": _create_zernike,
-    "toroidal": _create_toroidal,
     "paraxial": _create_paraxial,
+    "polynomial": _create_polynomial,
+    "standard": _create_standard,
+    "toroidal": _create_toroidal,
+    "zernike": _create_zernike,
 }
 
 

--- a/optiland/surfaces/factories/geometry_factory.py
+++ b/optiland/surfaces/factories/geometry_factory.py
@@ -41,7 +41,8 @@ class GeometryConfig:
         norm_y (float): normalization factor in y. Defaults to 1.0.
         norm_radius (float): normalization radius. Defaults to 1.0.
         radius_x (float): radius of curvature in x for biconic. Defaults to be.inf.
-        radius_y (float): radius of curvature in y for biconic or YZ radius for toroidal. Defaults to be.inf.
+        radius_y (float): radius of curvature in y for biconic or YZ radius for
+            toroidal. Defaults to be.inf.
         conic_x (float): conic constant in x for biconic. Defaults to 0.0.
         conic_y (float): conic constant in y for biconic. Defaults to 0.0.
         toroidal_coeffs_poly_y (list): toroidal YZ polynomial coefficients.
@@ -59,8 +60,8 @@ class GeometryConfig:
     # Biconic and Toroidal parameters
     radius_x: float = be.inf  # Used by Biconic
     radius_y: float = be.inf  # Used by Biconic and Toroidal (as radius_yz)
-    conic_x: float = 0.0    # Used by Biconic
-    conic_y: float = 0.0    # Used by Biconic
+    conic_x: float = 0.0  # Used by Biconic
+    conic_y: float = 0.0  # Used by Biconic
     toroidal_coeffs_poly_y: list[float] = field(default_factory=list)
 
 
@@ -214,9 +215,14 @@ def _create_biconic(cs: CoordinateSystem, config: GeometryConfig):
     Returns:
         BiconicGeometry
     """
-    if be.isinf(config.radius_x) and be.isinf(config.radius_y) and config.conic_x == 0.0 and config.conic_y == 0.0:
-         # If all radii are infinite and conics are zero, it's a plane
-         return Plane(cs)
+    if (
+        be.isinf(config.radius_x)
+        and be.isinf(config.radius_y)
+        and config.conic_x == 0.0
+        and config.conic_y == 0.0
+    ):
+        # If all radii are infinite and conics are zero, it's a plane
+        return Plane(cs)
     return BiconicGeometry(
         coordinate_system=cs,
         radius_x=config.radius_x,
@@ -242,8 +248,8 @@ def _create_toroidal(cs: CoordinateSystem, config: GeometryConfig):
 
     return ToroidalGeometry(
         coordinate_system=cs,
-        radius_rotation=config.radius, # Toroidal uses the main 'radius' for rotation
-        radius_yz=config.radius_y,     # Toroidal uses 'radius_y' for its YZ radius
+        radius_rotation=config.radius,  # Toroidal uses the main 'radius' for rotation
+        radius_yz=config.radius_y,  # Toroidal uses 'radius_y' for its YZ radius
         conic=config.conic,
         coeffs_poly_y=config.toroidal_coeffs_poly_y,
         tol=config.tol,

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -4,6 +4,7 @@ import numpy as np
 from optiland.optic import Optic
 from optiland.materials import Material, IdealMaterial
 from optiland import geometries
+from optiland.geometries import BiconicGeometry
 from optiland.coordinate_system import CoordinateSystem
 from optiland.rays import RealRays
 from .utils import assert_allclose
@@ -1122,3 +1123,231 @@ class TestToroidalGeometry:
             be.allclose(ix, be.array(0.0), rtol=1e-5, atol=1e-6)
             be.allclose(iy, be.array(0.0), rtol=1e-5, atol=1e-6)
             be.allclose(iz, be.array(0.0), rtol=1e-5, atol=1e-6) # Intersection coordinates should be (0, 0, 0)
+
+
+class TestBiconicGeometry:
+    def test_str(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0)
+        assert str(geom) == "Biconic"
+
+    def test_sag_vertex(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0, conic_x=0.5, conic_y=-0.5)
+        assert_allclose(geom.sag(0, 0), 0.0)
+
+    def test_sag_finite_radii(self, set_test_backend):
+        cs = CoordinateSystem()
+        # Rx=10, Ry=20, kx=0, ky=0
+        # zx(1) = (0.1 * 1) / (1 + sqrt(1 - 0.01 * 1)) = 0.1 / (1 + sqrt(0.99)) = 0.05012562854249503
+        # zy(1) = (0.05 * 1) / (1 + sqrt(1 - 0.0025 * 1)) = 0.05 / (1 + sqrt(0.9975)) = 0.02501563183003138
+        # expected_sag = 0.05012562854249503 + 0.02501563183003138 = 0.07514126037252641
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0)
+        assert_allclose(geom.sag(x=1, y=1), 0.07514126037252641)
+
+    def test_sag_rx_infinite(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=be.inf, radius_y=20.0) # Cylindrical along X
+        # Sag should only depend on y. zx(any) = 0
+        # zy(1) for Ry=20 is 0.02501563183003138
+        assert_allclose(geom.sag(x=10, y=1), 0.02501563183003138)
+        assert_allclose(geom.sag(x=-5, y=1), 0.02501563183003138)
+
+    def test_sag_ry_infinite(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=be.inf) # Cylindrical along Y
+        # Sag should only depend on x. zy(any) = 0
+        # zx(1) for Rx=10 is 0.05012562854249503
+        assert_allclose(geom.sag(x=1, y=10), 0.05012562854249503)
+        assert_allclose(geom.sag(x=1, y=-5), 0.05012562854249503)
+
+    def test_sag_both_infinite_plane(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=be.inf, radius_y=be.inf)
+        assert_allclose(geom.sag(x=10, y=20), 0.0)
+        # Also test with conics, should still be zero
+        geom_conic = BiconicGeometry(cs, radius_x=be.inf, radius_y=be.inf, conic_x=0.5, conic_y=-1.0)
+        assert_allclose(geom_conic.sag(x=10, y=20), 0.0)
+
+
+    def test_sag_with_conics(self, set_test_backend):
+        cs = CoordinateSystem()
+        # Rx=10, kx=-1 (parabolic in x); Ry=20, ky=0.5 (elliptical in y)
+        # zx(1) for Rx=10, kx=-1: (0.1 * 1^2) / (1 + sqrt(1 - (1 + (-1)) * 0.1^2 * 1^2)) = 0.1 / (1 + sqrt(1)) = 0.1 / 2 = 0.05
+        # zy(1) for Ry=20, ky=0.5: (0.05*1^2)/(1+sqrt(1-(1+0.5)*0.05^2*1^2)) = 0.05/(1+sqrt(1-1.5*0.0025))
+        # = 0.05/(1+sqrt(1-0.00375)) = 0.05/(1+sqrt(0.99625)) = 0.05/(1+0.9981232387) = 0.02502345130203264
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0, conic_x=-1.0, conic_y=0.5)
+        expected_sag = 0.05 + 0.02502345130203264
+        assert_allclose(geom.sag(x=1, y=1), expected_sag)
+
+    def test_sag_array_input(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0)
+        x = be.array([0, 1, 2])
+        y = be.array([0, 1, 1])
+        # sag(0,0) = 0
+        # sag(1,1) = 0.07514126037252641 (from test_sag_finite_radii)
+        # sag(2,1):
+        # zx(2) for Rx=10: (0.1 * 4) / (1 + sqrt(1 - 0.01 * 4)) = 0.4 / (1 + sqrt(0.96)) = 0.4 / (1+0.9797958971) = 0.2020410900760968
+        # zy(1) for Ry=20: 0.02501563183003138
+        # expected_sag_2_1 = 0.2020410900760968 + 0.02501563183003138 = 0.22705672190612818
+        expected_sags = be.array([0.0, 0.07514126037252641, 0.22705672190612818])
+        assert_allclose(geom.sag(x, y), expected_sags)
+
+    def test_surface_normal_vertex(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0, conic_x=0.5, conic_y=-0.5)
+        nx, ny, nz = geom._surface_normal(x=0, y=0)
+        assert_allclose(nx, 0.0)
+        assert_allclose(ny, 0.0)
+        assert_allclose(nz, -1.0) # Optiland convention
+
+    def test_surface_normal_spherical_case(self, set_test_backend):
+        cs = CoordinateSystem()
+        R = 10.0
+        geom = BiconicGeometry(cs, radius_x=R, radius_y=R, conic_x=0.0, conic_y=0.0)
+        # For biconic sum of sags:
+        # dfdx = (cx * x) / sqrt(1 - (1+kx)cx^2*x^2)
+        # dfdy = (cy * y) / sqrt(1 - (1+ky)cy^2*y^2)
+        # At x=1, y=1, Rx=10, Ry=10, kx=0, ky=0:
+        # cx = 0.1, cy = 0.1
+        # dfdx = (0.1*1) / sqrt(1 - (1+0)*0.1^2*1^2) = 0.1 / sqrt(1 - 0.01) = 0.1 / sqrt(0.99) = 0.10050378152592118
+        # dfdy = (0.1*1) / sqrt(1 - (1+0)*0.1^2*1^2) = 0.1 / sqrt(0.99) = 0.10050378152592118
+        # mag_sq = dfdx^2 + dfdy^2 + 1 = 2 * (0.10050378152592118^2) + 1 = 2 * 0.010100999999999998 + 1 = 1.0202019999999999
+        # mag = sqrt(1.0202019999999999) = 1.0100504938109406
+        # nx = dfdx / mag = 0.10050378152592118 / 1.0100504938109406 = 0.09950371902099892
+        # ny = dfdy / mag = 0.09950371902099892
+        # nz = -1 / mag = -1 / 1.0100504938109406 = -0.9900493732390136
+        nx, ny, nz = geom._surface_normal(x=1, y=1)
+        assert_allclose(nx, 0.09950371902099892)
+        assert_allclose(ny, 0.09950371902099892)
+        assert_allclose(nz, -0.9900493732390136)
+
+    def test_surface_normal_cylindrical_rx_inf(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=be.inf, radius_y=10.0, conic_y=0.0) # Cylinder along X
+        # dfdx should be 0
+        # dfdy at y=1 for Ry=10, ky=0: (0.1*1) / sqrt(1 - (1+0)*0.1^2*1^2) = 0.1 / sqrt(0.99) = 0.10050378152592118
+        # mag_sq = 0^2 + dfdy^2 + 1 = 0.010100999999999998 + 1 = 1.0101009999999998
+        # mag = sqrt(1.0101009999999998) = 1.0050378152592118
+        # nx = 0
+        # ny = dfdy / mag = 0.10050378152592118 / 1.0050378152592118 = 0.1
+        # nz = -1 / mag = -1 / 1.0050378152592118 = -0.9950000000000001
+        nx, ny, nz = geom._surface_normal(x=5, y=1) # x shouldn't matter for dfdx=0
+        assert_allclose(nx, 0.0)
+        assert_allclose(ny, 0.1)
+        assert_allclose(nz, -0.9950000000000001)
+        
+    def test_surface_normal_array_input(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=10.0, conic_x=0.0, conic_y=0.0) # Spherical R=10
+        x = be.array([0, 1])
+        y = be.array([0, 1])
+        
+        # Point (0,0): nx=0, ny=0, nz=-1
+        # Point (1,1): nx=0.099503719, ny=0.099503719, nz=-0.990049373 (from spherical test)
+        expected_nx = be.array([0.0, 0.09950371902099892])
+        expected_ny = be.array([0.0, 0.09950371902099892])
+        expected_nz = be.array([-1.0, -0.9900493732390136])
+        
+        nx_calc, ny_calc, nz_calc = geom._surface_normal(x, y)
+        assert_allclose(nx_calc, expected_nx)
+        assert_allclose(ny_calc, expected_ny)
+        assert_allclose(nz_calc, expected_nz)
+
+
+    def test_distance_simple(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=10.0, radius_y=20.0)
+        rays = RealRays(x=0.0, y=0.0, z=-5.0, L=0.0, M=0.0, N=1.0, wavelength=0.55, intensity=1.0)
+        # Sag at (0,0) is 0, so distance to surface at (0,0) should be 5.0
+        assert_allclose(geom.distance(rays), 5.0, atol=1e-9) # Newton-Raphson tolerance
+
+    def test_distance_planar_biconic(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom = BiconicGeometry(cs, radius_x=be.inf, radius_y=be.inf, conic_x=0.0, conic_y=0.0) # Planar
+        rays = RealRays(x=1.0, y=1.0, z=-5.0, L=0.0, M=0.0, N=1.0, wavelength=0.55, intensity=1.0)
+        # Distance to plane z=0 should be 5.0
+        # The parent NewtonRaphsonGeometry's _intersection calls _intersection_plane if self.radius is inf.
+        # In Biconic.__init__, self.radius is set to radius_x. So this path is tested.
+        assert_allclose(geom.distance(rays), 5.0, atol=1e-9)
+
+    def test_to_dict_from_dict(self, set_test_backend):
+        cs = CoordinateSystem(x=1, y=2, z=3, tilt_x=0.1, tilt_y=-0.1, tilt_z=0.05)
+        original_geom = BiconicGeometry(
+            cs,
+            radius_x=100.0,
+            radius_y=-150.0,
+            conic_x=-0.5,
+            conic_y=0.2,
+            tol=1e-9,
+            max_iter=50,
+        )
+        geom_dict = original_geom.to_dict()
+
+        assert geom_dict["type"] == "BiconicGeometry"
+        assert geom_dict["radius_x"] == 100.0
+        assert geom_dict["radius_y"] == -150.0
+        assert geom_dict["conic_x"] == -0.5
+        assert geom_dict["conic_y"] == 0.2
+        assert geom_dict["tol"] == 1e-9
+        assert geom_dict["max_iter"] == 50
+        assert "radius" not in geom_dict 
+        assert "conic" not in geom_dict
+
+        reconstructed_geom = BiconicGeometry.from_dict(geom_dict)
+        assert isinstance(reconstructed_geom, BiconicGeometry)
+        assert_allclose(reconstructed_geom.Rx, original_geom.Rx)
+        assert_allclose(reconstructed_geom.Ry, original_geom.Ry)
+        assert_allclose(reconstructed_geom.kx, original_geom.kx)
+        assert_allclose(reconstructed_geom.ky, original_geom.ky)
+        assert reconstructed_geom.tol == original_geom.tol
+        assert reconstructed_geom.max_iter == original_geom.max_iter
+        assert reconstructed_geom.cs.to_dict() == original_geom.cs.to_dict()
+        
+        # Check if the reconstructed dict is identical (it should be)
+        assert reconstructed_geom.to_dict() == geom_dict
+
+    def test_from_dict_missing_keys(self, set_test_backend):
+        cs = CoordinateSystem()
+        minimal_valid_dict = {
+            "type": "BiconicGeometry", # Added type for clarity, though from_dict might not use it directly
+            "cs": cs.to_dict(),
+            "radius_x": 10.0,
+            "radius_y": 20.0,
+            # conic_x, conic_y, tol, max_iter will use defaults
+        }
+        
+        # Test missing radius_x
+        invalid_dict_rx = minimal_valid_dict.copy()
+        del invalid_dict_rx["radius_x"]
+        with pytest.raises(ValueError, match="Missing required BiconicGeometry keys: {'radius_x'}"):
+            BiconicGeometry.from_dict(invalid_dict_rx)
+
+        # Test missing radius_y
+        invalid_dict_ry = minimal_valid_dict.copy()
+        del invalid_dict_ry["radius_y"]
+        with pytest.raises(ValueError, match="Missing required BiconicGeometry keys: {'radius_y'}"):
+            BiconicGeometry.from_dict(invalid_dict_ry)
+            
+        # Test missing cs
+        invalid_dict_cs = minimal_valid_dict.copy()
+        del invalid_dict_cs["cs"]
+        with pytest.raises(ValueError, match="Missing required BiconicGeometry keys: {'cs'}"):
+            BiconicGeometry.from_dict(invalid_dict_cs)
+
+    def test_from_dict_default_conics_tol_max_iter(self, set_test_backend):
+        cs = CoordinateSystem()
+        geom_data = {
+            "type": "BiconicGeometry",
+            "cs": cs.to_dict(),
+            "radius_x": 10.0,
+            "radius_y": 20.0,
+        }
+        geom = BiconicGeometry.from_dict(geom_data)
+        assert geom.Rx == 10.0
+        assert geom.Ry == 20.0
+        assert geom.kx == 0.0  # Default
+        assert geom.ky == 0.0  # Default
+        assert geom.tol == 1e-10  # Default from NewtonRaphsonGeometry via BiconicGeometry
+        assert geom.max_iter == 100 # Default from NewtonRaphsonGeometry via BiconicGeometry


### PR DESCRIPTION
# Biconic Surfaces

- Adds support for the biconic surface type

A **biconic surface** is a generalization of a conic surface, allowing independent curvature and conic constants in the orthogonal \( x \) and \( y \) directions. This is useful in optical systems requiring different curvatures in sagittal and tangential planes.

### Surface Equation

The surface height \( z(x, y) \) is defined as:

$z(x, y) = z_x(x) + z_y(y)$

where

$z_x(x) = \\frac{c_x x^2}{1 + \\sqrt{1 - (1 + k_x) c_x^2 x^2}}$

$z_y(y) = \\frac{c_y y^2}{1 + \\sqrt{1 - (1 + k_y) c_y^2 y^2}}$

### Parameters

- $c_x = \\frac{1}{R_x}$: Curvature in the \( x \)-direction  
- $c_y = \\frac{1}{R_y}$: Curvature in the \( y \)-direction  
- $k_x$: Conic constant in the \( x \)-direction  
- $k_y$: Conic constant in the \( y \)-direction  

### Example:

```python
import optiland.backend as be
from optiland.optic import Optic

lens = Optic()

lens.add_surface(index=0, thickness=be.inf)
lens.add_surface(index=1, thickness=7, radius_x=20.0, radius_y=15.0, conic_x=0.1, conic_y=0.05,
                 is_stop=True, material="N-SF11", surface_type="biconic")
lens.add_surface(index=2, thickness=23.0)
lens.add_surface(index=3)

lens.set_aperture(aperture_type="EPD", value=20)

lens.set_field_type(field_type="angle")
lens.add_field(y=0)

lens.add_wavelength(value=0.55, is_primary=True)

lens.draw(num_rays=10)
```