### PR TITLE
Refactor spot diagram dataclass

### DIFF
--- a/optiland/analysis/encircled_energy.py
+++ b/optiland/analysis/encircled_energy.py
@@ -9,7 +9,8 @@ import matplotlib.pyplot as plt
 
 import optiland.backend as be
 from optiland.analysis.spot_diagram import SpotDiagram
-from .spot_diagram import SpotData  # Add this import
+
+from .spot_diagram import SpotData
 
 
 class EncircledEnergy(SpotDiagram):
@@ -80,10 +81,8 @@ class EncircledEnergy(SpotDiagram):
 
         """
         centroid = []
-        for (
-            field_data
-        ) in self.data:  # field_data is a list containing one SpotData object
-            spot_data_item = field_data[0]  # Access the SpotData object
+        for field_data in self.data:
+            spot_data_item = field_data[0]
             centroid_x = be.mean(spot_data_item.x)
             centroid_y = be.mean(spot_data_item.y)
             centroid.append((centroid_x, centroid_y))
@@ -105,12 +104,11 @@ class EncircledEnergy(SpotDiagram):
         r_max = axis_lim * buffer
         r_step = be.linspace(0, r_max, num_points)
 
-        for points in field_data:  # points is a SpotData object
+        for points in field_data:
             x = points.x
             y = points.y
-            energy = (
-                points.intensity
-            )  # Assuming 'energy' here corresponds to 'intensity' in SpotData
+            # energy and intensity are used interchangeably here
+            energy = points.intensity
             radii = be.sqrt(x**2 + y**2)
 
             def vectorized_ee(r):

--- a/optiland/analysis/encircled_energy.py
+++ b/optiland/analysis/encircled_energy.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 
 import optiland.backend as be
 from optiland.analysis.spot_diagram import SpotDiagram
+from .spot_diagram import SpotData  # Add this import
 
 
 class EncircledEnergy(SpotDiagram):
@@ -79,9 +80,12 @@ class EncircledEnergy(SpotDiagram):
 
         """
         centroid = []
-        for field_data in self.data:
-            centroid_x = be.mean(field_data[0][0])
-            centroid_y = be.mean(field_data[0][1])
+        for (
+            field_data
+        ) in self.data:  # field_data is a list containing one SpotData object
+            spot_data_item = field_data[0]  # Access the SpotData object
+            centroid_x = be.mean(spot_data_item.x)
+            centroid_y = be.mean(spot_data_item.y)
             centroid.append((centroid_x, centroid_y))
         return centroid
 
@@ -101,8 +105,12 @@ class EncircledEnergy(SpotDiagram):
         r_max = axis_lim * buffer
         r_step = be.linspace(0, r_max, num_points)
 
-        for points in field_data:
-            x, y, energy = points
+        for points in field_data:  # points is a SpotData object
+            x = points.x
+            y = points.y
+            energy = (
+                points.intensity
+            )  # Assuming 'energy' here corresponds to 'intensity' in SpotData
             radii = be.sqrt(x**2 + y**2)
 
             def vectorized_ee(r):
@@ -135,11 +143,11 @@ class EncircledEnergy(SpotDiagram):
             coordinates (str): Coordinate system choice (ignored).
 
         Returns:
-            list: List of field data, including x, y and energy points.
+            SpotData: SpotData object containing x, y, and intensity arrays.
 
         """
         self.optic.trace(*field, wavelength, num_rays, distribution)
         x = self.optic.surface_group.x[-1, :]
         y = self.optic.surface_group.y[-1, :]
         intensity = self.optic.surface_group.intensity[-1, :]
-        return [x, y, intensity]
+        return SpotData(x=x, y=y, intensity=intensity)

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -6,12 +6,28 @@ Kramer Harrison, 2024
 """
 
 from typing import Literal
+from dataclasses import dataclass  # Add this import
 
 import matplotlib.pyplot as plt
 from matplotlib import patches
 
 import optiland.backend as be
 from optiland.visualization.utils import transform
+
+
+@dataclass
+class SpotData:
+    """Stores the x, y coordinates and intensity of a spot.
+
+    Attributes:
+        x: Array of x-coordinates.
+        y: Array of y-coordinates.
+        intensity: Array of intensity values.
+    """
+
+    x: be.array
+    y: be.array
+    intensity: be.array
 
 
 class SpotDiagram:
@@ -27,9 +43,9 @@ class SpotDiagram:
         fields (tuple): fields at which data is generated
         wavelengths (tuple[float]): wavelengths at which data is generated
         num_rings (int): number of rings in pupil distribution for ray tracing
-        data (List): contains spot data in a nested list. Data is ordered as
-            field (dim 0), wavelength (dim 1), then x, y and intensity data
-            (dim 2).
+        data (List[List[SpotData]]): contains spot data in a nested list.
+            Data is ordered as field (dim 0), wavelength (dim 1), then
+            SpotData objects.
         coordinates (Literal['global', 'local']): Coordinate system for data
                                                   and plotting.
 
@@ -382,8 +398,9 @@ class SpotDiagram:
         norm_index = self.optic.wavelengths.primary_index
         centroid = []
         for field_data in self.data:
-            centroid_x = be.mean(field_data[norm_index][0])
-            centroid_y = be.mean(field_data[norm_index][1])
+            spot_data_item = field_data[norm_index]  # This is a SpotData object
+            centroid_x = be.mean(spot_data_item.x)
+            centroid_y = be.mean(spot_data_item.y)
             centroid.append((centroid_x, centroid_y))
         return centroid
 
@@ -399,8 +416,8 @@ class SpotDiagram:
         geometric_size = []
         for field_data in data:
             geometric_size_field = []
-            for wave_data in field_data:
-                r = be.sqrt(wave_data[0] ** 2 + wave_data[1] ** 2)
+            for wave_data in field_data:  # wave_data is a SpotData object
+                r = be.sqrt(wave_data.x**2 + wave_data.y**2)
                 geometric_size_field.append(be.max(r))
             geometric_size.append(geometric_size_field)
         return geometric_size
@@ -416,8 +433,8 @@ class SpotDiagram:
         rms = []
         for field_data in data:
             rms_field = []
-            for wave_data in field_data:
-                r2 = wave_data[0] ** 2 + wave_data[1] ** 2
+            for wave_data in field_data:  # wave_data is a SpotData object
+                r2 = wave_data.x**2 + wave_data.y**2
                 rms_field.append(be.sqrt(be.mean(r2)))
             rms.append(rms_field)
         return rms
@@ -437,20 +454,25 @@ class SpotDiagram:
 
         # Build a true deep copy of the nested list, cloning each array via the backend
         centered = []
-        for i, field_data in enumerate(data):
-            field_copy = []
-            for x, y, intensity in field_data:
+        for i, field_data_list in enumerate(
+            data
+        ):  # field_data_list is a list of SpotData objects
+            field_copy_list = []
+            for (
+                spot_data_item
+            ) in field_data_list:  # spot_data_item is a SpotData object
                 # clone each array/tensor
-                x2 = be.copy(x)
-                y2 = be.copy(y)
-                i2 = be.copy(intensity)
+                x2 = be.copy(spot_data_item.x)
+                y2 = be.copy(spot_data_item.y)
+                i2 = be.copy(spot_data_item.intensity)
 
                 # subtract centroid
-                x2 = x2 - centroids[i][0]  # not in-place, to prevent breaking autograd
+                # not in-place, to prevent breaking autograd
+                x2 = x2 - centroids[i][0]
                 y2 = y2 - centroids[i][1]
 
-                field_copy.append([x2, y2, i2])
-            centered.append(field_copy)
+                field_copy_list.append(SpotData(x=x2, y=y2, intensity=i2))
+            centered.append(field_copy_list)
         return centered
 
     def _generate_data(
@@ -509,9 +531,8 @@ class SpotDiagram:
             coordinates (str): The coordinate system ('local' or 'global').
 
         Returns:
-            list: A list containing the local x-coordinates,
-                local y-coordinates, and intensity values of the
-                generated spot data.
+            SpotData: An object containing x, y, and intensity values
+                of the generated spot data.
 
         """
         self.optic.trace(*field, wavelength, num_rays, distribution)
@@ -535,7 +556,7 @@ class SpotDiagram:
             plot_x = x_global
             plot_y = y_global
 
-        return [plot_x, plot_y, intensity]
+        return SpotData(x=plot_x, y=plot_y, intensity=intensity)
 
     def _plot_field(
         self,
@@ -573,8 +594,11 @@ class SpotDiagram:
         import numpy as np
 
         markers = ["o", "s", "^"]
-        for k, points in enumerate(field_data):
-            x, y, intensity = points
+        for k, points in enumerate(field_data):  # points is a SpotData object
+            # x, y, intensity = points
+            x = points.x
+            y = points.y
+            intensity = points.intensity
             # one‐liner conversion for BOTH backends:
             x_np = be.to_numpy(x)
             y_np = be.to_numpy(y)

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -588,7 +588,7 @@ class SpotDiagram:
         import numpy as np
 
         markers = ["o", "s", "^"]
-        for k, points in enumerate(field_data):  # points is a SpotData object
+        for k, points in enumerate(field_data):
             # x, y, intensity = points
             x = points.x
             y = points.y

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -5,8 +5,8 @@ This module provides a spot diagram analysis for optical systems.
 Kramer Harrison, 2024
 """
 
+from dataclasses import dataclass
 from typing import Literal
-from dataclasses import dataclass  # Add this import
 
 import matplotlib.pyplot as plt
 from matplotlib import patches
@@ -194,7 +194,6 @@ class SpotDiagram:
             theta_rad (float): angle in radians.
 
         """
-        # Compute the angle using arccos
         a = a / be.linalg.norm(a)
         b = b / be.linalg.norm(b)
         theta = be.arccos(be.clip(be.dot(a, b), -1, 1))
@@ -398,7 +397,7 @@ class SpotDiagram:
         norm_index = self.optic.wavelengths.primary_index
         centroid = []
         for field_data in self.data:
-            spot_data_item = field_data[norm_index]  # This is a SpotData object
+            spot_data_item = field_data[norm_index]
             centroid_x = be.mean(spot_data_item.x)
             centroid_y = be.mean(spot_data_item.y)
             centroid.append((centroid_x, centroid_y))
@@ -416,7 +415,7 @@ class SpotDiagram:
         geometric_size = []
         for field_data in data:
             geometric_size_field = []
-            for wave_data in field_data:  # wave_data is a SpotData object
+            for wave_data in field_data:
                 r = be.sqrt(wave_data.x**2 + wave_data.y**2)
                 geometric_size_field.append(be.max(r))
             geometric_size.append(geometric_size_field)
@@ -433,7 +432,7 @@ class SpotDiagram:
         rms = []
         for field_data in data:
             rms_field = []
-            for wave_data in field_data:  # wave_data is a SpotData object
+            for wave_data in field_data:
                 r2 = wave_data.x**2 + wave_data.y**2
                 rms_field.append(be.sqrt(be.mean(r2)))
             rms.append(rms_field)
@@ -454,20 +453,15 @@ class SpotDiagram:
 
         # Build a true deep copy of the nested list, cloning each array via the backend
         centered = []
-        for i, field_data_list in enumerate(
-            data
-        ):  # field_data_list is a list of SpotData objects
+        for i, field_data_list in enumerate(data):
             field_copy_list = []
-            for (
-                spot_data_item
-            ) in field_data_list:  # spot_data_item is a SpotData object
+            for spot_data_item in field_data_list:
                 # clone each array/tensor
                 x2 = be.copy(spot_data_item.x)
                 y2 = be.copy(spot_data_item.y)
                 i2 = be.copy(spot_data_item.intensity)
 
-                # subtract centroid
-                # not in-place, to prevent breaking autograd
+                # subtract centroid - not in-place, to prevent breaking autograd
                 x2 = x2 - centroids[i][0]
                 y2 = y2 - centroids[i][1]
 

--- a/optiland/mtf.py
+++ b/optiland/mtf.py
@@ -126,10 +126,8 @@ class GeometricMTF(SpotDiagram):
             scale_factor = 1
 
         mtf = []  # TODO: add option for polychromatic MTF
-        for (
-            field_data
-        ) in self.data:  # field_data is a list containing one SpotData object
-            spot_data_item = field_data[0]  # Access the SpotData object
+        for field_data in self.data:
+            spot_data_item = field_data[0]
             xi, yi = spot_data_item.x, spot_data_item.y
             mtf.append(
                 [

--- a/optiland/mtf.py
+++ b/optiland/mtf.py
@@ -126,8 +126,11 @@ class GeometricMTF(SpotDiagram):
             scale_factor = 1
 
         mtf = []  # TODO: add option for polychromatic MTF
-        for field_data in self.data:
-            xi, yi = field_data[0][0], field_data[0][1]
+        for (
+            field_data
+        ) in self.data:  # field_data is a list containing one SpotData object
+            spot_data_item = field_data[0]  # Access the SpotData object
+            xi, yi = spot_data_item.x, spot_data_item.y
             mtf.append(
                 [
                     self._compute_field_data(yi, self.freq, scale_factor),

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -7,6 +7,7 @@ import optiland.backend as be
 import pytest
 
 from optiland import analysis
+from optiland.analysis.spot_diagram import SpotData  # Add this import
 from optiland.optic import Optic
 from optiland.samples.objectives import CookeTriplet, TripletTelescopeObjective
 from optiland.physical_apertures import RectangularAperture
@@ -66,7 +67,7 @@ class TestCookeTripetSpotDiagram:
     def test_spot_geometric_radius(self, set_test_backend, cooke_triplet):
         spot = analysis.SpotDiagram(cooke_triplet)
         geo_radius = spot.geometric_spot_radius()
-        
+
         assert_allclose(geo_radius[0][0], 0.00597244087781)
         assert_allclose(geo_radius[0][1], 0.00628645771124)
         assert_allclose(geo_radius[0][2], 0.00931911440064)
@@ -103,13 +104,15 @@ class TestCookeTripetSpotDiagram:
         assert_allclose(airy_radius_x[0], 0.0033403700287742426)
         assert_allclose(airy_radius_x[1], 0.003579789351003376)
         assert_allclose(airy_radius_x[2], 0.003825501589577882)
-        
+
         assert_allclose(airy_radius_y[0], 0.0033403700287742426)
         assert_allclose(airy_radius_y[1], 0.003430811760325915)
         assert_allclose(airy_radius_y[2], 0.0035453238661865244)
-    
+
     @patch("matplotlib.pyplot.show")
-    def test_airy_disc_in_view_spot_diagram(self, mock_show, set_test_backend, cooke_triplet):
+    def test_airy_disc_in_view_spot_diagram(
+        self, mock_show, set_test_backend, cooke_triplet
+    ):
         spot = analysis.SpotDiagram(cooke_triplet)
         spot.view(add_airy_disk=True)
         mock_show.assert_called_once()
@@ -123,7 +126,9 @@ class TestCookeTripetSpotDiagram:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_spot_diagram_larger_fig(self, mock_show, set_test_backend, cooke_triplet):
+    def test_view_spot_diagram_larger_fig(
+        self, mock_show, set_test_backend, cooke_triplet
+    ):
         spot = analysis.SpotDiagram(cooke_triplet)
         spot.view(figsize=(20, 10))
         mock_show.assert_called_once()
@@ -139,7 +144,9 @@ class TestTripletSpotDiagram:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_spot_diagram_larger_fig(self, mock_show, set_test_backend, triplet_four_fields):
+    def test_view_spot_diagram_larger_fig(
+        self, mock_show, set_test_backend, triplet_four_fields
+    ):
         spot = analysis.SpotDiagram(triplet_four_fields)
         spot.view(figsize=(20, 10))
         mock_show.assert_called_once()
@@ -153,13 +160,13 @@ class TestCookeTripletEncircledEnergy:
 
         # encircled energy calculation includes randomness, so abs. tolerance
         # is set to 1e-3
-        
+
         assert_allclose(centroid[0][0], -8.207497747771947e-06, atol=1e-3, rtol=1e-3)
         assert_allclose(centroid[0][1], 1.989147771098717e-06, atol=1e-3, rtol=1e-3)
 
         assert_allclose(centroid[1][0], 3.069405792964239e-05, atol=1e-3, rtol=1e-3)
         assert_allclose(centroid[1][1], 12.421326489507168, atol=1e-3, rtol=1e-3)
-        
+
         assert_allclose(centroid[2][0], 3.1631726815066986e-07, atol=1e-3, rtol=1e-3)
         assert_allclose(centroid[2][1], 18.13502264954927, atol=1e-3, rtol=1e-3)
 
@@ -171,7 +178,9 @@ class TestCookeTripletEncircledEnergy:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_encircled_energy_larger_fig(self, mock_show, set_test_backend, cooke_triplet):
+    def test_view_encircled_energy_larger_fig(
+        self, mock_show, set_test_backend, cooke_triplet
+    ):
         encircled_energy = analysis.EncircledEnergy(cooke_triplet)
         encircled_energy.view(figsize=(20, 10))
         mock_show.assert_called_once()
@@ -188,7 +197,11 @@ class TestCookeTripletRayFan:
         assert_allclose(fan.data["Py"][0], -1)
         assert_allclose(fan.data["Py"][-1], 1)
 
-        assert_allclose(fan.data["(0.0, 0.0)"]["0.48"]["x"][0], 0.00238814980958324, atol=1e-9, )
+        assert_allclose(
+            fan.data["(0.0, 0.0)"]["0.48"]["x"][0],
+            0.00238814980958324,
+            atol=1e-9,
+        )
 
         assert_allclose(
             fan.data["(0.0, 0.0)"]["0.48"]["x"][0],
@@ -403,7 +416,9 @@ class TestTelescopeTripletYYbar:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_yybar_larger_fig(self, mock_show, set_test_backend, telescope_objective):
+    def test_view_yybar_larger_fig(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         yybar = analysis.YYbar(telescope_objective)
         yybar.view(figsize=(12.4, 10))
         mock_show.assert_called_once()
@@ -426,14 +441,14 @@ class TestTelescopeTripletDistortion:
     def test_f_theta_distortion(self, set_test_backend, telescope_objective):
         dist = analysis.Distortion(telescope_objective, distortion_type="f-theta")
 
-        assert_allclose(dist.data[0][0],0.0, atol=1e-9)
-        assert_allclose(dist.data[0][-1],0.016106265133212852, atol=1e-9)
-        
-        assert_allclose(dist.data[1][0],0.0, atol=1e-9)
-        assert_allclose(dist.data[1][-1],0.015942044760968603, atol=1e-9)
-        
-        assert_allclose(dist.data[2][0],0.0, atol=1e-9)
-        assert_allclose(dist.data[2][-1],0.015876125134060767, atol=1e-9)
+        assert_allclose(dist.data[0][0], 0.0, atol=1e-9)
+        assert_allclose(dist.data[0][-1], 0.016106265133212852, atol=1e-9)
+
+        assert_allclose(dist.data[1][0], 0.0, atol=1e-9)
+        assert_allclose(dist.data[1][-1], 0.015942044760968603, atol=1e-9)
+
+        assert_allclose(dist.data[2][0], 0.0, atol=1e-9)
+        assert_allclose(dist.data[2][-1], 0.015876125134060767, atol=1e-9)
 
     def test_invalid_distortion_type(self, set_test_backend, telescope_objective):
         with pytest.raises(ValueError):
@@ -447,7 +462,9 @@ class TestTelescopeTripletDistortion:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_distortion_larger_fig(self, mock_show, set_test_backend, telescope_objective):
+    def test_view_distortion_larger_fig(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         dist = analysis.Distortion(telescope_objective)
         dist.view(figsize=(12.4, 10))
         mock_show.assert_called_once()
@@ -503,14 +520,18 @@ class TestTelescopeTripletGridDistortion:
             analysis.GridDistortion(telescope_objective, distortion_type="invalid")
 
     @patch("matplotlib.pyplot.show")
-    def test_view_grid_distortion(self, mock_show, set_test_backend, telescope_objective):
+    def test_view_grid_distortion(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         dist = analysis.GridDistortion(telescope_objective)
         dist.view()
         mock_show.assert_called_once()
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_grid_distortion_larger_fig(self, mock_show, set_test_backend, telescope_objective):
+    def test_view_grid_distortion_larger_fig(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         dist = analysis.GridDistortion(telescope_objective)
         dist.view(figsize=(12.4, 10))
         mock_show.assert_called_once()
@@ -527,7 +548,9 @@ class TestTelescopeTripletFieldCurvature:
         )
         assert field_curvature.num_points == 128
 
-    def test_field_curvature_init_with_wavelength(self, set_test_backend, telescope_objective):
+    def test_field_curvature_init_with_wavelength(
+        self, set_test_backend, telescope_objective
+    ):
         field_curvature = analysis.FieldCurvature(
             telescope_objective,
             wavelengths=[0.5, 0.6],
@@ -536,7 +559,9 @@ class TestTelescopeTripletFieldCurvature:
         assert field_curvature.wavelengths == [0.5, 0.6]
         assert field_curvature.num_points == 128
 
-    def test_field_curvature_init_with_num_points(self, set_test_backend, telescope_objective):
+    def test_field_curvature_init_with_num_points(
+        self, set_test_backend, telescope_objective
+    ):
         num_points = 256
         field_curvature = analysis.FieldCurvature(
             telescope_objective,
@@ -549,7 +574,9 @@ class TestTelescopeTripletFieldCurvature:
         )
         assert field_curvature.num_points == num_points
 
-    def test_field_curvature_init_with_all_parameters(self, set_test_backend, telescope_objective):
+    def test_field_curvature_init_with_all_parameters(
+        self, set_test_backend, telescope_objective
+    ):
         num_points = 256
         field_curvature = analysis.FieldCurvature(
             telescope_objective,
@@ -561,7 +588,9 @@ class TestTelescopeTripletFieldCurvature:
         assert field_curvature.num_points == num_points
 
     @patch("matplotlib.pyplot.show")
-    def test_field_curvature_view(self, mock_show, set_test_backend, telescope_objective):
+    def test_field_curvature_view(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         field_curvature = analysis.FieldCurvature(telescope_objective)
         field_curvature.view()
         mock_show.assert_called_once()
@@ -604,7 +633,9 @@ class TestTelescopeTripletFieldCurvature:
 
 
 class TestSpotVsField:
-    def test_rms_spot_size_vs_field_initialization(self, set_test_backend, telescope_objective):
+    def test_rms_spot_size_vs_field_initialization(
+        self, set_test_backend, telescope_objective
+    ):
         spot_vs_field = analysis.RmsSpotSizeVsField(telescope_objective)
         assert spot_vs_field.num_fields == 64
         assert be.array_equal(spot_vs_field._field[:, 1], be.linspace(0, 1, 64))
@@ -625,7 +656,9 @@ class TestSpotVsField:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_spot_vs_field_larger_fig(self, mock_show, set_test_backend, telescope_objective):
+    def test_view_spot_vs_field_larger_fig(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         spot_vs_field = analysis.RmsSpotSizeVsField(telescope_objective)
         spot_vs_field.view(figsize=(12.4, 10))
         mock_show.assert_called_once()
@@ -663,7 +696,9 @@ class TestWavefrontErrorVsField:
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_view_wave_larger_fig(self, mock_show, set_test_backend, telescope_objective):
+    def test_view_wave_larger_fig(
+        self, mock_show, set_test_backend, telescope_objective
+    ):
         wavefront_error_vs_field = analysis.RmsWavefrontErrorVsField(
             telescope_objective,
         )
@@ -701,10 +736,12 @@ class TestPupilAberration:
         mock_show.assert_called_once()
         plt.close()
 
+
 def test_spotdiagram_invalid_coordinates(cooke_triplet):
     with pytest.raises(ValueError) as excinfo:
         analysis.SpotDiagram(cooke_triplet, coordinates="invalid")
     assert str(excinfo.value) == "Coordinates must be 'global' or 'local'."
+
 
 def test_generate_field_data_local(set_test_backend, cooke_triplet):
 
@@ -722,12 +759,15 @@ def test_generate_field_data_local(set_test_backend, cooke_triplet):
         coordinates="local",
     )
 
-    plot_x, plot_y, _ = data
+    plot_x = data.x
+    plot_y = data.y
+    # intensity = data.intensity # if needed for future assertions
     global_x = spot.optic.surface_group.x[-1, :]
     global_y = spot.optic.surface_group.y[-1, :]
     assert_allclose(plot_x, global_x)
     assert_allclose(plot_y, global_y)
-    
+
+
 def test_generate_field_data_global(set_test_backend, cooke_triplet):
 
     spot = analysis.SpotDiagram(cooke_triplet, coordinates="global")
@@ -744,12 +784,15 @@ def test_generate_field_data_global(set_test_backend, cooke_triplet):
         coordinates="global",
     )
 
-    plot_x, plot_y, _ = data
+    plot_x = data.x
+    plot_y = data.y
+    # intensity = data.intensity # if needed for future assertions
     global_x = spot.optic.surface_group.x[-1, :]
     global_y = spot.optic.surface_group.y[-1, :]
     assert_allclose(plot_x, global_x)
     assert_allclose(plot_y, global_y)
-    
+
+
 @pytest.fixture
 def test_system_irradiance_v1():
     class TestSystemIrradianceV1(Optic):
@@ -759,13 +802,17 @@ def test_system_irradiance_v1():
             self.add_surface(index=1, thickness=0, is_stop=True)
             self.add_surface(index=2, thickness=10)
             self.add_surface(index=3)  # image
-            detector_size = RectangularAperture(x_max=2.5, x_min=-2.5, y_max=2.5, y_min=-2.5)
+            detector_size = RectangularAperture(
+                x_max=2.5, x_min=-2.5, y_max=2.5, y_min=-2.5
+            )
             self.surface_group.surfaces[-1].aperture = detector_size
             self.add_wavelength(0.55)
-            self.set_field_type('angle')
+            self.set_field_type("angle")
             self.add_field(y=0)
-            self.set_aperture('EPD', 5.0)
+            self.set_aperture("EPD", 5.0)
+
     return TestSystemIrradianceV1()
+
 
 @pytest.fixture
 def perfect_mirror_system():
@@ -774,15 +821,26 @@ def perfect_mirror_system():
             super().__init__()
             self.add_surface(index=0, thickness=be.inf)
             self.add_surface(index=1, thickness=50)
-            self.add_surface(index=2, thickness=-25, radius=-50, conic=-1.0, material='mirror', is_stop=True)
+            self.add_surface(
+                index=2,
+                thickness=-25,
+                radius=-50,
+                conic=-1.0,
+                material="mirror",
+                is_stop=True,
+            )
             self.add_surface(index=3)  # image
-            detector_size = RectangularAperture(x_max=2.5, x_min=-2.5, y_max=2.5, y_min=-2.5)
+            detector_size = RectangularAperture(
+                x_max=2.5, x_min=-2.5, y_max=2.5, y_min=-2.5
+            )
             self.surface_group.surfaces[-1].aperture = detector_size
             self.add_wavelength(0.55)
-            self.set_field_type('angle')
+            self.set_field_type("angle")
             self.add_field(y=0)
-            self.set_aperture('EPD', 5.0)
+            self.set_aperture("EPD", 5.0)
+
     return PerfectMirror()
+
 
 def _create_square_grid_rays(num_rays_edge, min_coord, max_coord, wavelength_val=0.55):
     x_rays_np = be.linspace(min_coord, max_coord, num_rays_edge)
@@ -791,17 +849,20 @@ def _create_square_grid_rays(num_rays_edge, min_coord, max_coord, wavelength_val
     y_be_flat = be.array(y_np.flatten())
     num_rays = x_be_flat.shape[0]
 
-    z_be = be.zeros((num_rays,)) # pass shape as tuple because of torch backend
-    L_be = be.zeros((num_rays,)) 
-    M_be = be.zeros((num_rays,)) 
-    N_be = be.ones((num_rays,))  
-    I_be = be.ones((num_rays,))  
-    W_be = be.full((num_rays,), wavelength_val) 
+    z_be = be.zeros((num_rays,))  # pass shape as tuple because of torch backend
+    L_be = be.zeros((num_rays,))
+    M_be = be.zeros((num_rays,))
+    N_be = be.ones((num_rays,))
+    I_be = be.ones((num_rays,))
+    W_be = be.full((num_rays,), wavelength_val)
     return RealRays(x_be_flat, y_be_flat, z_be, L_be, M_be, N_be, I_be, W_be)
 
-def _apply_gaussian_apodization(x_coords_flat, y_coords_flat, sigma_x, sigma_y, peak_intensity=1.0):
+
+def _apply_gaussian_apodization(
+    x_coords_flat, y_coords_flat, sigma_x, sigma_y, peak_intensity=1.0
+):
     # x_coords_flat and y_coords_flat are expected to be 1D backend arrays
-    x_np = be.to_numpy(x_coords_flat) 
+    x_np = be.to_numpy(x_coords_flat)
     y_np = be.to_numpy(y_coords_flat)
     exponent = -(((x_np**2) / (2 * sigma_x**2)) + ((y_np**2) / (2 * sigma_y**2)))
     intensities_np = peak_intensity * be.exp(exponent)
@@ -810,34 +871,43 @@ def _apply_gaussian_apodization(x_coords_flat, y_coords_flat, sigma_x, sigma_y, 
 
 class TestIncoherentIrradiance:
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_v1_uniform_and_user_defined_rays(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_v1_uniform_and_user_defined_rays(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
         res = (5, 5)
 
         # Test with default uniform rays
-        irr_uniform = analysis.IncoherentIrradiance(optic_sys, num_rays=5, distribution='uniform', res=res) 
+        irr_uniform = analysis.IncoherentIrradiance(
+            optic_sys, num_rays=5, distribution="uniform", res=res
+        )
         irr_map_uniform, _, _ = irr_uniform.irr_data[0][0]
-        
+
         # This is a basic check, not a precise value assertion
         assert be.sum(irr_map_uniform) > 0
         assert be.max(irr_map_uniform) > 0
         irr_uniform.view()
         plt.close()
 
-
         # Test with user-defined rays
-        user_rays = _create_square_grid_rays(num_rays_edge=5, min_coord=-2.25, max_coord=1.75)
-        irr_user = analysis.IncoherentIrradiance(optic_sys, res=res, user_initial_rays=user_rays)
+        user_rays = _create_square_grid_rays(
+            num_rays_edge=5, min_coord=-2.25, max_coord=1.75
+        )
+        irr_user = analysis.IncoherentIrradiance(
+            optic_sys, res=res, user_initial_rays=user_rays
+        )
         irr_map_user, _, _ = irr_user.irr_data[0][0]
-    
-        pixel_area_expected = ( (2.5 - (-2.5)) / res[0] ) * ( (2.5 - (-2.5)) / res[1] )
+
+        pixel_area_expected = ((2.5 - (-2.5)) / res[0]) * ((2.5 - (-2.5)) / res[1])
         expected_irr_value = 1.0 / pixel_area_expected
         assert_allclose(irr_map_user, be.full(res, expected_irr_value), atol=1e-5)
         irr_user.view()
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_v1_one_ray_per_other_pixel(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_v1_one_ray_per_other_pixel(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
         res_val = (10, 10)
 
@@ -845,8 +915,10 @@ class TestIncoherentIrradiance:
         x_centers_np = be.linspace(-2.25, 2.25, 10)
         selected_x_np = x_centers_np[::2]
         selected_y_np = x_centers_np[::2]
-        x_np_mesh, y_np_mesh = be.meshgrid(selected_x_np, selected_y_np) # Use numpy for meshgrid setup
-        
+        x_np_mesh, y_np_mesh = be.meshgrid(
+            selected_x_np, selected_y_np
+        )  # Use numpy for meshgrid setup
+
         x_be_flat = be.array(x_np_mesh.flatten())
         y_be_flat = be.array(y_np_mesh.flatten())
         num_rays_flat = x_be_flat.shape[0]
@@ -858,27 +930,35 @@ class TestIncoherentIrradiance:
             L=be.zeros((num_rays_flat,)),
             M=be.zeros((num_rays_flat,)),
             N=be.ones((num_rays_flat,)),
-            intensity=be.ones((num_rays_flat,)),      
-            wavelength=be.full((num_rays_flat,), 0.55) 
+            intensity=be.ones((num_rays_flat,)),
+            wavelength=be.full((num_rays_flat,), 0.55),
         )
 
-        irr_analysis = analysis.IncoherentIrradiance(optic_sys, res=res_val, user_initial_rays=user_rays)
+        irr_analysis = analysis.IncoherentIrradiance(
+            optic_sys, res=res_val, user_initial_rays=user_rays
+        )
         irr_map_be, _, _ = irr_analysis.irr_data[0][0]
 
-        expected_map_np = np.zeros(res_val) # create the expected map with numpy 
-        pixel_area_expected = ((2.5 - (-2.5)) / res_val[0]) * ((2.5 - (-2.5)) / res_val[1])
+        expected_map_np = np.zeros(res_val)  # create the expected map with numpy
+        pixel_area_expected = ((2.5 - (-2.5)) / res_val[0]) * (
+            (2.5 - (-2.5)) / res_val[1]
+        )
         irr_value_per_ray = 1.0 / pixel_area_expected
 
         for i in range(0, res_val[0], 2):
             for j in range(0, res_val[1], 2):
                 expected_map_np[i, j] = irr_value_per_ray
 
-        assert_allclose(irr_map_be, expected_map_np, atol=1e-5) # assert_allclose handles be_tensor vs np_array
+        assert_allclose(
+            irr_map_be, expected_map_np, atol=1e-5
+        )  # assert_allclose handles be_tensor vs np_array
         irr_analysis.view()
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_gaussian_apodization(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_gaussian_apodization(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
         res_val = (50, 50)
         num_rays_edge = 100
@@ -890,43 +970,57 @@ class TestIncoherentIrradiance:
         y_be_flat = be.array(y_np_mesh.flatten())
         num_rays_flat = x_be_flat.shape[0]
 
-        gaussian_intensities = _apply_gaussian_apodization(x_be_flat, y_be_flat, sigma_x=sigma_val, sigma_y=sigma_val)
-
-        user_rays_apodized = RealRays(
-            x=x_be_flat, y=y_be_flat, z=be.zeros((num_rays_flat,)),
-            L=be.zeros((num_rays_flat,)), M=be.zeros((num_rays_flat,)), N=be.ones((num_rays_flat,)),
-            intensity=gaussian_intensities, wavelength=be.full((num_rays_flat,), 0.55)
+        gaussian_intensities = _apply_gaussian_apodization(
+            x_be_flat, y_be_flat, sigma_x=sigma_val, sigma_y=sigma_val
         )
 
-        irr_apodized = analysis.IncoherentIrradiance(optic_sys, res=res_val, user_initial_rays=user_rays_apodized)
+        user_rays_apodized = RealRays(
+            x=x_be_flat,
+            y=y_be_flat,
+            z=be.zeros((num_rays_flat,)),
+            L=be.zeros((num_rays_flat,)),
+            M=be.zeros((num_rays_flat,)),
+            N=be.ones((num_rays_flat,)),
+            intensity=gaussian_intensities,
+            wavelength=be.full((num_rays_flat,), 0.55),
+        )
+
+        irr_apodized = analysis.IncoherentIrradiance(
+            optic_sys, res=res_val, user_initial_rays=user_rays_apodized
+        )
         irr_map_apodized_be, x_edges, y_edges = irr_apodized.irr_data[0][0]
 
         center_idx_x = res_val[0] // 2
         center_idx_y = res_val[1] // 2
-        
+
         val_center = irr_map_apodized_be[center_idx_x, center_idx_y]
         val_corner1 = irr_map_apodized_be[0, 0]
-        val_corner2 = irr_map_apodized_be[res_val[0]-1, res_val[1]-1]
+        val_corner2 = irr_map_apodized_be[res_val[0] - 1, res_val[1] - 1]
         max_val_be = be.max(irr_map_apodized_be)
 
         assert be.to_numpy(val_center) > be.to_numpy(val_corner1)
         assert be.to_numpy(val_center) > be.to_numpy(val_corner2)
-        assert_allclose(val_center, max_val_be, rtol=1e-3) 
+        assert_allclose(val_center, max_val_be, rtol=1e-3)
 
         irr_apodized.view()
         plt.close()
 
-
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_perfect_mirror_focus(self, mock_show, set_test_backend, perfect_mirror_system):
+    def test_irradiance_perfect_mirror_focus(
+        self, mock_show, set_test_backend, perfect_mirror_system
+    ):
         optic_sys = perfect_mirror_system
         res_val = (21, 21)
         num_rays_epd = 51
 
-        user_rays_grid = _create_square_grid_rays(num_rays_edge=num_rays_epd, min_coord=-2.5, max_coord=2.5)
+        user_rays_grid = _create_square_grid_rays(
+            num_rays_edge=num_rays_epd, min_coord=-2.5, max_coord=2.5
+        )
 
-        irr_perfect = analysis.IncoherentIrradiance(optic_sys, res=res_val, user_initial_rays=user_rays_grid)
-        irr_map_perfect_be = irr_perfect.irr_data[0][0][0] 
+        irr_perfect = analysis.IncoherentIrradiance(
+            optic_sys, res=res_val, user_initial_rays=user_rays_grid
+        )
+        irr_map_perfect_be = irr_perfect.irr_data[0][0][0]
 
         center_x_idx = res_val[0] // 2
         center_y_idx = res_val[1] // 2
@@ -934,19 +1028,23 @@ class TestIncoherentIrradiance:
         total_sum_be = be.sum(irr_map_perfect_be)
         center_pixel_value_be = irr_map_perfect_be[center_x_idx, center_y_idx]
 
-        assert be.to_numpy(total_sum_be) > 1e-9 
+        assert be.to_numpy(total_sum_be) > 1e-9
         assert_allclose(center_pixel_value_be, total_sum_be, atol=1e-5)
 
-        irr_map_perfect_np = be.to_numpy(irr_map_perfect_be) # convert for easy masking with numpy
+        irr_map_perfect_np = be.to_numpy(
+            irr_map_perfect_be
+        )  # convert for easy masking with numpy
         mask = np.ones(irr_map_perfect_np.shape, dtype=bool)
         mask[center_x_idx, center_y_idx] = False
         assert_allclose(np.sum(irr_map_perfect_np[mask]), 0.0, atol=1e-5)
 
         irr_perfect.view()
         plt.close()
-        
+
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_plot_cross_section_gaussian(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_plot_cross_section_gaussian(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
         res_val = (50, 50)
         num_rays_edge = 100
@@ -958,32 +1056,43 @@ class TestIncoherentIrradiance:
         y_be_flat = be.array(y_np_mesh.flatten())
         num_rays_flat = x_be_flat.shape[0]
 
-        gaussian_intensities = _apply_gaussian_apodization(x_be_flat, y_be_flat, sigma_x=sigma_val, sigma_y=sigma_val)
-        user_rays_apodized = RealRays(
-            x=x_be_flat, y=y_be_flat, z=be.zeros((num_rays_flat,)),
-            L=be.zeros((num_rays_flat,)), M=be.zeros((num_rays_flat,)), N=be.ones((num_rays_flat,)),
-            intensity=gaussian_intensities, wavelength=be.full((num_rays_flat,), 0.55)
+        gaussian_intensities = _apply_gaussian_apodization(
+            x_be_flat, y_be_flat, sigma_x=sigma_val, sigma_y=sigma_val
         )
-        irr_apodized = analysis.IncoherentIrradiance(optic_sys, res=res_val, user_initial_rays=user_rays_apodized)
+        user_rays_apodized = RealRays(
+            x=x_be_flat,
+            y=y_be_flat,
+            z=be.zeros((num_rays_flat,)),
+            L=be.zeros((num_rays_flat,)),
+            M=be.zeros((num_rays_flat,)),
+            N=be.ones((num_rays_flat,)),
+            intensity=gaussian_intensities,
+            wavelength=be.full((num_rays_flat,), 0.55),
+        )
+        irr_apodized = analysis.IncoherentIrradiance(
+            optic_sys, res=res_val, user_initial_rays=user_rays_apodized
+        )
 
         # Test cross-X plot at center
-        irr_apodized.view(cross_section=('cross-x', res_val[0] // 2))
+        irr_apodized.view(cross_section=("cross-x", res_val[0] // 2))
         # Test cross-Y plot at default middle slice
-        irr_apodized.view(cross_section=('cross-y', None))
+        irr_apodized.view(cross_section=("cross-y", None))
         # Test cross-X plot with normalize=False
-        irr_apodized.view(cross_section=('cross-x', res_val[0] // 2), normalize=False)
+        irr_apodized.view(cross_section=("cross-x", res_val[0] // 2), normalize=False)
 
         assert mock_show.call_count >= 3
-        plt.close('all') 
+        plt.close("all")
 
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_peak_irradiance(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_peak_irradiance(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
-        irr = analysis.IncoherentIrradiance(optic_sys, num_rays=20, res=(10,10))
-        peaks = irr.peak_irradiance() 
+        irr = analysis.IncoherentIrradiance(optic_sys, num_rays=20, res=(10, 10))
+        peaks = irr.peak_irradiance()
         assert len(peaks) == len(irr.fields)
         assert len(peaks[0]) == len(irr.wavelengths)
-        assert be.to_numpy(peaks[0][0]) >= 0 
+        assert be.to_numpy(peaks[0][0]) >= 0
 
     def test_detector_surface_no_aperture(self, set_test_backend):
         class TestSystemNoAperture(Optic):
@@ -992,81 +1101,107 @@ class TestIncoherentIrradiance:
                 self.add_surface(index=0, thickness=be.inf)
                 self.add_surface(index=1, thickness=0, is_stop=True)
                 self.add_surface(index=2, thickness=10)
-                self.add_surface(index=3) # Image plane, no aperture
+                self.add_surface(index=3)  # Image plane, no aperture
                 self.add_wavelength(0.55)
-                self.set_field_type('angle')
+                self.set_field_type("angle")
                 self.add_field(y=0)
-                self.set_aperture('EPD', 5.0)
+                self.set_aperture("EPD", 5.0)
+
         optic_no_ap = TestSystemNoAperture()
-        with pytest.raises(ValueError, match="Detector surface has no physical aperture"):
-            analysis.IncoherentIrradiance(optic_no_ap, num_rays=5, res=(5,5))
+        with pytest.raises(
+            ValueError, match="Detector surface has no physical aperture"
+        ):
+            analysis.IncoherentIrradiance(optic_no_ap, num_rays=5, res=(5, 5))
 
     @patch("matplotlib.pyplot.show")
-    @patch("builtins.print") 
-    def test_px_size_overrides_res_warning(self, mock_print, mock_show, set_test_backend, test_system_irradiance_v1):
+    @patch("builtins.print")
+    def test_px_size_overrides_res_warning(
+        self, mock_print, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
         # Detector aperture is 5mm x 5mm. px_size of (1.0, 1.0) should result in 5x5 pixels.
         # res of (10,10) should be ignored and a warning printed.
-        irr = analysis.IncoherentIrradiance(optic_sys, res=(10,10), px_size=(1.0, 1.0), num_rays=10)
+        irr = analysis.IncoherentIrradiance(
+            optic_sys, res=(10, 10), px_size=(1.0, 1.0), num_rays=10
+        )
         irr_map_be, x_edges, y_edges = irr.irr_data[0][0]
 
         # Check that the effective resolution is 5x5
         assert irr_map_be.shape == (5, 5)
-        assert len(x_edges) == 5 + 1 # x_edges has N+1 elements for N pixels
+        assert len(x_edges) == 5 + 1  # x_edges has N+1 elements for N pixels
         assert len(y_edges) == 5 + 1
 
         # Check that the warning was printed
-        mock_print.assert_any_call("[IncoherentIrradiance] Warning: res parameter ignored - derived from px_size instead → (5,5) pixels")
+        mock_print.assert_any_call(
+            "[IncoherentIrradiance] Warning: res parameter ignored - derived from px_size instead → (5,5) pixels"
+        )
         irr.view()
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_view_options(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_view_options(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
-        irr = analysis.IncoherentIrradiance(optic_sys, num_rays=10, res=(10,10))
+        irr = analysis.IncoherentIrradiance(optic_sys, num_rays=10, res=(10, 10))
 
         # Test with different cmap and normalize=False
         irr.view(cmap="viridis", normalize=False)
         mock_show.assert_called_once()
         plt.close()
-        mock_show.reset_mock() 
+        mock_show.reset_mock()
 
         # Test with cross-section, normalize=True, and different cmap
-        irr.view(cross_section=('cross-x', 0), normalize=True, cmap="magma")
+        irr.view(cross_section=("cross-x", 0), normalize=True, cmap="magma")
         mock_show.assert_called_once()
         plt.close()
 
     @patch("matplotlib.pyplot.show")
     @patch("builtins.print")
-    def test_irradiance_cross_section_invalid_slice(self, mock_print, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_irradiance_cross_section_invalid_slice(
+        self, mock_print, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
-        res_val = (5,5)
+        res_val = (5, 5)
         irr = analysis.IncoherentIrradiance(optic_sys, num_rays=10, res=res_val)
 
         # Invalid slice index for cross-x
-        irr.view(cross_section=('cross-x', res_val[0] + 5)) # Index out of bounds
-        mock_print.assert_any_call(f"[IncoherentIrradiance] Warning: X-slice index {res_val[0]+5} is out of bounds for map shape {(res_val[0],res_val[1])}. Skipping plot.")
-        
+        irr.view(cross_section=("cross-x", res_val[0] + 5))  # Index out of bounds
+        mock_print.assert_any_call(
+            f"[IncoherentIrradiance] Warning: X-slice index {res_val[0]+5} is out of bounds for map shape {(res_val[0],res_val[1])}. Skipping plot."
+        )
+
         # Invalid slice index for cross-y
-        irr.view(cross_section=('cross-y', res_val[1] + 5)) # Index out of bounds
-        mock_print.assert_any_call(f"[IncoherentIrradiance] Warning: Y-slice index {res_val[1]+5} is out of bounds for map shape {(res_val[0],res_val[1])}. Skipping plot.")
+        irr.view(cross_section=("cross-y", res_val[1] + 5))  # Index out of bounds
+        mock_print.assert_any_call(
+            f"[IncoherentIrradiance] Warning: Y-slice index {res_val[1]+5} is out of bounds for map shape {(res_val[0],res_val[1])}. Skipping plot."
+        )
 
         # Invalid cross_section_info format (not tuple)
         irr.view(cross_section="invalid")
-        mock_print.assert_any_call("[IncoherentIrradiance] Warning: Invalid cross_section_info type. Expected tuple. Defaulting to 2D plot.")
+        mock_print.assert_any_call(
+            "[IncoherentIrradiance] Warning: Invalid cross_section_info type. Expected tuple. Defaulting to 2D plot."
+        )
         # Invalid cross_section_info format (tuple wrong length)
-        irr.view(cross_section=('cross-x',))
-        mock_print.assert_any_call("[IncoherentIrradiance] Warning: Invalid cross_section_info type. Expected tuple. Defaulting to 2D plot.")
-         # Invalid cross_section_info format (tuple wrong types)
-        irr.view(cross_section=(123, 'cross-y'))
-        mock_print.assert_any_call("[IncoherentIrradiance] Warning: Invalid cross_section_info format. Expected ('cross-x' or 'cross-y', int). Defaulting to 2D plot.")
-        plt.close('all')
-
+        irr.view(cross_section=("cross-x",))
+        mock_print.assert_any_call(
+            "[IncoherentIrradiance] Warning: Invalid cross_section_info type. Expected tuple. Defaulting to 2D plot."
+        )
+        # Invalid cross_section_info format (tuple wrong types)
+        irr.view(cross_section=(123, "cross-y"))
+        mock_print.assert_any_call(
+            "[IncoherentIrradiance] Warning: Invalid cross_section_info format. Expected ('cross-x' or 'cross-y', int). Defaulting to 2D plot."
+        )
+        plt.close("all")
 
     @patch("matplotlib.pyplot.show")
-    def test_irradiance_view_no_data(self, mock_show, capsys, set_test_backend, test_system_irradiance_v1):
-        irr = analysis.IncoherentIrradiance(test_system_irradiance_v1, num_rays=1, res=(2,2)) # Minimal rays to get some data
-        irr.irr_data = [] # Force no data
+    def test_irradiance_view_no_data(
+        self, mock_show, capsys, set_test_backend, test_system_irradiance_v1
+    ):
+        irr = analysis.IncoherentIrradiance(
+            test_system_irradiance_v1, num_rays=1, res=(2, 2)
+        )  # Minimal rays to get some data
+        irr.irr_data = []  # Force no data
         irr.view()
         captured = capsys.readouterr()
         assert "No irradiance data to display." in captured.out
@@ -1077,40 +1212,60 @@ class TestIncoherentIrradiance:
         irr.irr_data = [[]]
         irr.view()
         captured = capsys.readouterr()
-        assert "Warning: Field block 0 is empty." in captured.out or "No valid irradiance map data found to plot." in captured.out
+        assert (
+            "Warning: Field block 0 is empty." in captured.out
+            or "No valid irradiance map data found to plot." in captured.out
+        )
         plt.close()
 
         # Test with None entry in field block
         irr.irr_data = [[None]]
         irr.view()
         captured = capsys.readouterr()
-        assert "Warning: Entry 0 in field block 0 is None." in captured.out or "No valid irradiance map data found to plot." in captured.out
+        assert (
+            "Warning: Entry 0 in field block 0 is None." in captured.out
+            or "No valid irradiance map data found to plot." in captured.out
+        )
         plt.close()
 
         # Test with None irradiance map in entry
-        dummy_edges = be.array([0.0,1.0]) 
+        dummy_edges = be.array([0.0, 1.0])
         irr.irr_data = [[(None, dummy_edges, dummy_edges)]]
         irr.view()
         captured = capsys.readouterr()
-        assert "Warning: Irradiance map in entry 0, field block 0 is None." in captured.out or "No valid irradiance map data found to plot." in captured.out
+        assert (
+            "Warning: Irradiance map in entry 0, field block 0 is None." in captured.out
+            or "No valid irradiance map data found to plot." in captured.out
+        )
         plt.close()
 
     @patch("matplotlib.pyplot.show")
-    def test_vmin_vmax_equal_case(self, mock_show, set_test_backend, test_system_irradiance_v1):
+    def test_vmin_vmax_equal_case(
+        self, mock_show, set_test_backend, test_system_irradiance_v1
+    ):
         optic_sys = test_system_irradiance_v1
         num_rays = 10
         user_rays = RealRays(
-            x=be.full((num_rays,), 0.0), y=be.full((num_rays,), 0.0), z=be.zeros((num_rays,)),
-            L=be.zeros((num_rays,)), M=be.zeros((num_rays,)), N=be.ones((num_rays,)),
-            intensity=be.ones((num_rays,)), wavelength=be.full((num_rays,), 0.55)
+            x=be.full((num_rays,), 0.0),
+            y=be.full((num_rays,), 0.0),
+            z=be.zeros((num_rays,)),
+            L=be.zeros((num_rays,)),
+            M=be.zeros((num_rays,)),
+            N=be.ones((num_rays,)),
+            intensity=be.ones((num_rays,)),
+            wavelength=be.full((num_rays,), 0.55),
         )
-        res_tuple = (5,5)
-        irr = analysis.IncoherentIrradiance(optic_sys, res=res_tuple, user_initial_rays=user_rays)
-        dummy_edges = np.array([-2.5, -1.5, -0.5,  0.5,  1.5,  2.5]) # numpy array for dummy edges
+        res_tuple = (5, 5)
+        irr = analysis.IncoherentIrradiance(
+            optic_sys, res=res_tuple, user_initial_rays=user_rays
+        )
+        dummy_edges = np.array(
+            [-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]
+        )  # numpy array for dummy edges
 
         # Case 1: All pixels have same non-zero irradiance
         irr.irr_data = [[(be.full(res_tuple, 10.0), dummy_edges, dummy_edges)]]
-        irr.view(normalize=False) # Test the vmin=vmax branch in plotting
+        irr.view(normalize=False)  # Test the vmin=vmax branch in plotting
         mock_show.assert_called_once()
         plt.close()
         mock_show.reset_mock()
@@ -1128,33 +1283,53 @@ class TestIncoherentIrradiance:
         mock_show.assert_called_once()
         plt.close()
 
-    def test_peak_irradiance_empty_data(self, set_test_backend, test_system_irradiance_v1):
-        irr = analysis.IncoherentIrradiance(test_system_irradiance_v1, num_rays=1, res=(2,2))
+    def test_peak_irradiance_empty_data(
+        self, set_test_backend, test_system_irradiance_v1
+    ):
+        irr = analysis.IncoherentIrradiance(
+            test_system_irradiance_v1, num_rays=1, res=(2, 2)
+        )
         irr.irr_data = []
         assert irr.peak_irradiance() == []
 
         irr.irr_data = [[]]
         assert irr.peak_irradiance() == [[]]
 
-        dummy_edges = be.array([0., 1.]) # numpy array for dummy edges
+        dummy_edges = be.array([0.0, 1.0])  # numpy array for dummy edges
         # Ensure float values for irradiance maps for consistent type with backend
-        irr.irr_data = [[(be.array([[1.0,2.0],[3.0,4.0]]), dummy_edges, dummy_edges), 
-                         (be.array([[5.0,6.0],[7.0,8.0]]), dummy_edges, dummy_edges)]]
-        peaks = irr.peak_irradiance() # list of lists of backend scalars
-        assert_allclose(peaks[0][0], be.array(4.0)) # Compare backend scalar with backend scalar
+        irr.irr_data = [
+            [
+                (be.array([[1.0, 2.0], [3.0, 4.0]]), dummy_edges, dummy_edges),
+                (be.array([[5.0, 6.0], [7.0, 8.0]]), dummy_edges, dummy_edges),
+            ]
+        ]
+        peaks = irr.peak_irradiance()  # list of lists of backend scalars
+        assert_allclose(
+            peaks[0][0], be.array(4.0)
+        )  # Compare backend scalar with backend scalar
         assert_allclose(peaks[0][1], be.array(8.0))
 
 
-def test_incoherent_irradiance_initialization(set_test_backend, test_system_irradiance_v1):
+def test_incoherent_irradiance_initialization(
+    set_test_backend, test_system_irradiance_v1
+):
     optic = test_system_irradiance_v1
-    irr = analysis.IncoherentIrradiance(optic, num_rays=10, res=(64, 64), px_size=(0.1, 0.1),
-                               detector_surface=-1, fields="all", wavelengths="all",
-                               distribution="random", user_initial_rays=None)
+    irr = analysis.IncoherentIrradiance(
+        optic,
+        num_rays=10,
+        res=(64, 64),
+        px_size=(0.1, 0.1),
+        detector_surface=-1,
+        fields="all",
+        wavelengths="all",
+        distribution="random",
+        user_initial_rays=None,
+    )
     assert irr.optic == optic
     assert irr.num_rays == 10
     # npix_x/y get overridden by px_size if px_size implies a different resolution
     # Detector is 5mm wide. 0.1mm pixels -> 50 pixels.
-    assert irr.npix_x == 50 
+    assert irr.npix_x == 50
     assert irr.npix_y == 50
     assert irr.px_size == (0.1, 0.1)
     assert irr.detector_surface == -1
@@ -1164,32 +1339,51 @@ def test_incoherent_irradiance_initialization(set_test_backend, test_system_irra
     assert len(irr.irr_data) == len(optic.fields.get_field_coords())
     assert len(irr.irr_data[0]) == len(optic.wavelengths.get_wavelengths())
 
+
 @patch("matplotlib.pyplot.show")
-def test_view_normalize_true_peak_zero(mock_show, set_test_backend, test_system_irradiance_v1):
+def test_view_normalize_true_peak_zero(
+    mock_show, set_test_backend, test_system_irradiance_v1
+):
     optic = test_system_irradiance_v1
-    irr = analysis.IncoherentIrradiance(optic, num_rays=1, res=(5,5))
-    dummy_edges = np.array([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]) # numpy array for dummy
-    irr.irr_data = [[(be.zeros((5,5)), dummy_edges, dummy_edges)]] # All zero irradiance map
-    
-    irr.view(normalize=True) # Should handle peak_val = 0
+    irr = analysis.IncoherentIrradiance(optic, num_rays=1, res=(5, 5))
+    dummy_edges = np.array([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5])  # numpy array for dummy
+    irr.irr_data = [
+        [(be.zeros((5, 5)), dummy_edges, dummy_edges)]
+    ]  # All zero irradiance map
+
+    irr.view(normalize=True)  # Should handle peak_val = 0
     mock_show.assert_called_once()
     plt.close()
 
+
 @patch("matplotlib.pyplot.show")
 @patch("builtins.print")
-def test_cross_section_plot_helper_out_of_bounds(mock_print, mock_show, set_test_backend, test_system_irradiance_v1):
+def test_cross_section_plot_helper_out_of_bounds(
+    mock_print, mock_show, set_test_backend, test_system_irradiance_v1
+):
     optic = test_system_irradiance_v1
-    irr = analysis.IncoherentIrradiance(optic, num_rays=5, res=(5,5))
-    irr_map_be, x_edges, y_edges = irr.irr_data[0][0] # x_edges, y_edges are numpy arrays
+    irr = analysis.IncoherentIrradiance(optic, num_rays=5, res=(5, 5))
+    irr_map_be, x_edges, y_edges = irr.irr_data[0][
+        0
+    ]  # x_edges, y_edges are numpy arrays
 
     # Test cross-x out of bounds
-    irr._plot_cross_section(irr_map_be, x_edges, y_edges, 'cross-x', 10, (6,5), "Test", True)
-    mock_print.assert_any_call("[IncoherentIrradiance] Warning: X-slice index 10 is out of bounds for map shape (5, 5). Skipping plot.")
-    
+    irr._plot_cross_section(
+        irr_map_be, x_edges, y_edges, "cross-x", 10, (6, 5), "Test", True
+    )
+    mock_print.assert_any_call(
+        "[IncoherentIrradiance] Warning: X-slice index 10 is out of bounds for map shape (5, 5). Skipping plot."
+    )
+
     # Test cross-y out of bounds
-    irr._plot_cross_section(irr_map_be, x_edges, y_edges, 'cross-y', 10, (6,5), "Test", True)
-    mock_print.assert_any_call("[IncoherentIrradiance] Warning: Y-slice index 10 is out of bounds for map shape (5, 5). Skipping plot.")
+    irr._plot_cross_section(
+        irr_map_be, x_edges, y_edges, "cross-y", 10, (6, 5), "Test", True
+    )
+    mock_print.assert_any_call(
+        "[IncoherentIrradiance] Warning: Y-slice index 10 is out of bounds for map shape (5, 5). Skipping plot."
+    )
 
     # Test invalid axis type
-    irr._plot_cross_section(irr_map_be, x_edges, y_edges, 'invalid-axis', 0, (6,5), "Test", True)
-    
+    irr._plot_cross_section(
+        irr_map_be, x_edges, y_edges, "invalid-axis", 0, (6, 5), "Test", True
+    )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -7,7 +7,7 @@ import optiland.backend as be
 import pytest
 
 from optiland import analysis
-from optiland.analysis.spot_diagram import SpotData  # Add this import
+from optiland.analysis.spot_diagram import SpotData
 from optiland.optic import Optic
 from optiland.samples.objectives import CookeTriplet, TripletTelescopeObjective
 from optiland.physical_apertures import RectangularAperture


### PR DESCRIPTION
- Refactor SpotDiagram class to use a `SpotData` dataclass to hold spot diagram data
- Updates to corresponding classes relying on SpotDiagram
- Testing updates after refactor 