### PR TITLE
Improvement on LeastSquares Optimization

### DIFF
--- a/optiland/optimization/optimization.py
+++ b/optiland/optimization/optimization.py
@@ -316,7 +316,7 @@ class LeastSquares(OptimizerGeneric):
             return be.to_numpy(be.full(num_operands, error_value))
 
     def optimize(
-        self, max_nfev=None, disp=False, tol=1e-3, method_choice="lm"
+        self, maxiter=None, disp=False, tol=1e-3, method_choice="lm"
     ):  # Default to 'lm' for DLS
         """
         Optimize the problem using a SciPy least squares method.
@@ -384,7 +384,7 @@ class LeastSquares(OptimizerGeneric):
                 x0_numpy,
                 method=method_choice,
                 bounds=actual_bounds_for_scipy,
-                max_nfev=max_nfev,
+                max_nfev=maxiter,
                 verbose=scipy_verbose_level,
                 ftol=tol,
             )

--- a/optiland/optimization/optimization.py
+++ b/optiland/optimization/optimization.py
@@ -441,6 +441,12 @@ class DualAnnealing(OptimizerGeneric):
                 x0=x0_numpy,
                 callback=callback,
             )
+            
+        for idvar, var in enumerate(self.problem.variables):
+            var.update(result.x[idvar]) 
+
+        self.problem.update_optics()    
+            
         return result
 
 
@@ -508,6 +514,12 @@ class DifferentialEvolution(OptimizerGeneric):
                 workers=workers,
                 callback=callback,
             )
+            
+        for idvar, var in enumerate(self.problem.variables):
+            var.update(result.x[idvar]) 
+
+        self.problem.update_optics() 
+            
         return result
 
 
@@ -566,6 +578,12 @@ class SHGO(OptimizerGeneric):
                 callback=callback,
                 **kwargs,
             )
+            
+        for idvar, var in enumerate(self.problem.variables):
+            var.update(result.x[idvar]) 
+
+        self.problem.update_optics()  
+            
         return result
 
 
@@ -628,4 +646,10 @@ class BasinHopping(OptimizerGeneric):
                 callback=callback,
                 **kwargs,
             )
+            
+        for idvar, var in enumerate(self.problem.variables):
+            var.update(result.x[idvar]) 
+
+        self.problem.update_optics() 
+            
         return result


### PR DESCRIPTION
Refactor(optim): Optimize LeastSquares with dedicated residuals vector method

Refactored the `LeastSquares` optimizer to use its own internal
`_compute_residuals_vector` method. This method is responsible for:
1. Updating Optiland problem variables from SciPy's current iteration.
2. Updating the optical system (e.g., for pickups, solves).
3. Computing the vector of weighted residuals (`[op.fun() for op in problem.operands]`).
4. Handling potential NaNs or exceptions by returning a high-penalty error vector.
5. Ensuring the final output is a NumPy array, as required by `scipy.optimize.least_squares`.

`LeastSquares` manages its residuals calculation directly. This is done to address observed performance
degradations from alternative refactorings where the residuals vector
calculation was more deeply integrated into the `OptimizerGeneric`'s primary
scalar evaluation path (`_fun`).

The `OptimizerGeneric._fun` method remains optimized for scalar optimizers,
calculating the sum-of-squares directly without an intermediate vector step,
thus preserving their performance. `LeastSquares` now uses its own efficient
path for vector-based optimization.