### PR TITLE
Feature / add_wavelengths

### DIFF
--- a/optiland/backend/torch_backend.py
+++ b/optiland/backend/torch_backend.py
@@ -160,6 +160,30 @@ def linspace(start, stop, num=50):
     )
 
 
+def arange(*args, step=1):
+    if len(args) == 1:
+        start = 0
+        end = args[0]
+    elif len(args) == 2:
+        start, end = args
+
+    if isinstance(start, torch.Tensor):
+        start = start.item()
+    if isinstance(end, torch.Tensor):
+        end = end.item()
+    if isinstance(step, torch.Tensor):
+        step = step.item()
+
+    return torch.arange(
+        start,
+        end,
+        step,
+        device=get_device(),
+        dtype=get_precision(),
+        requires_grad=grad_mode.requires_grad,
+    )
+
+
 def zeros_like(x):
     return torch.zeros_like(
         array(x),
@@ -311,6 +335,14 @@ def cos(x):
 
 def exp(x):
     return torch.exp(array(x))
+
+
+def log2(x):
+    return torch.log2(array(x))
+
+
+def abs(x):
+    return torch.abs(array(x))
 
 
 def radians(x):
@@ -574,6 +606,7 @@ __all__ = [
     "ones",
     "full",
     "linspace",
+    "arange",
     "zeros_like",
     "ones_like",
     "full_like",
@@ -603,6 +636,8 @@ __all__ = [
     "sin",
     "cos",
     "exp",
+    "log2",
+    "abs",
     "radians",
     "deg2rad",
     "max",

--- a/optiland/wavelength.py
+++ b/optiland/wavelength.py
@@ -10,6 +10,8 @@ with multiple wavelengths simultaneously.
 Kramer Harrison, 2024
 """
 
+import optiland.backend as be
+
 
 class Wavelength:
     """Represents a wavelength value with support for unit conversion.
@@ -211,3 +213,84 @@ class WavelengthGroup:
             new_group.add_wavelength(**wave_data)
 
         return new_group
+
+
+def add_wavelengths(
+    wavelength_group,
+    min_value,
+    max_value,
+    num_wavelengths,
+    unit="um",
+    *,
+    sampling="chebyshev",
+    scale="log",
+):
+    """Add new wavelengths corresponding to the geometrically-spaced Chebyshev nodes
+
+    Args:
+        min_value (float): Minimum wavelength value.
+        max_value (float): Maximum wavelength value.
+        num_wavelengths (int) : The number of wavelengths to be added.
+            Has to be an odd integer.
+        unit (str, optional): The unit of the wavelength. Default is 'um'.
+        sampling (str, optional): The sampling algorithm used. Defaults to 'chebyshev'.
+            Currently supported options are:
+                'chebyshev' - chebyshev nodes of the first type
+                'uniform' - uniformly spaced nodes across the specified range
+        scale (str, optional): space in which the nodes are sampled. Defaults to 'log'.
+            Currently supported options are:
+                'log' - nodes are sampled in the logarithms of wavelength.
+                'frequency' - nodes sampled in the frequency domain.
+                'wavelength' - nodes sampled in the frequency domain. Not recommended.
+
+
+    """
+    if (
+        not isinstance(num_wavelengths, int)
+        or num_wavelengths % 2 == 0
+        or num_wavelengths <= 0
+    ):
+        raise ValueError("num_wavelengths must be an odd positive integer")
+
+    if min_value <= 0 or max_value <= 0:
+        raise ValueError("min_value and max_value must be positive")
+
+    scale = scale.lower()
+    if scale in {"freq", "frequency"}:
+        scale = "frequency"
+    elif scale in {"wavelength"}:
+        scale = "wavelength"
+    elif scale in {"log", "logarithmic"}:
+        scale = "log"
+    else:
+        raise ValueError(f"Unknown scale: {scale!r}")
+
+    if scale == "frequency":
+        power = -1.0
+    elif scale == "wavelength":
+        power = 1.0
+
+    nodes = be.arange(1.0, num_wavelengths + 1.0)
+
+    if sampling == "chebyshev":
+        nodes = 0.5 * (1.0 - be.cos((2 * nodes - 1) * be.pi / (2 * num_wavelengths)))
+
+    elif sampling == "uniform":
+        nodes = (nodes - 0.5) / num_wavelengths
+
+    if scale == "log":
+        span = be.log2(max_value / min_value)
+        for i, node in enumerate(nodes):
+            is_primary = i == num_wavelengths // 2
+            value = min_value * 2 ** (span * node)
+            wavelength_group.wavelengths.append(Wavelength(value, is_primary, unit))
+    else:
+        min_value = min_value**power
+        max_value = max_value**power
+        span = max_value - min_value
+        for i, node in enumerate(nodes):
+            is_primary = i == num_wavelengths // 2
+            value = min_value + (span * node)
+            wavelength_group.wavelengths.append(
+                Wavelength(value ** (1.0 / power), is_primary, unit)
+            )


### PR DESCRIPTION
Here is the implementation of the "add_wavelengths" functionality which finally doesn't seem to violate any of the developer guidlines (or at least I hope so).

One issue I have with it is the overconstrained default method, although I'm not able to find anything remotely correct with less constraints than that.

As for now the default combination of arguments should select the wavelengths approximately optimizing maximum of the merit function if;

1. The merit function is approximately a linear function of dispersion
2. The [Cautchy's equation](https://en.wikipedia.org/wiki/Cauchy%27s_equation) truncated to two terms accurately 
3. The weights corresponding to all wavelengths are equal

Or at least that's the case if my reasoning isn't incorrect (and it definitely may be).

While I'm not sure if the proposed method is correct it seems to consistently outperform the default 'Gaussian quadrature' spacing in the Zemax OpticStudio.

Here are example values for 102 mm f/6 'Frauhoffer' doublet (S-FPL55 + N-KZFS2 glass), optimized for RMS across 400-800 nm range - for both results the designs were performing the worst at the edges of intervals.

> add_wavelengths with default settings for 5 wavelengths;
>     400 nm - 10.185 µm RMS, 28.049 µm geometric radious
>     800 nm - 9.375 µm RMS, 14.752 µm geometric radious

    

> Zemax's 'gaussian quadrature' (6 wavelengths, as the number has to be even);
>     400 nm - 17.012 µm RMS, 42.515 µm geometric radious
>     800 nm - 7.141 µm RMS, 10.748 µm GEO

    
    
Generally it seems to behave as expected with resulting RMS being slightly higher at the longer wavelength edge of the spectrum (as a result of higher-order terms), however the results seem to consistently fall pretty close to each other. The difference between geometric radii here is a result of spherochromatism and it doesn't concern me too much (if optimized for geometric spot size result is comparable GEO, but significant RMS discrepancy).