### PR TITLE
Fix/surface creation order

### DIFF
--- a/optiland/surfaces/factories/coordinate_system_factory.py
+++ b/optiland/surfaces/factories/coordinate_system_factory.py
@@ -20,7 +20,6 @@ class CoordinateSystemFactory:
 
     def __init__(self, surface_factory):
         self.surface_factory = surface_factory
-        self.last_thickness = 0
 
     def create(self, index, surface_group, **kwargs):
         """Creates and returns a CoordinateSystem instance.
@@ -75,12 +74,10 @@ class CoordinateSystemFactory:
             elif index == 1:
                 z = 0  # first surface, always at zero
             else:
-                z = (
-                    float(surface_group.positions[index - 1].item())
-                    + self.surface_factory.last_thickness
-                )
-
-                self.last_thickness = thickness
+                prev_surface = surface_group.surfaces[index - 1]
+                z_prev_surface = prev_surface.geometry.cs.z
+                thickness_after_prev_surface = prev_surface.thickness
+                z = z_prev_surface + thickness_after_prev_surface
 
         rx = kwargs.get("rx", 0)
         ry = kwargs.get("ry", 0)

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -109,6 +109,8 @@ class SurfaceFactory:
             if surface_type == "paraxial":
                 raise ValueError("Paraxial surface cannot be the object surface.")
             surface_obj = ObjectSurface(geometry, material_post, comment)
+            surface_obj.thickness = kwargs.get("thickness", 0.0)
+            return surface_obj
 
         # Create the appropriate surface type
         if surface_type == "paraxial":
@@ -123,18 +125,19 @@ class SurfaceFactory:
                 surface_type=surface_type,
                 aperture=kwargs.get("aperture"),
             )
-        else:  # standard surface
-            surface_obj = Surface(
-                geometry,
-                material_pre,
-                material_post,
-                is_stop,
-                is_reflective=is_reflective,
-                coating=coating,
-                surface_type=surface_type,
-                comment=comment,
-                aperture=kwargs.get("aperture"),
-            )
+
+        # Standard surface - `surface_type` indicates geometrical shape of surface
+        surface_obj = Surface(
+            geometry,
+            material_pre,
+            material_post,
+            is_stop,
+            is_reflective=is_reflective,
+            coating=coating,
+            surface_type=surface_type,
+            comment=comment,
+            aperture=kwargs.get("aperture"),
+        )
 
         # Add the thickness as an attribute to the surface
         surface_obj.thickness = kwargs.get("thickness", 0.0)

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -125,6 +125,8 @@ class SurfaceFactory:
                 surface_type=surface_type,
                 aperture=kwargs.get("aperture"),
             )
+            surface_obj.thickness = kwargs.get("thickness", 0.0)
+            return surface_obj
 
         # Standard surface - `surface_type` indicates geometrical shape of surface
         surface_obj = Surface(
@@ -141,5 +143,4 @@ class SurfaceFactory:
 
         # Add the thickness as an attribute to the surface
         surface_obj.thickness = kwargs.get("thickness", 0.0)
-
         return surface_obj

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -110,8 +110,6 @@ class SurfaceFactory:
                 raise ValueError("Paraxial surface cannot be the object surface.")
             surface_obj = ObjectSurface(geometry, material_post, comment)
 
-        common_params = {"aperture": kwargs.get("aperture")}
-
         # Create the appropriate surface type
         if surface_type == "paraxial":
             surface_obj = ParaxialSurface(
@@ -123,20 +121,20 @@ class SurfaceFactory:
                 is_reflective=is_reflective,
                 coating=coating,
                 surface_type=surface_type,
-                **common_params,
+                aperture=kwargs.get("aperture"),
             )
-
-        surface_obj = Surface(
-            geometry,
-            material_pre,
-            material_post,
-            is_stop,
-            is_reflective=is_reflective,
-            coating=coating,
-            surface_type=surface_type,
-            comment=comment,
-            **common_params,
-        )
+        else:  # standard surface
+            surface_obj = Surface(
+                geometry,
+                material_pre,
+                material_post,
+                is_stop,
+                is_reflective=is_reflective,
+                coating=coating,
+                surface_type=surface_type,
+                comment=comment,
+                aperture=kwargs.get("aperture"),
+            )
 
         # Add the thickness as an attribute to the surface
         surface_obj.thickness = kwargs.get("thickness", 0.0)

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -64,7 +64,7 @@ class SurfaceFactory:
             ValueError: If the index is greater than the number of surfaces.
         """
         if index > self._surface_group.num_surfaces:
-            raise ValueError("Surface index cannot be greater than number of surfaces.")
+            raise IndexError("Surface index cannot be greater than number of surfaces.")
 
         # Build coordinate system
         coordinate_system = self._coordinate_factory.create(

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -108,13 +108,13 @@ class SurfaceFactory:
         if index == 0:
             if surface_type == "paraxial":
                 raise ValueError("Paraxial surface cannot be the object surface.")
-            return ObjectSurface(geometry, material_post, comment)
+            surface_obj = ObjectSurface(geometry, material_post, comment)
 
         common_params = {"aperture": kwargs.get("aperture")}
 
         # Create the appropriate surface type
         if surface_type == "paraxial":
-            return ParaxialSurface(
+            surface_obj = ParaxialSurface(
                 kwargs["f"],
                 geometry,
                 material_pre,
@@ -126,7 +126,7 @@ class SurfaceFactory:
                 **common_params,
             )
 
-        return Surface(
+        surface_obj = Surface(
             geometry,
             material_pre,
             material_post,
@@ -137,3 +137,8 @@ class SurfaceFactory:
             comment=comment,
             **common_params,
         )
+
+        # Add the thickness as an attribute to the surface
+        surface_obj.thickness = kwargs.get("thickness", 0.0)
+
+        return surface_obj

--- a/optiland/surfaces/standard_surface.py
+++ b/optiland/surfaces/standard_surface.py
@@ -65,6 +65,8 @@ class Surface:
         self.surface_type = surface_type
         self.comment = comment
 
+        self.thickness = 0.0  # used for surface positioning
+
         self.reset()
 
     def __init_subclass__(cls, **kwargs):

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -267,6 +267,12 @@ class SurfaceGroup:
 
             self.surfaces.insert(index, new_surface)
 
+            # If a surface was inserted (not appended) and there's a surface after it
+            if index < len(self.surfaces) - 1:
+                surface_after_inserted = self.surfaces[index + 1]
+                new_surface = self.surfaces[index]
+                surface_after_inserted.material_pre = new_surface.material_post
+
             # Update coordinate systems if surface was inserted
             if not self.surface_factory.use_absolute_cs and index < (
                 len(self.surfaces) - 1

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -237,8 +237,6 @@ class SurfaceGroup:
             ValueError: If index is not provided when defining a new surface.
 
         """
-        update_start_index = -1
-
         if new_surface is None:
             if index is None:
                 raise ValueError("Must define index when defining surface.")
@@ -257,17 +255,10 @@ class SurfaceGroup:
                 surface.is_stop = False
 
         if index is None:
-            # This case means new_surface was provided directly, and no index was given.
-            # This implies appending the surface.
             self.surfaces.append(new_surface)
-            # When appending, the new surface is last. No update to subsequent surfaces is needed
-            # as there are none. Its own CS is assumed correct or absolute by the caller.
         else:
-            # An index was provided (either for surface creation or for a given new_surface).
             if index < 0:
                 raise IndexError(f"Index {index} cannot be negative.")
-            # Check against current length *before* insertion for valid insertion points.
-            # index == len(self.surfaces) means append.
             if index > len(self.surfaces):
                 raise IndexError(
                     f"Index {index} is out of bounds for insertion. "
@@ -276,13 +267,7 @@ class SurfaceGroup:
 
             self.surfaces.insert(index, new_surface)
 
-            # After insertion, if not using absolute_cs, and the inserted surface
-            # is NOT the new last surface, then update coordinate systems
-            # starting from the inserted surface's index.
-            # _update_coordinate_systems will correctly handle its own CS based on the
-            # preceding surface (if index > 0) or set it to 0 (if index == 1 and it's the first optical surface),
-            # and then update all subsequent surfaces.
-            # If the inserted surface IS the new object surface (index == 0), its CS is not modified by _update_coordinate_systems.
+            # Update coordinate systems if surface was inserted
             if not self.surface_factory.use_absolute_cs and index < (
                 len(self.surfaces) - 1
             ):

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -384,21 +384,25 @@ class SurfaceGroup:
             return
 
         for i in range(effective_start_index, len(self.surfaces)):
-            if i == 0:
-                continue
-
             current_surface = self.surfaces[i]
-            prev_surface = self.surfaces[i - 1]
-            thickness = prev_surface.thickness
 
-            if hasattr(thickness, "item"):
-                thickness = thickness.item()
+            if i == 0:  # no update to object surface
+                continue
+            elif i == 1:  # first surface lies at z=0.0 by definition
+                new_z = 0.0
+            else:
+                prev_surface = self.surfaces[i - 1]
+                thickness = prev_surface.thickness
 
-            if be.isinf(thickness):
-                raise ValueError(
-                    f"Coordinate system update failed due to infinite "
-                    f"thickness at surface {start_index - 1}"
-                )
+                if hasattr(thickness, "item"):
+                    thickness = thickness.item()
 
-            new_z = prev_surface.geometry.cs.z + thickness
+                if be.isinf(thickness):
+                    raise ValueError(
+                        f"Coordinate system update failed due to infinite "
+                        f"thickness at surface {start_index - 1}"
+                    )
+
+                new_z = prev_surface.geometry.cs.z + thickness
+
             current_surface.geometry.cs.z = be.array(new_z)

--- a/optiland/surfaces/surface_group.py
+++ b/optiland/surfaces/surface_group.py
@@ -259,8 +259,6 @@ class SurfaceGroup:
         else:
             self.surfaces.insert(index, new_surface)
 
-        self.surface_factory.last_thickness = kwargs.get("thickness", 0)
-
     def remove_surface(self, index):
         """Remove a surface from the list of surfaces.
 

--- a/optiland/tests/geometries/test_flip_geometries.py
+++ b/optiland/tests/geometries/test_flip_geometries.py
@@ -16,6 +16,7 @@ from optiland.geometries import (
 # Default coordinate system for tests
 cs = CoordinateSystem()
 
+
 def test_flip_standard_geometry():
     # Test StandardGeometry
     initial_radius = 10.0
@@ -32,14 +33,16 @@ def test_flip_standard_geometry():
     assert geom.radius == -initial_radius
     assert geom.k == initial_conic
 
+
 def test_flip_plane_geometry():
     # Test Plane
     geom = Plane(cs)
-    initial_radius = geom.radius # Should be be.inf
+    initial_radius = geom.radius  # Should be be.inf
 
     geom.flip()
 
-    assert geom.radius == initial_radius # be.inf should remain be.inf
+    assert geom.radius == initial_radius  # be.inf should remain be.inf
+
 
 def test_flip_biconic_geometry():
     # Test BiconicGeometry
@@ -47,7 +50,13 @@ def test_flip_biconic_geometry():
     initial_ry = -20.0
     initial_kx = 0.1
     initial_ky = -0.2
-    geom = BiconicGeometry(cs, radius_x=initial_rx, radius_y=initial_ry, conic_x=initial_kx, conic_y=initial_ky)
+    geom = BiconicGeometry(
+        cs,
+        radius_x=initial_rx,
+        radius_y=initial_ry,
+        conic_x=initial_kx,
+        conic_y=initial_ky,
+    )
 
     initial_cx_val = geom.cx
     initial_cy_val = geom.cy
@@ -66,11 +75,19 @@ def test_flip_biconic_geometry():
     assert be.allclose(geom.cx, -initial_cx_val if initial_rx != 0 else 0.0)
     assert be.allclose(geom.cy, -initial_cy_val if initial_ry != 0 else 0.0)
 
+
 def test_flip_chebyshev_geometry():
     initial_radius = 100.0
     initial_conic = -0.8
     initial_coeffs = [[0, 0.1], [0.2, 0.3]]
-    geom = ChebyshevPolynomialGeometry(cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs, norm_x=1.0, norm_y=1.0)
+    geom = ChebyshevPolynomialGeometry(
+        cs,
+        radius=initial_radius,
+        conic=initial_conic,
+        coefficients=initial_coeffs,
+        norm_x=1.0,
+        norm_y=1.0,
+    )
 
     assert geom.radius == initial_radius
     assert geom.k == initial_conic
@@ -81,12 +98,15 @@ def test_flip_chebyshev_geometry():
     assert geom.radius == -initial_radius
     assert geom.k == initial_conic
     assert be.allclose(geom.c, be.array(initial_coeffs))
+
 
 def test_flip_even_asphere_geometry():
     initial_radius = 50.0
     initial_conic = 0.0
-    initial_coeffs = [0.001, -0.0005] # C2, C4
-    geom = EvenAsphere(cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs)
+    initial_coeffs = [0.001, -0.0005]  # C2, C4
+    geom = EvenAsphere(
+        cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs
+    )
 
     assert geom.radius == initial_radius
     assert geom.k == initial_conic
@@ -97,6 +117,7 @@ def test_flip_even_asphere_geometry():
     assert geom.radius == -initial_radius
     assert geom.k == initial_conic
     assert geom.c == initial_coeffs
+
 
 def test_flip_odd_asphere_geometry():
     initial_radius = 75.0
@@ -104,11 +125,13 @@ def test_flip_odd_asphere_geometry():
     # Coefficients for OddAsphere are C_i * r^(i+1)
     # e.g., coefficients[0] is for C_1 * r^1, coefficients[1] for C_2 * r^2
     initial_coeffs = [0.01, 0.002]
-    geom = OddAsphere(cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs)
+    geom = OddAsphere(
+        cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs
+    )
 
     assert geom.radius == initial_radius
     assert geom.k == initial_conic
-    assert geom.c == initial_coeffs # In OddAsphere, self.c stores the coefficients
+    assert geom.c == initial_coeffs  # In OddAsphere, self.c stores the coefficients
 
     geom.flip()
 
@@ -116,18 +139,20 @@ def test_flip_odd_asphere_geometry():
     assert geom.k == initial_conic
     assert geom.c == initial_coeffs
 
+
 def test_flip_polynomial_geometry():
     initial_radius = 120.0
     initial_conic = 0.5
     # Ensure coefficients are structured as expected by PolynomialGeometry (list of lists or 2D array)
     initial_coeffs_list = [[0, 0.01, 0.02], [0.005, 0, 0]]
-    geom = PolynomialGeometry(cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs_list)
+    geom = PolynomialGeometry(
+        cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs_list
+    )
 
     assert geom.radius == initial_radius
     assert geom.k == initial_conic
     # PolynomialGeometry might convert to be.array internally, ensure comparison is robust
     assert be.allclose(geom.c, be.array(initial_coeffs_list))
-
 
     geom.flip()
 
@@ -141,7 +166,13 @@ def test_flip_toroidal_geometry():
     initial_r_yz = -100.0
     initial_k_yz = -0.7
     initial_coeffs_y = [0.0001, -0.00002]
-    geom = ToroidalGeometry(cs, radius_rotation=initial_r_rot, radius_yz=initial_r_yz, conic=initial_k_yz, coeffs_poly_y=initial_coeffs_y)
+    geom = ToroidalGeometry(
+        cs,
+        radius_rotation=initial_r_rot,
+        radius_yz=initial_r_yz,
+        conic=initial_k_yz,
+        coeffs_poly_y=initial_coeffs_y,
+    )
 
     initial_c_yz_val = geom.c_yz
     # NewtonRaphsonGeometry's radius is set to radius_rotation in Toroidal __init__
@@ -160,18 +191,27 @@ def test_flip_toroidal_geometry():
     assert geom.k_yz == initial_k_yz
     assert be.allclose(geom.coeffs_poly_y, be.array(initial_coeffs_y))
     # Handle comparison for c_yz which might be float or array
-    expected_c_yz = -initial_c_yz_val if initial_r_yz != 0 and be.isfinite(initial_r_yz) else 0.0
-    if hasattr(geom.c_yz, 'shape') or hasattr(expected_c_yz, 'shape'):
-         assert be.allclose(geom.c_yz, be.array(expected_c_yz))
+    expected_c_yz = (
+        -initial_c_yz_val if initial_r_yz != 0 and be.isfinite(initial_r_yz) else 0.0
+    )
+    if hasattr(geom.c_yz, "shape") or hasattr(expected_c_yz, "shape"):
+        assert be.allclose(geom.c_yz, be.array(expected_c_yz))
     else:
-         assert be.allclose(geom.c_yz, expected_c_yz)
-    assert geom.radius == -initial_base_radius # Check base radius also flipped
+        assert be.allclose(geom.c_yz, expected_c_yz)
+    assert geom.radius == -initial_base_radius  # Check base radius also flipped
+
 
 def test_flip_zernike_geometry():
     initial_radius = 300.0
     initial_conic = -0.2
-    initial_coeffs = [0, 0, 0.05, -0.03] # Z3, Z4 (indices 2, 3 in a 0-indexed list)
-    geom = ZernikePolynomialGeometry(cs, radius=initial_radius, conic=initial_conic, coefficients=initial_coeffs, norm_radius=10.0)
+    initial_coeffs = [0, 0, 0.05, -0.03]  # Z3, Z4 (indices 2, 3 in a 0-indexed list)
+    geom = ZernikePolynomialGeometry(
+        cs,
+        radius=initial_radius,
+        conic=initial_conic,
+        coefficients=initial_coeffs,
+        norm_radius=10.0,
+    )
 
     assert geom.radius == initial_radius
     assert geom.k == initial_conic
@@ -183,43 +223,50 @@ def test_flip_zernike_geometry():
     assert geom.k == initial_conic
     assert be.allclose(geom.c, be.array(initial_coeffs))
 
+
 def test_flip_biconic_zero_radius():
     geom = BiconicGeometry(cs, radius_x=0.0, radius_y=-20.0, conic_x=0.1, conic_y=-0.2)
-    initial_cx_val = geom.cx # Should be 0.0
+    initial_cx_val = geom.cx  # Should be 0.0
     initial_cy_val = geom.cy
     geom.flip()
-    assert geom.Rx == 0.0 # -0.0 is 0.0
+    assert geom.Rx == 0.0  # -0.0 is 0.0
     assert geom.Ry == 20.0
-    assert be.allclose(geom.cx, initial_cx_val) # cx should remain 0.0
+    assert be.allclose(geom.cx, initial_cx_val)  # cx should remain 0.0
     assert be.allclose(geom.cy, -initial_cy_val)
+
 
 def test_flip_toroidal_zero_radius():
     geom = ToroidalGeometry(cs, radius_rotation=0.0, radius_yz=-100.0, conic=-0.7)
     initial_c_yz_val = geom.c_yz
     geom.flip()
-    assert geom.R_rot == 0.0 # -0.0 is 0.0
+    assert geom.R_rot == 0.0  # -0.0 is 0.0
     assert geom.R_yz == 100.0
     expected_c_yz = -initial_c_yz_val if -100.0 != 0 and be.isfinite(-100.0) else 0.0
-    if hasattr(geom.c_yz, 'shape') or hasattr(expected_c_yz, 'shape'):
-         assert be.allclose(geom.c_yz, be.array(expected_c_yz))
+    if hasattr(geom.c_yz, "shape") or hasattr(expected_c_yz, "shape"):
+        assert be.allclose(geom.c_yz, be.array(expected_c_yz))
     else:
-         assert be.allclose(geom.c_yz, expected_c_yz)
-    assert geom.radius == 0.0 # Base radius also flipped (was 0.0, remains 0.0)
+        assert be.allclose(geom.c_yz, expected_c_yz)
+    assert geom.radius == 0.0  # Base radius also flipped (was 0.0, remains 0.0)
+
 
 def test_flip_standard_inf_radius():
     geom = StandardGeometry(cs, radius=be.inf, conic=0.0)
     geom.flip()
     assert geom.radius == -be.inf
 
+
 def test_flip_biconic_inf_radius():
-    geom = BiconicGeometry(cs, radius_x=be.inf, radius_y=-20.0, conic_x=0.1, conic_y=-0.2)
-    initial_cx_val = geom.cx # Should be 0.0
+    geom = BiconicGeometry(
+        cs, radius_x=be.inf, radius_y=-20.0, conic_x=0.1, conic_y=-0.2
+    )
+    initial_cx_val = geom.cx  # Should be 0.0
     initial_cy_val = geom.cy
     geom.flip()
     assert geom.Rx == -be.inf
     assert geom.Ry == 20.0
-    assert be.allclose(geom.cx, initial_cx_val) # cx should remain 0.0 as 1/inf is 0
+    assert be.allclose(geom.cx, initial_cx_val)  # cx should remain 0.0 as 1/inf is 0
     assert be.allclose(geom.cy, -initial_cy_val)
+
 
 def test_flip_toroidal_inf_radius():
     geom = ToroidalGeometry(cs, radius_rotation=be.inf, radius_yz=-100.0, conic=-0.7)
@@ -228,8 +275,8 @@ def test_flip_toroidal_inf_radius():
     assert geom.R_rot == -be.inf
     assert geom.R_yz == 100.0
     expected_c_yz = -initial_c_yz_val if -100.0 != 0 and be.isfinite(-100.0) else 0.0
-    if hasattr(geom.c_yz, 'shape') or hasattr(expected_c_yz, 'shape'):
-         assert be.allclose(geom.c_yz, be.array(expected_c_yz))
+    if hasattr(geom.c_yz, "shape") or hasattr(expected_c_yz, "shape"):
+        assert be.allclose(geom.c_yz, be.array(expected_c_yz))
     else:
-         assert be.allclose(geom.c_yz, expected_c_yz)
+        assert be.allclose(geom.c_yz, expected_c_yz)
     assert geom.radius == -be.inf

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -300,7 +300,9 @@ class TestLeastSquares:
         lens = Microscope20x()
         problem = optimization.OptimizationProblem()
         min_b, max_b = 10, 100
-        problem.add_variable(lens, "radius", surface_number=1, min_val=min_b, max_val=max_b)
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=min_b, max_val=max_b
+        )
         input_data = {"optic": lens}
         problem.add_operand(
             operand_type="f2",
@@ -309,18 +311,19 @@ class TestLeastSquares:
             input_data=input_data,
         )
         optimizer = optimization.LeastSquares(problem)
-        result = optimizer.optimize(method_choice='trf', maxiter=10, tol=1e-3)
+        result = optimizer.optimize(method_choice="trf", maxiter=10, tol=1e-3)
         assert result.success
         # Check if the optimized variable is within bounds (SciPy's TRF handles this)
         optimized_radius = lens.surface_group.surfaces[1].geometry.radius
         assert min_b <= optimized_radius <= max_b
 
-
     def test_method_dogbox_with_bounds(self):
         lens = Microscope20x()
         problem = optimization.OptimizationProblem()
         min_b, max_b = 10, 100
-        problem.add_variable(lens, "radius", surface_number=1, min_val=min_b, max_val=max_b)
+        problem.add_variable(
+            lens, "radius", surface_number=1, min_val=min_b, max_val=max_b
+        )
         input_data = {"optic": lens}
         problem.add_operand(
             operand_type="f2",
@@ -329,11 +332,10 @@ class TestLeastSquares:
             input_data=input_data,
         )
         optimizer = optimization.LeastSquares(problem)
-        result = optimizer.optimize(method_choice='dogbox', maxiter=10, tol=1e-3)
+        result = optimizer.optimize(method_choice="dogbox", maxiter=10, tol=1e-3)
         assert result.success
         optimized_radius = lens.surface_group.surfaces[1].geometry.radius
         assert min_b <= optimized_radius <= max_b
-
 
     def test_method_lm_with_bounds_warning(self, capsys):
         lens = Microscope20x()
@@ -347,7 +349,7 @@ class TestLeastSquares:
             input_data=input_data,
         )
         optimizer = optimization.LeastSquares(problem)
-        optimizer.optimize(method_choice='lm', maxiter=5)
+        optimizer.optimize(method_choice="lm", maxiter=5)
         captured = capsys.readouterr()
         expected_warning = (
             "Warning: Method 'lm' (Levenberg-Marquardt) chosen, "
@@ -356,11 +358,10 @@ class TestLeastSquares:
         )
         assert expected_warning in captured.out
 
-
     def test_unknown_method_choice_warning(self, capsys):
         lens = Microscope20x()
         problem = optimization.OptimizationProblem()
-        problem.add_variable(lens, "radius", surface_number=1) # No bounds needed
+        problem.add_variable(lens, "radius", surface_number=1)  # No bounds needed
         input_data = {"optic": lens}
         problem.add_operand(
             operand_type="f2",
@@ -369,11 +370,11 @@ class TestLeastSquares:
             input_data=input_data,
         )
         optimizer = optimization.LeastSquares(problem)
-        optimizer.optimize(method_choice='unknown_method', maxiter=5)
+        optimizer.optimize(method_choice="unknown_method", maxiter=5)
         captured = capsys.readouterr()
         expected_warning = (
             "Warning: Unknown method_choice 'unknown_method'. Defaulting to "
-            "'trf' method." # Updated expected warning
+            "'trf' method."  # Updated expected warning
         )
         assert expected_warning in captured.out
 
@@ -391,7 +392,7 @@ class MockOperandNaN:
     def delta(self):
         return be.nan
 
-    def value(self): # Add a value method
+    def value(self):  # Add a value method
         return be.nan
 
 
@@ -420,8 +421,10 @@ class TestLeastSquaresErrorHandling:
         problem.add_variable(lens, "radius", surface_number=1, min_val=10, max_val=100)
 
         mock_op = MockOperandNaN()
-        problem.initial_value = 1.0 # Set to non-zero to prevent sum_squared in OptimizerGeneric init
-        problem.operands.operands.append(mock_op) # Manually add mock operand
+        problem.initial_value = (
+            1.0  # Set to non-zero to prevent sum_squared in OptimizerGeneric init
+        )
+        problem.operands.operands.append(mock_op)  # Manually add mock operand
 
         optimizer = optimization.LeastSquares(problem)
         result = optimizer.optimize(maxiter=5)
@@ -430,7 +433,7 @@ class TestLeastSquaresErrorHandling:
         # So cost = 0.5 * (sqrt(1e10))^2 = 0.5 * 1e10
         assert be.isclose(result.cost, 0.5 * 1e10)
         # Check that optimization completed without crashing (status might vary)
-        assert result.status is not None # General check for completion
+        assert result.status is not None  # General check for completion
 
     def test_exception_in_residual_handling(self):
         lens = Microscope20x()
@@ -438,7 +441,9 @@ class TestLeastSquaresErrorHandling:
         problem.add_variable(lens, "radius", surface_number=1, min_val=10, max_val=100)
 
         mock_op = MockOperandException()
-        problem.initial_value = 1.0 # Set to non-zero to prevent sum_squared in OptimizerGeneric init
+        problem.initial_value = (
+            1.0  # Set to non-zero to prevent sum_squared in OptimizerGeneric init
+        )
         problem.operands.operands.append(mock_op)
 
         optimizer = optimization.LeastSquares(problem)

--- a/tests/test_surface_factory.py
+++ b/tests/test_surface_factory.py
@@ -150,7 +150,7 @@ class TestSurfaceFactory:
             )
 
     def test_invalid_surface_index(self, set_test_backend):
-        with pytest.raises(ValueError):
+        with pytest.raises(IndexError):
             self.factory.create_surface(
                 surface_type="standard",
                 comment="Invalid",

--- a/tests/test_surface_group.py
+++ b/tests/test_surface_group.py
@@ -1,0 +1,365 @@
+import pytest
+
+import optiland.backend as be
+from optiland.coordinate_system import CoordinateSystem
+from optiland.geometries import StandardGeometry
+from optiland.materials import IdealMaterial
+from optiland.surfaces.standard_surface import Surface
+from optiland.surfaces.surface_group import SurfaceGroup
+
+from tests.utils import assert_allclose
+
+
+# Helper to create a real Surface instance for tests
+def create_real_surface(
+    name="s",
+    thickness_val=10.0,
+    initial_z=0.0,
+    is_stop=False,
+    comment="",
+    radius=be.inf,
+    material_n=1.0,
+):
+    """
+    Creates a real Surface object.
+    The 'thickness' attribute is crucial for SurfaceGroup._update_coordinate_systems.
+    We will set it directly on the surface instance.
+    """
+    cs = CoordinateSystem(z=initial_z)
+    # StandardGeometry needs a radius; be.inf can represent a plane.
+    geom = StandardGeometry(coordinate_system=cs, radius=radius)
+
+    # Surfaces require material_pre and material_post
+    mat_pre = IdealMaterial(n=material_n)
+    mat_post = IdealMaterial(n=material_n)  # Keep it simple for now, or vary if needed
+
+    surface = Surface(
+        geometry=geom,
+        material_pre=mat_pre,
+        material_post=mat_post,
+        is_stop=is_stop,
+        comment=comment or name,
+        surface_type="Standard",  # A default type
+    )
+    surface.thickness = thickness_val
+    surface.name = name  # add for testing
+
+    return surface
+
+
+class TestSurfaceGroupUpdatesRealObjects:
+    def _setup_surface_group(
+        self,
+        num_initial_surfaces=0,
+        use_absolute_cs=False,
+        thicknesses=None,
+        initial_zs=None,
+    ):
+        """Helper to create a SurfaceGroup with real surfaces."""
+        sg = SurfaceGroup([])  # Start with empty
+        # The SurfaceGroup initializes its own SurfaceFactory.
+        # We can configure its 'use_absolute_cs' property.
+        sg.surface_factory.use_absolute_cs = use_absolute_cs
+
+        initial_surfaces = []
+        if thicknesses is None:
+            thicknesses = [10.0] * num_initial_surfaces
+        if initial_zs is None:
+            # Default initial Z: obj at -100, others at 0 before potential update
+            initial_zs = [
+                -100.0 if i == 0 else 0.0 for i in range(num_initial_surfaces)
+            ]
+            if num_initial_surfaces == 0:
+                initial_zs = []
+
+        for i in range(num_initial_surfaces):
+            surface = create_real_surface(
+                name=f"s{i}", thickness_val=thicknesses[i], initial_z=initial_zs[i]
+            )
+            initial_surfaces.append(surface)
+
+        sg.surfaces = initial_surfaces
+
+        if not use_absolute_cs and len(sg.surfaces) > 1:
+            sg._update_coordinate_systems(start_index=0)
+
+        return sg
+
+    @pytest.mark.parametrize("use_absolute_cs", [True, False])
+    def test_add_surface_new_object_append_empty(
+        self, set_test_backend, use_absolute_cs
+    ):
+        sg = self._setup_surface_group(use_absolute_cs=use_absolute_cs)
+        new_surf = create_real_surface(name="new", thickness_val=5.0, initial_z=10.0)
+        sg.add_surface(new_surface=new_surf)
+
+        assert len(sg.surfaces) == 1
+        assert sg.surfaces[0] is new_surf
+        assert_allclose(
+            sg.surfaces[0].geometry.cs.z, be.array(10.0)
+        )  # Keeps its initial Z
+
+    def test_add_surface_new_object_append_non_empty_abs_cs(self, set_test_backend):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=1,
+            use_absolute_cs=True,
+            thicknesses=[10],
+            initial_zs=[5.0],
+        )
+        s0_z = be.copy(sg.surfaces[0].geometry.cs.z)
+
+        new_surf = create_real_surface(name="new", thickness_val=5.0, initial_z=20.0)
+        sg.add_surface(new_surface=new_surf)  # Appends
+
+        assert len(sg.surfaces) == 2
+        assert sg.surfaces[1] is new_surf
+        assert_allclose(sg.surfaces[0].geometry.cs.z, s0_z)  # Unchanged
+        assert_allclose(sg.surfaces[1].geometry.cs.z, be.array(20.0))  # Keeps its Z
+
+    def test_add_surface_new_object_append_non_empty_rel_cs_no_update(
+        self, set_test_backend
+    ):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=1,
+            use_absolute_cs=False,
+            thicknesses=[10],
+            initial_zs=[-100.0],
+        )
+        # S0(z=-100, t=10)
+        s0 = sg.surfaces[0]
+
+        new_surf = create_real_surface(
+            name="S1_appended", thickness_val=5.0, initial_z=123.0
+        )
+        # Appending: index is not specified or index == len(sg.surfaces)
+        sg.add_surface(
+            new_surface=new_surf
+        )  # Appends, update_start_index points to new_surf, is_last_surface=True
+
+        assert len(sg.surfaces) == 2
+        assert sg.surfaces[1] is new_surf
+        assert_allclose(s0.geometry.cs.z, be.array(-100.0))
+        # _update_coordinate_systems is NOT called when appending to make it the last surface
+        assert_allclose(sg.surfaces[1].geometry.cs.z, be.array(123.0))
+
+    def test_add_surface_new_object_insert_middle_rel_cs_triggers_update(
+        self, set_test_backend
+    ):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=2,
+            use_absolute_cs=False,
+            thicknesses=[10, 20],
+            initial_zs=[-100.0, 0.0],
+        )
+        # After setup: S0(z=-100, t=10), S1_orig(z=0, t=20)
+        s1_orig_name = sg.surfaces[1].name
+
+        s_new = create_real_surface(
+            name="S_new", thickness_val=5.0, initial_z=123.0
+        )  # initial_z overridden
+        sg.add_surface(new_surface=s_new, index=1)
+
+        assert len(sg.surfaces) == 2
+        assert sg.surfaces[1] is s_new
+        assert sg.surfaces[0].name == "s0"
+
+        assert_allclose(
+            sg.surfaces[0].geometry.cs.z, be.array(-100.0)
+        )  # S0 z unchanged
+        assert_allclose(
+            sg.surfaces[1].geometry.cs.z, be.array(123.0)
+        )
+
+    def test_add_surface_new_object_is_stop_propagation(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=2, use_absolute_cs=False)
+        sg.surfaces[0].is_stop = True  # Set S0 as stop
+        new_surf = create_real_surface(name="new_stop", is_stop=True)
+        sg.add_surface(new_surface=new_surf, index=2)  # Append
+
+        assert len(sg.surfaces) == 3
+        assert not sg.surfaces[0].is_stop  # Old stop is cleared
+        assert not sg.surfaces[1].is_stop
+        assert sg.surfaces[2].is_stop
+
+    # --- Tests for add_surface by creation (new_surface is None) ---
+    def test_add_surface_by_creation_rel_cs(self, set_test_backend):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=1,
+            use_absolute_cs=False,
+            thicknesses=[10],
+            initial_zs=[-100.0],
+        )
+
+        # Add S1 by creation
+        # The 'thickness' kwarg should be handled by the actual SurfaceFactory
+        sg.add_surface(
+            surface_type="standard",
+            comment="S1_created",
+            index=1,
+            material="air",
+            thickness=5.0,
+        )  # 'air' is just a placeholder for material name
+
+        assert len(sg.surfaces) == 2
+        created_s1 = sg.surfaces[1]
+        assert created_s1.comment == "S1_created"
+        assert created_s1.thickness == 5.0  # Assuming factory sets this
+
+        # Add S1 by creation
+        sg.add_surface(
+            surface_type="standard",
+            comment="S2_inserted",
+            index=1,
+            material="glass",
+            thickness=12.0,
+        )
+        # Surfaces: S0, S2_inserted
+
+        assert len(sg.surfaces) == 2
+        s1_created_now_s2 = sg.surfaces[1]
+
+        assert s1_created_now_s2.comment == "S2_inserted"
+        assert s1_created_now_s2.thickness == 12.0
+
+    def test_add_surface_by_creation_error_no_index(self, set_test_backend):
+        sg = self._setup_surface_group(use_absolute_cs=False)
+        with pytest.raises(
+            ValueError, match="Must define index when defining surface."
+        ):
+            sg.add_surface(surface_type="standard", comment="no_index_surf")
+
+    # --- Tests for remove_surface ---
+    def test_remove_surface_middle_rel_cs_triggers_update(self, set_test_backend):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=3,
+            use_absolute_cs=False,
+            thicknesses=[10, 20, 30],
+            initial_zs=[-100, 0, 20],
+        )
+        # Initial: S0(z=-100,t=10), S1(z=0,t=20), S2(z=20,t=30)
+        s2_original_comment = sg.surfaces[2].comment  # Was s2
+
+        sg.remove_surface(index=1)  # Remove S1
+
+        assert len(sg.surfaces) == 2
+        assert sg.surfaces[0].comment == "s0"
+        assert sg.surfaces[1].comment == s2_original_comment  # Old S2 is now S1
+
+        assert_allclose(
+            sg.surfaces[0].geometry.cs.z, be.array(-100.0)
+        )  # S0 unchanged
+        # Old S2 (now new S1) z should be 0.0 because it's now the surface at index 1 and update was called
+        assert_allclose(sg.surfaces[1].geometry.cs.z, be.array(0.0))
+
+    def test_remove_surface_last_rel_cs_no_update_triggered(self, set_test_backend):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=3,
+            use_absolute_cs=False,
+            thicknesses=[10, 20, 30],
+            initial_zs=[-100, 0, 20],
+        )
+        # S0(z=-100,t=10), S1(z=0,t=20), S2(z=20,t=30)
+        s1_z_before_removal = be.copy(sg.surfaces[1].geometry.cs.z)
+
+        sg.remove_surface(index=2)  # Remove S2 (last optical surface)
+        # _update_coordinate_systems not called because was_not_last_surface is false
+
+        assert len(sg.surfaces) == 2
+        assert_allclose(
+            sg.surfaces[1].geometry.cs.z, s1_z_before_removal
+        )  # S1 z unchanged
+
+    def test_remove_surface_abs_cs_no_update(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=3, use_absolute_cs=True)
+        # Set specific Zs that wouldn't occur with relative CS updates
+        sg.surfaces[0].geometry.cs.z = be.array(0.0)
+        sg.surfaces[1].geometry.cs.z = be.array(10.0)
+        sg.surfaces[2].geometry.cs.z = be.array(30.0)
+
+        s2_z_original = be.copy(sg.surfaces[2].geometry.cs.z)
+
+        sg.remove_surface(index=1)  # Remove S1
+
+        assert len(sg.surfaces) == 2
+        # With absolute_cs=True, _update_coordinate_systems is not called
+        assert_allclose(
+            sg.surfaces[1].geometry.cs.z, s2_z_original
+        )  # Old S2 (now S1) keeps its original Z
+
+    def test_remove_surface_error_remove_object(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=1)
+        with pytest.raises(ValueError, match="Cannot remove object surface"):
+            sg.remove_surface(index=0)
+
+    # --- Error condition tests from SurfaceGroup code directly ---
+    def test_add_surface_new_object_error_negative_index(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=1)
+        with pytest.raises(IndexError, match="Index -1 cannot be negative."):
+            sg.add_surface(new_surface=create_real_surface(), index=-1)
+
+    def test_add_surface_new_object_error_index_out_of_bounds(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=1)  # surfaces[0] exists
+        # Valid indices for insertion/overwrite: 0, 1 (append)
+        with pytest.raises(IndexError, match="Index 2 is out of bounds"):
+            sg.add_surface(new_surface=create_real_surface(), index=2)
+
+    def test_add_surface_by_creation_error_negative_index(self, set_test_backend):
+        sg = self._setup_surface_group()
+        with pytest.raises(IndexError):
+            sg.add_surface(
+                surface_type="standard", index=-1, thickness=1
+            )  # Assuming factory handles thickness
+
+    def test_add_surface_by_creation_error_index_out_of_bounds(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=1)
+        with pytest.raises(IndexError):
+            sg.add_surface(surface_type="standard", index=2, thickness=1)
+
+    def test_remove_surface_error_index_out_of_bounds_negative(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=2)
+        with pytest.raises(IndexError, match="Index -1 is out of bounds"):
+            sg.remove_surface(index=-1)
+
+    def test_remove_surface_error_index_out_of_bounds_too_large(self, set_test_backend):
+        sg = self._setup_surface_group(num_initial_surfaces=2)  # Valid remove index: 1
+        with pytest.raises(IndexError, match="Index 2 is out of bounds"):
+            sg.remove_surface(index=2)
+        with pytest.raises(
+            IndexError, match="Index 3 is out of bounds"
+        ):  # Also too large
+            sg.remove_surface(index=3)
+
+    # --- Tests for _update_coordinate_systems specific cases ---
+    def test_update_coordinate_systems_infinite_thickness_error(self, set_test_backend):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=2,
+            use_absolute_cs=False,
+            thicknesses=[10, be.inf],
+            initial_zs=[-100, 0],
+        )
+        # S0(z=-100, t=10), S1(z=0, t=inf)
+        # Add a third surface; its position calculation will depend on S1's infinite thickness
+        s2 = create_real_surface(name="s2_after_inf", thickness_val=5.0)
+        sg.surfaces.append(s2)  # Now [S0, S1, s2]
+
+        # Update starting from index 2 (s2_after_inf), which looks at s1's thickness
+        with pytest.raises(
+            ValueError,
+            match="Coordinate system update failed due to infinite thickness at surface 1",
+        ):
+            sg._update_coordinate_systems(start_index=2)
+
+    def test_update_coordinate_systems_thickness_is_be_array(self, set_test_backend):
+        sg = self._setup_surface_group(
+            num_initial_surfaces=3,
+            use_absolute_cs=False,
+            thicknesses=[10, 20, 30],
+            initial_zs=[-100, 0, 20],
+        )
+        # S0(z=-100,t=10), S1(z=0,t=20), S2(z=20,t=30)
+        sg.surfaces[1].thickness = be.array(25.0)  # S1 thickness is a 0-d array
+
+        sg._update_coordinate_systems(start_index=2)  # Update S2 based on S1
+
+        # S2.z = S1.z + S1.thickness = 0.0 + 25.0
+        assert_allclose(sg.surfaces[2].geometry.cs.z, be.array(25.0))

--- a/tests/test_surface_group.py
+++ b/tests/test_surface_group.py
@@ -347,10 +347,7 @@ class TestSurfaceGroupUpdatesRealObjects:
     def test_add_surface_by_creation_error_index_out_of_bounds(self, set_test_backend):
         sg = self._setup_surface_group(num_initial_surfaces=1)  # len(sg.surfaces) = 1
         # Max index for insertion is 1. index=2 is out of bounds.
-        with pytest.raises(
-            IndexError,
-            match=r"Index 2 is out of bounds for insertion. Max index for insertion is 1 \(to append\)\.",
-        ):
+        with pytest.raises(IndexError):
             sg.add_surface(surface_type="standard", index=2, thickness=1)
 
     def test_remove_surface_error_index_out_of_bounds_negative(self, set_test_backend):

--- a/tests/test_surface_group.py
+++ b/tests/test_surface_group.py
@@ -1,6 +1,7 @@
 import pytest
 
 import optiland.backend as be
+from optiland import optic
 from optiland.coordinate_system import CoordinateSystem
 from optiland.geometries import StandardGeometry
 from optiland.materials import IdealMaterial
@@ -398,3 +399,29 @@ class TestSurfaceGroupUpdatesRealObjects:
 
         # S2.z = S1.z + S1.thickness = 0.0 + 25.0
         assert_allclose(sg.surfaces[2].geometry.cs.z, be.array(25.0))
+
+    def test_insert_all_at_index_1(self, set_test_backend):
+        lens = optic.Optic()
+
+        lens.add_surface(index=0, radius=be.inf, thickness=be.inf)
+        lens.add_surface(index=1)
+        lens.add_surface(index=1, radius=-18.39533, thickness=42.20778)
+        lens.add_surface(index=1, radius=79.68360, thickness=2.95208, material="SK16")
+        lens.add_surface(index=1, radius=20.29192, thickness=4.75041, is_stop=True)
+        lens.add_surface(index=1, radius=-22.21328, thickness=0.99997, material=("F2", "schott"))
+        lens.add_surface(index=1, radius=-435.76044, thickness=6.00755)
+        lens.add_surface(index=1, radius=22.01359, thickness=3.25896, material="SK16")
+
+        lens.set_aperture(aperture_type="EPD", value=10)
+
+        lens.set_field_type(field_type="angle")
+        lens.add_field(y=0)
+        lens.add_field(y=14)
+        lens.add_field(y=20)
+
+        lens.add_wavelength(value=0.48)
+        lens.add_wavelength(value=0.55, is_primary=True)
+        lens.add_wavelength(value=0.65)
+
+        rays = lens.trace(Hx=0, Hy=1, distribution="hexapolar", num_rays=3, wavelength=0.59)
+        assert_allclose(be.mean(rays.y), 18.13506822442731)  # mean y position for Cooke triplet defined above


### PR DESCRIPTION
- Fixes surface generation when inserting surfaces out of order. Fixes #106 

Example - Add surfaces in reverse order (so all are added at `index=1`):

```python
# We will define a Cooke triplet
lens = optic.Optic()

lens.add_surface(index=0, radius=be.inf, thickness=be.inf)  # first define object surface
lens.add_surface(index=1)
lens.add_surface(index=1, radius=-18.39533, thickness=42.20778)
lens.add_surface(index=1, radius=79.68360, thickness=2.95208, material="SK16")
lens.add_surface(index=1, radius=20.29192, thickness=4.75041, is_stop=True)
lens.add_surface(index=1, radius=-22.21328, thickness=0.99997, material=("F2", "schott"))
lens.add_surface(index=1, radius=-435.76044, thickness=6.00755)
lens.add_surface(index=1, radius=22.01359, thickness=3.25896, material="SK16")

lens.set_aperture(aperture_type="EPD", value=10)

lens.set_field_type(field_type="angle")
lens.add_field(y=0)
lens.add_field(y=14)
lens.add_field(y=20)

lens.add_wavelength(value=0.48)
lens.add_wavelength(value=0.55, is_primary=True)
lens.add_wavelength(value=0.65)

lens.draw()
```

Visualization is as expected:
![image](https://github.com/user-attachments/assets/8aeec954-7cad-490e-9351-9702ed07ef60)
