### PR TITLE
Add a live demo to the documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,11 +3,10 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "mambaforge-23.11"
 
-python:
-  install:
-    - requirements: docs/requirements.txt
+conda:
+  environment: docs/build-environment.yml
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -1,0 +1,17 @@
+name: sphinx-build
+channels:
+    - conda-forge
+dependencies:
+    - ipython=8.26.0
+    - nbsphinx=0.9.5
+    - sphinx=7.4.7
+    - sphinx-gallery=0.17.1
+    - sphinx-rtd-theme=2.0.0
+    - micromamba=2.0.5
+    - pip
+    - pandoc
+    - Pygments=2.18.0
+    - pip:
+        - jupyterlite-sphinx
+        - jupyterlite-xeus >=2.1.2
+        - ..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ author = "Kramer Harrison"
 release = "0.4.1"
 
 extensions = [
+    "jupyterlite_sphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
@@ -58,3 +59,6 @@ autodoc_default_options = {
     "special-members": False,
     "inherited-members": True,
 }
+
+# Jupyterlite configuration
+jupyterlite_bind_ipynb_suffix = False

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,16 @@
+name: jupyterlite-sphinx
+channels:
+  - https://repo.mamba.pm/emscripten-forge
+  - conda-forge
+dependencies:
+  - matplotlib
+  - numpy
+  - pandas
+  - pyyaml
+  - scipy
+  - seaborn
+  - xeus-python
+  - pip:
+    - ./jupyterlite/mock_libraries/numba
+    - ./jupyterlite/mock_libraries/vtk
+    - optiland

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,24 @@ Python code to generate this 3D visualization:
    lens = ReverseTelephoto()
    lens.draw3D()
 
+Try it Now
+----------
+
+Use the interactive shell to try Optiland in your browser!
+
+.. replite::
+   :kernel: xpython
+   :width: 100%
+   :height: 600px
+
+   from optiland.samples.objectives import CookeTriplet
+
+   lens = CookeTriplet()
+   lens.draw()
+
+.. note::
+
+   3D plotting does not work in the interactive shell, but you can run the code in your local Python environment to try the 3D visualizations.
 
 .. _getting_started:
 

--- a/docs/jupyterlite/mock_libraries/numba/numba/__init__.py
+++ b/docs/jupyterlite/mock_libraries/numba/numba/__init__.py
@@ -1,0 +1,16 @@
+def decorator_return_as_is(*args, **kwargs):
+    def f(x):
+        return x
+    
+    if len(args) == 0:
+        return f
+    
+    if callable(args[0]):
+        return args[0]
+    
+    return f
+
+
+jit = decorator_return_as_is
+njit = decorator_return_as_is
+prange = range

--- a/docs/jupyterlite/mock_libraries/numba/pyproject.toml
+++ b/docs/jupyterlite/mock_libraries/numba/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "numba"
+description = "Numba stub for running Optiland in WASM environments"
+readme = { content-type = "text/markdown", text = "" }
+license = { text = "" }
+requires-python = ">=3.9,<3.14"
+version = "0.61.2"

--- a/docs/jupyterlite/mock_libraries/vtk/pyproject.toml
+++ b/docs/jupyterlite/mock_libraries/vtk/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vtk"
+description = "VTK stub for running Optiland in WASM environments"
+readme = { content-type = "text/markdown", text = "" }
+license = { text = "" }
+requires-python = ">=3.9,<3.14"
+version = "9.4.2"

--- a/docs/jupyterlite/mock_libraries/vtk/vtk/__init__.py
+++ b/docs/jupyterlite/mock_libraries/vtk/vtk/__init__.py
@@ -1,0 +1,2 @@
+def __getattr__(name):
+    raise RuntimeError(f"VTK functionality is not available in this environment. Calling: {name}")


### PR DESCRIPTION
Add a live demo to the documentation using [jupyterlite-sphinx](https://jupyterlite-sphinx.readthedocs.io/en/stable/).
Includes a custom Python kernel with Optiland and its dependencies. This requires the ReadTheDocs build to use conda instead of the normal Python configuration.
Please let me know if this breaks your local development workflow.