### PR TITLE
Mimic OpticStudio sampling behavior in FFT PSF

### DIFF
--- a/optiland/psf/fft.py
+++ b/optiland/psf/fft.py
@@ -115,7 +115,7 @@ class FFTPSF(BasePSF):
         x, y = be.meshgrid(x, x)
         x = x.ravel()
         y = y.ravel()
-        R = be.sqrt(x**2 + y**2)
+        R2 = x**2 + y**2
 
         field = self.fields[0]  # PSF contains a single field.
         pupils = []
@@ -124,7 +124,7 @@ class FFTPSF(BasePSF):
             wavefront_data = self.get_data(field, wl)
             P = be.to_complex(be.zeros_like(x))
             amplitude = wavefront_data.intensity / be.mean(wavefront_data.intensity)
-            P[R <= 1] = be.to_complex(
+            P[R2 <= 1] = be.to_complex(
                 amplitude * be.exp(1j * 2 * be.pi * wavefront_data.opd)
             )
             P = be.reshape(P, (self.num_rays, self.num_rays))

--- a/tests/test_fft_psf.py
+++ b/tests/test_fft_psf.py
@@ -5,6 +5,8 @@ import matplotlib.pyplot as plt
 import optiland.backend as be
 import pytest
 
+from contextlib import nullcontext as does_not_raise
+
 from optiland.psf import FFTPSF
 from optiland.samples.objectives import CookeTriplet
 from .utils import assert_allclose
@@ -34,6 +36,38 @@ def test_initialization(make_fftpsf):
     assert fftpsf.grid_size == 1024
     assert len(fftpsf.pupils) == 1
     assert fftpsf.psf.shape == (1024, 1024)
+
+
+@pytest.mark.parametrize(
+    "num_rays,expected_pupil_sampling",
+    [
+        (32, 32),
+        (64, 45),
+        (128, 64),
+        (256, 90),
+        (512, 128),
+        (1024, 181),
+        (2048, 256),
+        (4096, 362),
+        (8192, 512),
+    ],
+)
+def test_num_rays_and_grid_size(make_fftpsf, num_rays, expected_pupil_sampling):
+    fftpsf = make_fftpsf(num_rays=num_rays, grid_size=None)
+
+    assert fftpsf.num_rays == expected_pupil_sampling
+    assert fftpsf.grid_size == 2 * num_rays
+
+
+@pytest.mark.parametrize("num_rays,grid_size,expectation", [
+    (32, None, does_not_raise()),
+    (64, None, does_not_raise()),
+    (12, 16, does_not_raise()),
+    (16, None, pytest.raises(ValueError, match="num_rays must be at least 32 if grid_size is not specified")),
+])
+def test_num_rays_below_32(make_fftpsf, num_rays, grid_size, expectation):
+    with expectation:
+        make_fftpsf(num_rays=num_rays, grid_size=grid_size)
 
 
 def test_strehl_ratio(make_fftpsf):
@@ -76,9 +110,13 @@ def test_view_invalid_projection(make_fftpsf):
     with pytest.raises(ValueError):
         fftpsf.view(projection="invalid", log=True)
 
+
 @pytest.mark.parametrize(
     "projection",
-    [ "2d", "3d",],
+    [
+        "2d",
+        "3d",
+    ],
 )
 @patch("matplotlib.figure.Figure.text")
 def test_view_annotate_sampling(mock_text, projection, make_fftpsf):
@@ -89,16 +127,21 @@ def test_view_annotate_sampling(mock_text, projection, make_fftpsf):
 
     plt.close("all")
 
+
 @pytest.mark.parametrize(
     "projection",
-    [ "2d", "3d",],
+    [
+        "2d",
+        "3d",
+    ],
 )
 def test_view_oversampling(projection, make_fftpsf):
     fftpsf = make_fftpsf(field=(0, 1))
 
     with pytest.warns(UserWarning, match="The PSF view has a high oversampling factor"):
         fftpsf.view(projection=projection, log=False, num_points=128)
-    
+
+
 def test_get_units_finite_obj(make_fftpsf):
     def tweak(optic):
         optic.surface_group.surfaces[0].geometry.cs.z = be.array(1e6)

--- a/tests/test_fft_psf.py
+++ b/tests/test_fft_psf.py
@@ -52,6 +52,22 @@ def test_initialization(make_fftpsf):
         (8192, 512),
     ],
 )
+def test_calculate_grid_size(make_fftpsf, num_rays, expected_pupil_sampling):
+    fftpsf = make_fftpsf()
+
+    assert fftpsf._calculate_grid_size(num_rays) == (expected_pupil_sampling, 2 * num_rays)
+
+
+@pytest.mark.parametrize(
+    "num_rays,expected_pupil_sampling",
+    [
+        (32, 32),
+        (64, 45),
+        (128, 64),
+        (256, 90),
+        (1024, 181),
+    ],
+)
 def test_num_rays_and_grid_size(make_fftpsf, num_rays, expected_pupil_sampling):
     fftpsf = make_fftpsf(num_rays=num_rays, grid_size=None)
 


### PR DESCRIPTION
Following the discussion in #157, this is a proposal to make Optiland by default mimic the sampling behavior in OpticStudio.
This behavior is documented here: https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/Zemax/v251/en/OpticStudio_User_Guide/OpticStudio_Help/topics/FFT_PSF.html

This behavior can be overriden by specifying both `num_rays` and `grid_size`. If only `num_rays` is specified, the grid size will be based on `num_rays`. Furthermore, `num_rays` will be set to the 'effective pupil sampling' as specified in the OpticStudio documentation.

The current implementation changes the number of rays used for pupil sampling. I investigated a different approach where `num_rays` is interpreted as the effective pupil sampling and the pupil sampling and grid size are calculated from that value. However, due to rounding of the effective values, I found it difficult to obtain the pupil sampling from the effective pupil sampling, which made it impossible to replicate OpticStudio's behavior with this alternative approach.