### PR TITLE
Fix/psf image space index

### DIFF
--- a/optiland/psf/base.py
+++ b/optiland/psf/base.py
@@ -364,9 +364,11 @@ class BasePSF(Wavefront):
         single defined field point and given wavelength.
 
         Algorithm:
-            1. Retrieve the defined given wavelength.
+            1. Retrieve the defined given wavelength and field coordinates.
             2. Determine the image-space refractive index 'n' at the given wavelength.
-            3. Trace four marginal rays (top, bottom, left, right) at the pupil edges.
+            3. Trace four marginal rays (top, bottom, left, right) at the pupil edges,
+               as well as the chief ray.
+            4. Compute the angle between each marginal ray and the chief ray.
             4. Calculate the average of the squared numerical apertures from all traced
                marginal rays.
             5. Compute the working F-number as 1 / (2 * sqrt(average_NA_squared)).
@@ -377,13 +379,12 @@ class BasePSF(Wavefront):
         """
         MAX_FNUM = 10000.0
 
-        Hx, Hy = 0, 0
+        Hx, Hy = self.fields[0]
         wavelength = self.wavelengths[0]
 
         n = self.optic.image_surface.material_post.n(wavelength)
         Px = be.array([0, 0, 0, 1, -1])
         Py = be.array([0, 1, -1, 0, 0])
-        numerical_apertures_squared = []
 
         rays = self.optic.trace_generic(
             Hx=Hx, Hy=Hy, Px=Px, Py=Py, wavelength=wavelength

--- a/optiland/psf/base.py
+++ b/optiland/psf/base.py
@@ -404,4 +404,9 @@ class BasePSF(Wavefront):
         if fno > MAX_FNUM:
             fno = MAX_FNUM
 
+        if be.isnan(fno):
+            raise ValueError(
+                "Working F/# could not be calculated due to raytrace errors."
+            )
+
         return fno

--- a/optiland/psf/fft.py
+++ b/optiland/psf/fft.py
@@ -248,7 +248,7 @@ class FFTPSF(BasePSF):
             These are returned as NumPy arrays as `BasePSF.view` expects them
             for Matplotlib's `extent` argument.
         """
-        FNO = self._get_effective_FNO()
+        FNO = self._get_working_FNO()
 
         Q = self.grid_size / self.num_rays
         dx = self.wavelengths[0] * FNO / Q

--- a/optiland/psf/huygens_fresnel.py
+++ b/optiland/psf/huygens_fresnel.py
@@ -85,7 +85,7 @@ class HuygensPSF(BasePSF):
         extent_geometric = be.max(be.hypot(rx - self.cx, ry - self.cy))
         extent_ideal = (
             num_Airy_disks
-            * self._get_effective_FNO()  # effective F-number
+            * self._get_working_FNO()  # effective F-number
             * 1.22
             * (self.wavelengths[0] * 1e-3)  # um --> mm
         )

--- a/optiland/rays/ray_generator.py
+++ b/optiland/rays/ray_generator.py
@@ -134,13 +134,16 @@ class RayGenerator:
 
             elif self.optic.field_type == "angle":
                 EPL = self.optic.paraxial.EPL()
-                z = self.optic.surface_group.positions[0]
-                x = -be.tan(be.radians(field_x)) * (EPL - z)
-                y = -be.tan(be.radians(field_y)) * (EPL - z)
+                z0 = self.optic.surface_group.positions[0]
+                x0 = -be.tan(be.radians(field_x)) * (EPL - z0)
+                y0 = -be.tan(be.radians(field_y)) * (EPL - z0)
 
-            x0 = be.full_like(Px, x)
-            y0 = be.full_like(Px, y)
-            z0 = be.full_like(Px, z)
+            if be.size(x0) == 1:
+                x0 = be.full_like(Px, x0)
+            if be.size(y0) == 1:
+                y0 = be.full_like(Px, y0)
+            if be.size(z0) == 1:
+                z0 = be.full_like(Px, z0)
 
         return x0, y0, z0
 

--- a/tests/test_fft_psf.py
+++ b/tests/test_fft_psf.py
@@ -180,13 +180,13 @@ def test_view_oversampling(projection, make_fftpsf):
 
 def test_get_units_finite_obj(make_fftpsf):
     def tweak(optic):
-        optic.surface_group.surfaces[0].geometry.cs.z = be.array(1e6)
+        optic.surface_group.surfaces[0].geometry.cs.z = -be.array(1e6)
 
     fftpsf = make_fftpsf(field=(0, 1), tweak_optic=tweak)
     image = be.zeros((128, 128))
     x, y = fftpsf._get_psf_units(image)
-    assert_allclose(x, 352.01567006276366)
-    assert_allclose(y, 352.01567006276366)
+    assert_allclose(x, 385.84203124)
+    assert_allclose(y, 385.84203124)
 
 
 def test_psf_log_tick_formatter(make_fftpsf):
@@ -197,6 +197,17 @@ def test_psf_log_tick_formatter(make_fftpsf):
     assert fftpsf._log_tick_formatter(-1) == "$10^{-1}$"
     assert fftpsf._log_tick_formatter(-10) == "$10^{-10}$"
 
+
+@patch("matplotlib.pyplot.show")
+def test_invalid_working_FNO(mock_show, make_fftpsf):
+    def tweak(optic):
+        optic.surface_group.surfaces[0].geometry.cs.z = -be.array(1e100)
+
+    fftpsf = make_fftpsf(field=(0, 1), tweak_optic=tweak)
+    with pytest.raises(ValueError):
+        fftpsf.view()
+        plt.close("all")
+    
 
 def test_interpolate_zoom_factor_one(make_fftpsf):
     fftpsf = make_fftpsf(field=(0, 1))


### PR DESCRIPTION
- Updates PSF calculation to use working F/# based on real marginal rays

Updated algorithm:
1. Retrieve the defined given wavelength and field coordinates.
2. Determine the image-space refractive index 'n' at the given wavelength.
3. Trace four marginal rays (top, bottom, left, right) at the pupil edges,
   as well as the chief ray.
4. Compute the angle between each marginal ray and the chief ray.
4. Calculate the average of the squared numerical apertures from all traced
   marginal rays.
5. Compute the working F-number as 1 / (2 * sqrt(average_NA_squared)).
6. Cap the calculated F/# at 10,000 if it exceeds this value.

Fixes #186 