### PR TITLE
Skip image surface when calculating front focal point

### DIFF
--- a/optiland/paraxial.py
+++ b/optiland/paraxial.py
@@ -83,7 +83,7 @@ class Paraxial:
         # start tracing 1 lens unit before first surface
         z_start = -1
         wavelength = self.optic.primary_wavelength
-        y, u = self._trace_generic(1.0, 0.0, z_start, wavelength, reverse=True)
+        y, u = self._trace_generic(1.0, 0.0, z_start, wavelength, reverse=True, skip=1)
         F1 = y[-1] / u[-1]
         return F1[0]
 

--- a/optiland/raytrace/paraxial_ray_tracer.py
+++ b/optiland/raytrace/paraxial_ray_tracer.py
@@ -76,7 +76,7 @@ class ParaxialRayTracer:
             pos = pos[-1] - be.flip(pos)
             surfs = surfs[::-1]
 
-        power = be.diff(n, prepend=be.array([1])) / R
+        power = be.diff(n, prepend=be.array([n[0]])) / R
 
         heights = []
         slopes = []


### PR DESCRIPTION
The front focal point calculation is based on a reverse ray trace that currently starts behind the image surface.
This results in incorrect values if the image surface is curved and has a refractive index $n \neq 1$, because the image surface then refracts the light (see #206).
Furthermore, the paraxial ray trace assumes $n = 1$ behind the image surface, which causes similar problems.
This PR addresses both issues:

- The image surface is skipped in the paraxial ray trace in `Paraxial.F1()`;
- The paraxial ray tracer now assumes the refractive index before the first surface is the same as the index after it (i.e. it prepends `n[0]` to `n` when calculating the power).