### PR TITLE
Add tabulate to demo dependencies

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,9 +9,9 @@ dependencies:
   - pyyaml
   - scipy
   - seaborn
-  - tabulate
   - xeus-python
   - pip:
     - ./jupyterlite/mock_libraries/numba
     - ./jupyterlite/mock_libraries/vtk
+    - tabulate
     - ..

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pyyaml
   - scipy
   - seaborn
+  - tabulate
   - xeus-python
   - pip:
     - ./jupyterlite/mock_libraries/numba


### PR DESCRIPTION
`tabulate` is currently not present in the demo's kernel. As a results, `Optic.info()` fails.