### PR TITLE
bugfix: sag and surface normal + refactor forbes geometry classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ htmlcov/
 **/auto_examples/
 **/gui/
 sg_execution_times.rst
+.qlty/

--- a/optiland/_types.py
+++ b/optiland/_types.py
@@ -50,6 +50,8 @@ SurfaceType = Literal[
     "biconic",
     "chebyshev",
     "even_asphere",
+    "forbes_q2d",
+    "forbes_qbfs",
     "odd_asphere",
     "paraxial",
     "polynomial",
@@ -77,8 +79,7 @@ class SurfaceParameters(TypedDict, total=False):
     toroidal_coeffs_poly_y: list[float]
     zernike_type: ZernikeType
     radial_terms: dict[int, float]
-    freeform_coeffs: dict[tuple[int, int] | tuple[int, int, Literal["sin"]], float]
-    forbes_norm_radius: float
+    freeform_coeffs: dict[tuple[str, int, int], float]
     grating_order: int
     grating_period: float
     groove_orientation_angle: float

--- a/optiland/geometries/__init__.py
+++ b/optiland/geometries/__init__.py
@@ -8,7 +8,12 @@ from .base import BaseGeometry
 from .biconic import BiconicGeometry
 from .chebyshev import ChebyshevPolynomialGeometry
 from .even_asphere import EvenAsphere
-from .forbes import ForbesQ2dGeometry, ForbesQbfsGeometry, SolverConfig, SurfaceConfig
+from .forbes import (
+    ForbesQ2dGeometry,
+    ForbesQbfsGeometry,
+    ForbesSolverConfig,
+    ForbesSurfaceConfig,
+)
 from .newton_raphson import NewtonRaphsonGeometry
 from .odd_asphere import OddAsphere
 from .plane import Plane
@@ -51,6 +56,6 @@ __all__ = [
     # From forbes subpackage
     "ForbesQ2dGeometry",
     "ForbesQbfsGeometry",
-    "SurfaceConfig",
-    "SolverConfig",
+    "ForbesSurfaceConfig",
+    "ForbesSolverConfig",
 ]

--- a/optiland/geometries/__init__.py
+++ b/optiland/geometries/__init__.py
@@ -8,7 +8,7 @@ from .base import BaseGeometry
 from .biconic import BiconicGeometry
 from .chebyshev import ChebyshevPolynomialGeometry
 from .even_asphere import EvenAsphere
-from .forbes import ForbesQ2dGeometry, ForbesQbfsGeometry
+from .forbes import ForbesQ2dGeometry, ForbesQbfsGeometry, SolverConfig, SurfaceConfig
 from .newton_raphson import NewtonRaphsonGeometry
 from .odd_asphere import OddAsphere
 from .plane import Plane
@@ -51,4 +51,6 @@ __all__ = [
     # From forbes subpackage
     "ForbesQ2dGeometry",
     "ForbesQbfsGeometry",
+    "SurfaceConfig",
+    "SolverConfig",
 ]

--- a/optiland/geometries/forbes/__init__.py
+++ b/optiland/geometries/forbes/__init__.py
@@ -4,7 +4,12 @@ for the Optiland backend.
 
 from __future__ import annotations
 
-from .geometry import ForbesQ2dGeometry, ForbesQbfsGeometry, SolverConfig, SurfaceConfig
+from .geometry import (
+    ForbesQ2dGeometry,
+    ForbesQbfsGeometry,
+    ForbesSolverConfig,
+    ForbesSurfaceConfig,
+)
 from .qpoly import (
     compute_z_zprime_q2d,
     q2d_nm_coeffs_to_ams_bms,
@@ -15,6 +20,6 @@ __all__ = [
     "ForbesQbfsGeometry",
     "compute_z_zprime_q2d",
     "q2d_nm_coeffs_to_ams_bms",
-    "SurfaceConfig",
-    "SolverConfig",
+    "ForbesSurfaceConfig",
+    "ForbesSolverConfig",
 ]

--- a/optiland/geometries/forbes/__init__.py
+++ b/optiland/geometries/forbes/__init__.py
@@ -4,15 +4,17 @@ for the Optiland backend.
 
 from __future__ import annotations
 
-from .geometry import ForbesQ2dGeometry, ForbesQbfsGeometry
+from .geometry import ForbesQ2dGeometry, ForbesQbfsGeometry, SolverConfig, SurfaceConfig
 from .qpoly import (
-    Q2d_nm_c_to_a_b,
-    compute_z_zprime_Q2d,
+    compute_z_zprime_q2d,
+    q2d_nm_coeffs_to_ams_bms,
 )
 
 __all__ = [
     "ForbesQ2dGeometry",
     "ForbesQbfsGeometry",
-    "compute_z_zprime_Q2d",
-    "Q2d_nm_c_to_a_b",
+    "compute_z_zprime_q2d",
+    "q2d_nm_coeffs_to_ams_bms",
+    "SurfaceConfig",
+    "SolverConfig",
 ]

--- a/optiland/geometries/forbes/qpoly.py
+++ b/optiland/geometries/forbes/qpoly.py
@@ -1,7 +1,6 @@
 """
 Tools for working with Q (Forbes) polynomials.
 
-
 code adapted in its majority from the prysm package - (https://github.com/brandondube/prysm)
 Manuel Fragata Mendes, 2025
 
@@ -19,208 +18,148 @@ from scipy import special
 import optiland.backend as be
 
 
-def kronecker(i, j):
+def kronecker(i: int, j: int) -> int:
+    """The Kronecker delta function."""
     return 1 if i == j else 0
 
 
-def gamma_func(n, m):
+@lru_cache(None)
+def gamma_func(n: int, m: int) -> float:
+    """Recursive gamma function for Q2D polynomials."""
     if n == 1 and m == 2:
         return 3 / 8
-    elif n == 1 and m > 2:
+    if n == 1 and m > 2:
         mm1 = m - 1
         numerator = 2 * mm1 + 1
         denominator = 2 * (mm1 - 1)
-        coef = numerator / denominator
-        return coef * gamma_func(1, mm1)
-    else:
-        nm1 = n - 1
-        num = (nm1 + 1) * (2 * m + 2 * nm1 - 1)
-        den = (m + nm1 - 2) * (2 * nm1 + 1)
-        coef = num / den
-        return coef * gamma_func(nm1, m)
+        return (numerator / denominator) * gamma_func(1, mm1)
+
+    nm1 = n - 1
+    num = (nm1 + 1) * (2 * m + 2 * nm1 - 1)
+    den = (m + nm1 - 2) * (2 * nm1 + 1)
+    return (num / den) * gamma_func(nm1, m)
 
 
-@lru_cache(1000)
-def g_qbfs(n_minus_1):
+# bfs polynomials logic
+
+
+@lru_cache(None)
+def g_qbfs(n_minus_1: int) -> float:
+    """Recurrence coefficient g for Q-BFS polynomials."""
     if n_minus_1 == 0:
         return -1 / 2
-    else:
-        n_minus_2 = n_minus_1 - 1
-        return -(1 + g_qbfs(n_minus_2) * h_qbfs(n_minus_2)) / f_qbfs(n_minus_1)
+    n_minus_2 = n_minus_1 - 1
+    return -(1 + g_qbfs(n_minus_2) * h_qbfs(n_minus_2)) / f_qbfs(n_minus_1)
 
 
-@lru_cache(1000)
-def h_qbfs(n_minus_2):
+@lru_cache(None)
+def h_qbfs(n_minus_2: int) -> float:
+    """Recurrence coefficient h for Q-BFS polynomials."""
     n = n_minus_2 + 2
     return -n * (n - 1) / (2 * f_qbfs(n_minus_2))
 
 
-@lru_cache(1000)
-def f_qbfs(n):
+@lru_cache(None)
+def f_qbfs(n: int) -> float:
+    """Recurrence coefficient f for Q-BFS polynomials."""
     if n == 0:
-        return 2
-    elif n == 1:
+        return 2.0
+    if n == 1:
         return be.sqrt(19) / 2
-    else:
-        term1 = n * (n + 1) + 3
-        term2 = g_qbfs(n - 1) ** 2
-        term3 = h_qbfs(n - 2) ** 2
-        return be.sqrt(term1 - term2 - term3)
+    term1 = float(n * (n + 1) + 3)
+    term2 = g_qbfs(n - 1) ** 2
+    term3 = h_qbfs(n - 2) ** 2
+    return be.sqrt(term1 - term2 - term3)
 
 
-def change_basis_Qbfs_to_Pn(cs):
+def change_basis_qbfs_to_pn(cs: list[float]) -> be.array:
+    """Changes the basis of Q-BFS coefficients to orthonormal Pn coefficients."""
     bs = be.empty_like(be.array(cs))
-    M = len(bs) - 1
-    if M < 0:
-        return bs
-    fM = f_qbfs(M)
-    bs[M] = cs[M] / fM
-    if M == 0:
+    m = len(bs) - 1
+    if m < 0:
         return bs
 
-    g = g_qbfs(M - 1)
-    f = f_qbfs(M - 1)
-    bs[M - 1] = (cs[M - 1] - g * bs[M]) / f
-    for i in range(M - 2, -1, -1):
+    f_m = f_qbfs(m)
+    bs[m] = cs[m] / f_m
+    if m == 0:
+        return bs
+
+    g = g_qbfs(m - 1)
+    f = f_qbfs(m - 1)
+    bs[m - 1] = (cs[m - 1] - g * bs[m]) / f
+    for i in range(m - 2, -1, -1):
         g = g_qbfs(i)
         h = h_qbfs(i)
         f = f_qbfs(i)
         bs[i] = (cs[i] - g * bs[i + 1] - h * bs[i + 2]) / f
-
     return bs
 
 
 def _initialize_alphas_q(cs, x, alphas, j=0):
-    if alphas is None:
-        shape = (len(cs), *be.shape(x)) if hasattr(x, "shape") else (len(cs),)
-        if j != 0:
-            shape = (j + 1, *shape)
-        if be.get_backend() == "torch":
-            alphas = be.zeros(shape)
-            alphas.requires_grad = False
-        else:
-            alphas = be.zeros(shape)
+    """Initializes the alpha array for Clenshaw's algorithm."""
+    if alphas is not None:
+        return alphas
+    shape = (len(cs), *be.shape(x)) if hasattr(x, "shape") else (len(cs),)
+    if j != 0:
+        shape = (j + 1, *shape)
+    zeros = be.zeros(shape)
+    if be.get_backend() == "torch":
+        zeros.requires_grad = False
+    return zeros
+
+
+def _clenshaw_qbfs_recurrence(bs, usq, alphas):
+    """Backend-agnostic Clenshaw recurrence calculation for Q-BFS."""
+    m = len(bs) - 1
+    if m < 0:
+        return alphas
+
+    prefix = 2 - 4 * usq
+    alphas[m] = bs[m]
+    if m > 0:
+        alphas[m - 1] = bs[m - 1] + prefix * alphas[m]
+    for i in range(m - 2, -1, -1):
+        alphas[i] = bs[i] + prefix * alphas[i + 1] - alphas[i + 2]
     return alphas
 
 
-def _clenshaw_qbfs_functional(bs, usq):
-    """
-    Pure-functional Clenshaw that returns (S, alpha0, alpha1).
-    This version is fixed to handle broadcasting correctly.
-    """
-    M = len(bs) - 1
-    prefix = 2 - 4 * usq
+def clenshaw_qbfs(cs: list[float], usq: be.array, alphas: be.array = None):
+    """Computes the sum of Q-BFS polynomials using Clenshaw's algorithm."""
+    bs = change_basis_qbfs_to_pn(cs)
+    m = len(bs) - 1
+    if m < 0:
+        return be.zeros_like(usq) if hasattr(usq, "shape") else 0.0
 
-    if M < 0:
+    if be.get_backend() == "torch":
+        s, _, _ = _clenshaw_qbfs_functional(bs, usq)
+        if alphas is not None:
+            alphas_res = _clenshaw_qbfs_recurrence(bs, usq, be.empty_like(alphas))
+            alphas[...] = alphas_res
+        return s
+
+    alphas = _initialize_alphas_q(cs, usq, alphas)
+    alphas = _clenshaw_qbfs_recurrence(bs, usq, alphas)
+    return 2 * (alphas[0] + alphas[1]) if m > 0 else 2 * alphas[0]
+
+
+def _clenshaw_qbfs_functional(bs, usq):
+    """Pure-functional Clenshaw that returns (S, alpha0, alpha1)."""
+    m = len(bs) - 1
+    if m < 0:
         zeros = be.zeros_like(usq)
         return zeros, zeros, zeros
 
-    b_curr = bs[M] + usq * 0
+    prefix = 2 - 4 * usq
+    b_curr = bs[m] + usq * 0
     b_next = be.zeros_like(b_curr)
 
-    for n in range(M - 1, -1, -1):
+    for n in range(m - 1, -1, -1):
         b_new = bs[n] + prefix * b_curr - b_next
         b_next, b_curr = b_curr, b_new
 
     alpha0, alpha1 = b_curr, b_next
-    S = 2 * (alpha0 + alpha1) if M > 0 else 2 * alpha0
-    return S, alpha0, alpha1
-
-
-def clenshaw_qbfs(cs, usq, alphas=None):
-    """
-    Computes the sum of Q-BFS polynomials.
-    NOTE: This function returns the raw polynomial sum. The u^2(1-u^2) prefactor
-    is applied by the geometry's sag method.
-    """
-    if be.get_backend() == "torch":
-        bs = change_basis_Qbfs_to_Pn(cs)
-        S, alpha0, _ = _clenshaw_qbfs_functional(bs, usq)
-
-        if alphas is not None:
-            M = len(bs) - 1
-            fill = []
-            if M >= 0:
-                prefix = 2 - 4 * usq
-                alphas_list = [be.zeros_like(alpha0) for _ in range(M + 1)]
-                alphas_list[M] = bs[M] + usq * 0
-                if M > 0:
-                    alphas_list[M - 1] = bs[M - 1] + prefix * alphas_list[M]
-                for i in range(M - 2, -1, -1):
-                    alphas_list[i] = (
-                        bs[i] + prefix * alphas_list[i + 1] - alphas_list[i + 2]
-                    )
-                fill = alphas_list
-            if fill:
-                alphas[...] = be.stack(fill)
-        return S
-
-    # ─ NumPy backend – keep original fast in-place path ─
-    x = usq
-    bs = change_basis_Qbfs_to_Pn(cs)
-    alphas = _initialize_alphas_q(cs, x, alphas, j=0)
-    M = len(bs) - 1
-    if M < 0:
-        return be.zeros_like(x) if hasattr(x, "shape") else 0.0
-
-    prefix = 2 - 4 * x
-    alphas[M] = bs[M]
-    if M > 0:
-        alphas[M - 1] = bs[M - 1] + prefix * alphas[M]
-    for i in range(M - 2, -1, -1):
-        alphas[i] = bs[i] + prefix * alphas[i + 1] - alphas[i + 2]
-
-    S = 2 * (alphas[0] + alphas[1]) if M > 0 else 2 * alphas[0]
-    return S
-
-
-def _clenshaw_qbfs_der_functional(cs, usq, j=1):
-    """Pure-functional Clenshaw for Q-BFS derivatives (PyTorch backend)."""
-    M = len(cs) - 1
-    if M < 0:
-        shape = (
-            (j + 1, len(cs), *be.shape(usq))
-            if hasattr(usq, "shape")
-            else (j + 1, len(cs))
-        )
-        return be.zeros(shape)
-
-    prefix = 2 - 4 * usq
-    bs = change_basis_Qbfs_to_Pn(cs)
-
-    # j=0 part (the polynomial recurrence values)
-    alphas_j0_list = [be.zeros_like(usq) for _ in range(M + 1)]
-    if M >= 0:
-        alphas_j0_list[M] = bs[M] + usq * 0
-    if M >= 1:
-        alphas_j0_list[M - 1] = bs[M - 1] + prefix * alphas_j0_list[M]
-    for i in range(M - 2, -1, -1):
-        alphas_j0_list[i] = (
-            bs[i] + prefix * alphas_j0_list[i + 1] - alphas_j0_list[i + 2]
-        )
-
-    all_alphas_tensors = [be.stack(alphas_j0_list)]
-
-    prev_alphas_j_list = alphas_j0_list
-    for jj in range(1, j + 1):
-        alphas_jj_list = [be.zeros_like(usq) for _ in range(M + 1)]
-        if M - jj >= 0:
-            alphas_jj_list[M - jj] = -4 * jj * prev_alphas_j_list[M - jj + 1]
-        if M - jj - 1 >= 0:
-            alphas_jj_list[M - jj - 1] = (
-                prefix * alphas_jj_list[M - jj] - 4 * jj * prev_alphas_j_list[M - jj]
-            )
-        for n in range(M - jj - 2, -1, -1):
-            alphas_jj_list[n] = (
-                prefix * alphas_jj_list[n + 1]
-                - alphas_jj_list[n + 2]
-                - 4 * jj * prev_alphas_j_list[n + 1]
-            )
-
-        all_alphas_tensors.append(be.stack(alphas_jj_list))
-        prev_alphas_j_list = alphas_jj_list
-
-    return be.stack(all_alphas_tensors)
+    s = 2 * (alpha0 + alpha1) if m > 0 else 2 * alpha0
+    return s, alpha0, alpha1
 
 
 def clenshaw_qbfs_der(cs, usq, j=1, alphas=None):
@@ -228,261 +167,363 @@ def clenshaw_qbfs_der(cs, usq, j=1, alphas=None):
     if be.get_backend() == "torch":
         return _clenshaw_qbfs_der_functional(cs, usq, j)
 
-    # --- NumPy backend – keep original fast in-place path ---
-    x = usq
-    M = len(cs) - 1
-    if M < 0:
-        return _initialize_alphas_q(cs, usq, alphas, j=j)
-
-    prefix = 2 - 4 * x
+    m = len(cs) - 1
     alphas = _initialize_alphas_q(cs, usq, alphas, j=j)
+    if m < 0:
+        return alphas
 
-    # Populate alphas[0] using the in-place buffer argument of clenshaw_qbfs
     clenshaw_qbfs(cs, usq, alphas=alphas[0])
 
+    prefix = 2 - 4 * usq
     for jj in range(1, j + 1):
-        if M - jj < 0:
+        if m - jj < 0:
             continue
-        alphas[jj][M - jj] = -4 * jj * alphas[jj - 1][M - jj + 1]
-        if M - jj - 1 >= 0:
-            alphas[jj][M - jj - 1] = (
-                prefix * alphas[jj][M - jj] - 4 * jj * alphas[jj - 1][M - jj]
+        alphas[jj][m - jj] = -4 * jj * alphas[jj - 1][m - jj + 1]
+        if m - jj - 1 >= 0:
+            alphas[jj][m - jj - 1] = (
+                prefix * alphas[jj][m - jj] - 4 * jj * alphas[jj - 1][m - jj]
             )
-        for n in range(M - jj - 2, -1, -1):
+        for n in range(m - jj - 2, -1, -1):
             alphas[jj][n] = (
                 prefix * alphas[jj][n + 1]
                 - alphas[jj][n + 2]
                 - 4 * jj * alphas[jj - 1][n + 1]
             )
-
     return alphas
 
 
-def compute_z_zprime_Qbfs(coefs, u, usq):
-    """
-    Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u.
-    This version contains the corrected derivative calculation.
-    """
+def _clenshaw_qbfs_der_functional(cs, usq, j=1):
+    """Pure-functional Clenshaw for Q-BFS derivatives (PyTorch backend)."""
+    m = len(cs) - 1
+    if m < 0:
+        shape = (
+            (j + 1, len(cs), *be.shape(usq))
+            if hasattr(usq, "shape")
+            else (j + 1, len(cs))
+        )
+        return be.zeros(shape)
+
+    bs = change_basis_qbfs_to_pn(cs)
+    prefix = 2 - 4 * usq
+
+    alphas_j0_list = list(
+        _clenshaw_qbfs_recurrence(bs, usq, be.empty((len(bs), *usq.shape)))
+    )
+    all_alphas_tensors = [be.stack(alphas_j0_list)]
+    prev_alphas_j_list = alphas_j0_list
+
+    for jj in range(1, j + 1):
+        alphas_jj_list = [be.zeros_like(usq) for _ in range(m + 1)]
+        if m - jj >= 0:
+            alphas_jj_list[m - jj] = -4 * jj * prev_alphas_j_list[m - jj + 1]
+        if m - jj - 1 >= 0:
+            alphas_jj_list[m - jj - 1] = (
+                prefix * alphas_jj_list[m - jj] - 4 * jj * prev_alphas_j_list[m - jj]
+            )
+        for n in range(m - jj - 2, -1, -1):
+            alphas_jj_list[n] = (
+                prefix * alphas_jj_list[n + 1]
+                - alphas_jj_list[n + 2]
+                - 4 * jj * prev_alphas_j_list[n + 1]
+            )
+        all_alphas_tensors.append(be.stack(alphas_jj_list))
+        prev_alphas_j_list = alphas_jj_list
+
+    return be.stack(all_alphas_tensors)
+
+
+def compute_z_zprime_qbfs(
+    coefs: list[float], u: be.array, usq: be.array
+) -> tuple[be.array, be.array]:
+    """Computes the raw Q-BFS polynomial sum and its derivative w.r.t. u."""
     if coefs is None or len(coefs) == 0:
         zeros = be.zeros_like(u)
         return zeros, zeros
 
     alphas = clenshaw_qbfs_der(coefs, usq, j=1)
 
-    # The sum S is 2*(alpha_0 + alpha_1)
-    # The derivative S' w.r.t. usq is 2*(alpha_0' + alpha_1')
     if len(coefs) > 1:
-        S = 2 * (alphas[0][0] + alphas[0][1])
-        dS_dusq = 2 * (alphas[1][0] + alphas[1][1])
+        s = 2 * (alphas[0, 0] + alphas[0, 1])
+        ds_dusq = 2 * (alphas[1, 0] + alphas[1, 1])
     else:
-        S = 2 * alphas[0][0]
-        dS_dusq = 2 * alphas[1][0]
+        s = 2 * alphas[0, 0]
+        ds_dusq = 2 * alphas[1, 0]
 
-    # dS/du = dS/dusq * d(usq)/du
-    # d(usq)/du = d(u^2)/du = 2*u
-    dS_du = dS_dusq * 2 * u
-    return S, dS_du
+    ds_du = ds_dusq * 2 * u
+    return s, ds_du
 
 
-@lru_cache(4000)
-def abc_q2d(n, m):
-    D = (4 * n**2 - 1) * (m + n - 2) * (m + 2 * n - 3)
-    if D == 0:
-        D = 1e-99
-    term1 = (2 * n - 1) * (m + 2 * n - 2)
-    term2 = 4 * n * (m + n - 2) + (m - 3) * (2 * m - 1)
-    A = (term1 * term2) / D
-    num = -2 * (2 * n - 1) * (m + 2 * n - 3) * (m + 2 * n - 2) * (m + 2 * n - 1)
-    B = num / D
-    num = n * (2 * n - 3) * (m + 2 * n - 1) * (2 * m + 2 * n - 3)
-    C = num / D
-    return A, B, C
+# q2d polynomials logic
 
 
-@lru_cache(4000)
-def G_q2d(n, m):
+@lru_cache(None)
+def _g_q2d_raw(n: int, m: int) -> float:
+    """Raw G coefficient for Q2D polynomials."""
     if n == 0:
         num = special.factorial2(2 * m - 1)
         den = 2 ** (m + 1) * special.factorial(m - 1)
         return num / den
-    elif n > 0 and m == 1:
+    if n > 0 and m == 1:
         t1num = (2 * n**2 - 1) * (n**2 - 1)
         t1den = 8 * (4 * n**2 - 1)
         term1 = -t1num / t1den
         term2 = 1 / 24 * kronecker(n, 1)
         return term1 - term2
-    else:
-        nt1 = 2 * n * (m + n - 1) - m
-        nt2 = (n + 1) * (2 * m + 2 * n - 1)
-        num = nt1 * nt2
-        dt1 = (m + 2 * n - 2) * (m + 2 * n - 1)
-        dt2 = (m + 2 * n) * (2 * n + 1)
-        den = dt1 * dt2
-        term1 = -num / den
-        return term1 * gamma_func(n, m)
+
+    nt1 = 2 * n * (m + n - 1) - m
+    nt2 = (n + 1) * (2 * m + 2 * n - 1)
+    num = nt1 * nt2
+    dt1 = (m + 2 * n - 2) * (m + 2 * n - 1)
+    dt2 = (m + 2 * n) * (2 * n + 1)
+    den = dt1 * dt2
+    term1 = -num / den
+    return term1 * gamma_func(n, m)
 
 
-@lru_cache(4000)
-def F_q2d(n, m):
+@lru_cache(None)
+def _f_q2d_raw(n: int, m: int) -> float:
+    """Raw F coefficient for Q2D polynomials."""
     if n == 0 and m == 1:
         return 0.25
     if n == 0:
         num = m**2 * special.factorial2(2 * m - 3)
         den = 2 ** (m + 1) * special.factorial(m - 1)
         return num / den
-    elif n > 0 and m == 1:
+    if n > 0 and m == 1:
         t1num = 4 * (n - 1) ** 2 * n**2 + 1
         t1den = 8 * (2 * n - 1) ** 2
         term1 = t1num / t1den
         term2 = 11 / 32 * kronecker(n, 1)
         return term1 + term2
-    else:
-        Chi = m + n - 2
-        nt1 = 2 * n * Chi * (3 - 5 * m + 4 * n * Chi)
-        nt2 = m**2 * (3 - m + 4 * n * Chi)
-        num = nt1 + nt2
-        dt1 = (m + 2 * n - 3) * (m + 2 * n - 2)
-        dt2 = (m + 2 * n - 1) * (2 * n - 1)
-        den = dt1 * dt2
-        term1 = num / den
-        return term1 * gamma_func(n, m)
+
+    chi = m + n - 2
+    nt1 = 2 * n * chi * (3 - 5 * m + 4 * n * chi)
+    nt2 = m**2 * (3 - m + 4 * n * chi)
+    num = nt1 + nt2
+    dt1 = (m + 2 * n - 3) * (m + 2 * n - 2)
+    dt2 = (m + 2 * n - 1) * (2 * n - 1)
+    den = dt1 * dt2
+    term1 = num / den
+    return term1 * gamma_func(n, m)
 
 
-@lru_cache(4000)
-def g_q2d(n, m):
-    return G_q2d(n, m) / f_q2d(n, m)
+@lru_cache(None)
+def g_q2d(n: int, m: int) -> float:
+    """Recurrence coefficient g for Q2D polynomials."""
+    return _g_q2d_raw(n, m) / f_q2d(n, m)
 
 
-@lru_cache(4000)
-def f_q2d(n, m):
+@lru_cache(None)
+def f_q2d(n: int, m: int) -> float:
+    """Recurrence coefficient f for Q2D polynomials."""
     if n == 0:
-        return be.sqrt(F_q2d(n=0, m=m))
-    else:
-        return be.sqrt(F_q2d(n, m) - g_q2d(n - 1, m) ** 2)
+        return be.sqrt(_f_q2d_raw(n=0, m=m))
+    return be.sqrt(_f_q2d_raw(n, m) - g_q2d(n - 1, m) ** 2)
 
 
-def change_of_basis_Q2d_to_Pnm(cns, m):
-    if m < 0:
-        m = -m
-    cs = cns
-    ds = be.empty_like(be.array(cs))
-    N = len(cs) - 1
-    if N < 0:
+def change_basis_q2d_to_pnm(cns: list[float], m: int) -> be.array:
+    """Changes the basis of Q2D coefficients to orthonormal Pnm coefficients."""
+    m = abs(m)
+    ds = be.empty_like(be.array(cns))
+    n_max = len(cns) - 1
+    if n_max < 0:
         return ds
-    ds[N] = cs[N] / f_q2d(N, m)
-    for n in range(N - 1, -1, -1):
-        ds[n] = (cs[n] - g_q2d(n, m) * ds[n + 1]) / f_q2d(n, m)
+
+    ds[n_max] = cns[n_max] / f_q2d(n_max, m)
+    for n in range(n_max - 1, -1, -1):
+        ds[n] = (cns[n] - g_q2d(n, m) * ds[n + 1]) / f_q2d(n, m)
     return ds
 
 
-@lru_cache(4000)
-def abc_q2d_clenshaw(n, m):
-    if m == 1:
-        if n == 0:
-            return 2, -1, 0
-        if n == 1:
-            return -4 / 3, -8 / 3, -11 / 3
-        if n == 2:
-            return 9 / 5, -24 / 5, 0
-    if m == 2 and n == 0:
-        return 3, -2, 0
-    if m == 3 and n == 0:
-        return 5, -4, 0
-    return abc_q2d(n, m)
+_ABC_Q2D_SPECIAL_CASES = {
+    (1, 0): (2, -1, 0),
+    (1, 1): (-4 / 3, -8 / 3, -11 / 3),
+    (1, 2): (9 / 5, -24 / 5, 0),
+    (2, 0): (3, -2, 0),
+    (3, 0): (5, -4, 0),
+}
 
 
-def _clenshaw_q2d_functional(ds, m, usq):
-    """Pure-functional Clenshaw for Q2D polynomials."""
-    x = usq
-    N = len(ds) - 1
-    if N < 0:
-        return []
+@lru_cache(None)
+def abc_q2d(n: int, m: int) -> tuple[float, float, float]:
+    """Recurrence coefficients A, B, C for Q2D Clenshaw algorithm."""
+    d = (4 * n**2 - 1) * (m + n - 2) * (m + 2 * n - 3)
+    if d == 0:
+        d = 1e-99
+    term1 = (2 * n - 1) * (m + 2 * n - 2)
+    term2 = 4 * n * (m + n - 2) + (m - 3) * (2 * m - 1)
+    a = (term1 * term2) / d
+    num_b = -2 * (2 * n - 1) * (m + 2 * n - 3) * (m + 2 * n - 2) * (m + 2 * n - 1)
+    b = num_b / d
+    num_c = n * (2 * n - 3) * (m + 2 * n - 1) * (2 * m + 2 * n - 3)
+    c = num_c / d
+    return a, b, c
 
-    all_alphas = [be.zeros_like(x) for _ in range(N + 1)]
 
-    if N >= 0:
-        all_alphas[N] = ds[N] + x * 0
+def abc_q2d_clenshaw(n: int, m: int) -> tuple[float, float, float]:
+    """Provides A, B, C coefficients for Clenshaw, handling special cases."""
+    return _ABC_Q2D_SPECIAL_CASES.get((m, n), abc_q2d(n, m))
 
-    if N >= 1:
-        A, B, _ = abc_q2d_clenshaw(N - 1, m)
-        all_alphas[N - 1] = ds[N - 1] + (A + B * x) * all_alphas[N]
 
-    for n in range(N - 2, -1, -1):
-        A, B, _ = abc_q2d_clenshaw(n, m)
-        _, _, C = abc_q2d_clenshaw(n + 1, m)
-        all_alphas[n] = ds[n] + (A + B * x) * all_alphas[n + 1] - C * all_alphas[n + 2]
+def q2d_sum_from_alphas(alphas: be.array, m: int, num_coeffs: int) -> be.array:
+    """
+    Computes the final sum from the alpha coefficients returned by Clenshaw's
+    method, applying the special summation rule for m=1.
+    """
+    s = 0.5 * alphas[0]
+    # special case for m=1, as in Forbes' papers
+    if m == 1 and num_coeffs - 1 > 2:
+        s -= 2 / 5 * alphas[3]
+    return s
 
-    return all_alphas
+
+def _get_s_and_s_prime(alphas, m, num_coeffs):
+    """Helper to compute S and S' from alpha derivatives for Q2D."""
+    s = q2d_sum_from_alphas(alphas[0], m, num_coeffs)
+    s_prime = q2d_sum_from_alphas(alphas[1], m, num_coeffs)
+    return s, s_prime
+
+
+def _compute_m_gt0_components(ams, bms, u, t, usq):
+    """Computes the sum and derivatives for all m>0 components."""
+    poly_sum_terms = []
+    dr_terms = []
+    dt_terms = []
+
+    for m_idx, (a_coef, b_coef) in enumerate(zip(ams, bms, strict=False)):
+        m = m_idx + 1
+        has_a = a_coef and any(c != 0 for c in a_coef)
+        has_b = b_coef and any(c != 0 for c in b_coef)
+        if not has_a and not has_b:
+            continue
+
+        s_a, s_b, s_prime_a, s_prime_b = 0, 0, 0, 0
+        if has_a:
+            alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1)
+            s_a, s_prime_a = _get_s_and_s_prime(alphas_a, m, len(a_coef))
+        if has_b:
+            alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1)
+            s_b, s_prime_b = _get_s_and_s_prime(alphas_b, m, len(b_coef))
+
+        um = u**m
+        cost = be.cos(m * t)
+        sint = be.sin(m * t)
+
+        poly_sum_terms.append(um * (cost * s_a + sint * s_b))
+        umm1 = u ** (m - 1) if m > 0 else be.ones_like(u)
+        two_usq = 2 * usq
+
+        aterm = cost * (two_usq * s_prime_a + m * s_a)
+        bterm = sint * (two_usq * s_prime_b + m * s_b)
+        dr_terms.append(umm1 * (aterm + bterm))
+        dt_terms.append(m * um * (-s_a * sint + s_b * cost))
+
+    zeros = be.zeros_like(u)
+    poly_sum_m_gt0 = (
+        be.sum(be.stack(poly_sum_terms), axis=0) if poly_sum_terms else zeros
+    )
+    dr_m_gt0 = be.sum(be.stack(dr_terms), axis=0) if dr_terms else zeros
+    dt_m_gt0 = be.sum(be.stack(dt_terms), axis=0) if dt_terms else zeros
+
+    return poly_sum_m_gt0, dr_m_gt0, dt_m_gt0
+
+
+def compute_z_zprime_q2d(cm0, ams, bms, u, t):
+    """Computes the polynomial sum components for a Q2D surface."""
+    usq = u * u
+    zeros = be.zeros_like(u)
+
+    poly_sum_m0, d_poly_sum_m0_du = zeros, zeros
+    if cm0 and any(c != 0 for c in cm0):
+        poly_sum_m0, d_poly_sum_m0_du = compute_z_zprime_qbfs(cm0, u, usq)
+
+    poly_sum_m_gt0, dr_m_gt0, dt_m_gt0 = _compute_m_gt0_components(ams, bms, u, t, usq)
+
+    return poly_sum_m0, d_poly_sum_m0_du, poly_sum_m_gt0, dr_m_gt0, dt_m_gt0
+
+
+def q2d_nm_coeffs_to_ams_bms(nms: list[tuple[int, int]], coefs: list[float]):
+    """Converts a list of (n, m) indexed coefficients to grouped a_m and b_m lists."""
+    cms = []
+    ac = defaultdict(list)
+    bc = defaultdict(list)
+
+    for (n, m), c in zip(nms, coefs, strict=False):
+        if m == 0:
+            if n >= len(cms):
+                cms.extend([0.0] * (n - len(cms) + 1))
+            cms[n] = c
+            continue
+
+        target_dict = ac if m > 0 else bc
+        m_abs = abs(m)
+        if n >= len(target_dict[m_abs]):
+            target_dict[m_abs].extend([0.0] * (n - len(target_dict[m_abs]) + 1))
+        target_dict[m_abs][n] = c
+
+    max_m = 0
+    if ac:
+        max_m = max(max_m, max(ac.keys()))
+    if bc:
+        max_m = max(max_m, max(bc.keys()))
+
+    ams_ret = [ac.get(i, []) for i in range(1, max_m + 1)]
+    bms_ret = [bc.get(i, []) for i in range(1, max_m + 1)]
+
+    return cms, ams_ret, bms_ret
 
 
 def clenshaw_q2d(cns, m, usq, alphas=None):
     if be.get_backend() == "torch":
-        ds = change_of_basis_Q2d_to_Pnm(cns, m)
+        ds = change_basis_q2d_to_pnm(cns, m)
         all_alphas_list = _clenshaw_q2d_functional(ds, m, usq)
 
-        if alphas is not None and all_alphas_list:
-            alphas[...] = be.stack(all_alphas_list)
+        if not all_alphas_list:
+            return _initialize_alphas_q(cns, usq, alphas)
+
+        result_tensor = be.stack(all_alphas_list)
+        if alphas is not None:
+            alphas[...] = result_tensor
+            return alphas
+        return result_tensor
+
+    ds = change_basis_q2d_to_pnm(cns, m)
+    alphas = _initialize_alphas_q(ds, usq, alphas)
+    n_max = len(ds) - 1
+    if n_max < 0:
         return alphas
 
-    # --- NumPy backend – keep original fast in-place path ---
-    x = usq
-    ds = change_of_basis_Q2d_to_Pnm(cns, m)
-    alphas = _initialize_alphas_q(ds, x, alphas, j=0)
-    N = len(ds) - 1
-    if N < 0:
-        return alphas
+    alphas[n_max] = ds[n_max]
+    if n_max > 0:
+        a, b, _ = abc_q2d_clenshaw(n_max - 1, m)
+        alphas[n_max - 1] = ds[n_max - 1] + (a + b * usq) * alphas[n_max]
 
-    alphas[N] = ds[N]
-    if N == 0:
-        return alphas
-
-    A, B, _ = abc_q2d_clenshaw(N - 1, m)
-    alphas[N - 1] = ds[N - 1] + (A + B * x) * alphas[N]
-    for n in range(N - 2, -1, -1):
-        A, B, _ = abc_q2d_clenshaw(n, m)
-        _, _, C = abc_q2d_clenshaw(n + 1, m)
-        alphas[n] = ds[n] + (A + B * x) * alphas[n + 1] - C * alphas[n + 2]
+    for n in range(n_max - 2, -1, -1):
+        a, b, _ = abc_q2d_clenshaw(n, m)
+        _, _, c = abc_q2d_clenshaw(n + 1, m)
+        alphas[n] = ds[n] + (a + b * usq) * alphas[n + 1] - c * alphas[n + 2]
     return alphas
 
 
-def _clenshaw_q2d_der_functional(cns, m, usq, j=1):
-    """Pure-functional Clenshaw for Q-2D derivatives (PyTorch backend)."""
-    N = len(cns) - 1
-    x = usq
+def _clenshaw_q2d_functional(ds, m, usq):
+    """Pure-functional Clenshaw for Q2D polynomials."""
+    n_max = len(ds) - 1
+    if n_max < 0:
+        return []
 
-    if N < 0:
-        shape = (
-            (j + 1, len(cns), *be.shape(usq))
-            if hasattr(usq, "shape")
-            else (j + 1, len(cns))
+    all_alphas = [be.zeros_like(usq) for _ in range(n_max + 1)]
+    if n_max >= 0:
+        all_alphas[n_max] = ds[n_max] + usq * 0
+    if n_max >= 1:
+        a, b, _ = abc_q2d_clenshaw(n_max - 1, m)
+        all_alphas[n_max - 1] = ds[n_max - 1] + (a + b * usq) * all_alphas[n_max]
+    for n in range(n_max - 2, -1, -1):
+        a, b, _ = abc_q2d_clenshaw(n, m)
+        _, _, c = abc_q2d_clenshaw(n + 1, m)
+        all_alphas[n] = (
+            ds[n] + (a + b * usq) * all_alphas[n + 1] - c * all_alphas[n + 2]
         )
-        return be.zeros(shape)
-
-    ds = change_of_basis_Q2d_to_Pnm(cns, m)
-
-    # j=0 part
-    alphas_j0_list = _clenshaw_q2d_functional(ds, m, usq)
-    all_alphas_tensors = [be.stack(alphas_j0_list)]
-
-    prev_alphas_j_list = alphas_j0_list
-    for jj in range(1, j + 1):
-        alphas_jj_list = [be.zeros_like(x) for _ in range(N + 1)]
-        if N - jj >= 0:
-            _, b, _ = abc_q2d_clenshaw(N - jj, m)
-            alphas_jj_list[N - jj] = jj * b * prev_alphas_j_list[N - jj + 1]
-            for n in range(N - jj - 1, -1, -1):
-                a, b, _ = abc_q2d_clenshaw(n, m)
-                _, _, c = abc_q2d_clenshaw(n + 1, m)
-                alphas_jj_list[n] = (
-                    jj * b * prev_alphas_j_list[n + 1]
-                    + (a + b * x) * alphas_jj_list[n + 1]
-                    - c * alphas_jj_list[n + 2]
-                )
-
-        all_alphas_tensors.append(be.stack(alphas_jj_list))
-        prev_alphas_j_list = alphas_jj_list
-
-    return be.stack(all_alphas_tensors)
+    return all_alphas
 
 
 def clenshaw_q2d_der(cns, m, usq, j=1, alphas=None):
@@ -490,145 +531,57 @@ def clenshaw_q2d_der(cns, m, usq, j=1, alphas=None):
     if be.get_backend() == "torch":
         return _clenshaw_q2d_der_functional(cns, m, usq, j)
 
-    # --- NumPy backend – keep original fast in-place path ---
-    cs = cns
-    x = usq
-    N = len(cs) - 1
-    alphas = _initialize_alphas_q(cs, x, alphas, j=j)
-    if N < 0:
+    n_max = len(cns) - 1
+    alphas = _initialize_alphas_q(cns, usq, alphas, j=j)
+    if n_max < 0:
         return alphas
 
-    clenshaw_q2d(cs, m, x, alphas[0])
+    clenshaw_q2d(cns, m, usq, alphas[0])
     for jj in range(1, j + 1):
-        if N - jj < 0:
+        if n_max - jj < 0:
             continue
-        _, b, _ = abc_q2d_clenshaw(N - jj, m)
-        alphas[jj][N - jj] = jj * b * alphas[jj - 1][N - jj + 1]
-        for n in range(N - jj - 1, -1, -1):
+        _, b, _ = abc_q2d_clenshaw(n_max - jj, m)
+        alphas[jj][n_max - jj] = jj * b * alphas[jj - 1][n_max - jj + 1]
+        for n in range(n_max - jj - 1, -1, -1):
             a, b, _ = abc_q2d_clenshaw(n, m)
             _, _, c = abc_q2d_clenshaw(n + 1, m)
             alphas[jj][n] = (
                 jj * b * alphas[jj - 1][n + 1]
-                + (a + b * x) * alphas[jj][n + 1]
+                + (a + b * usq) * alphas[jj][n + 1]
                 - c * alphas[jj][n + 2]
             )
-
     return alphas
 
 
-def compute_z_zprime_Q2d(cm0, ams, bms, u, t):
-    """
-    Computes the polynomial sum components for a Q2D surface.
-    """
-    usq = u * u
-    zeros = be.zeros_like(u)
+def _clenshaw_q2d_der_functional(cns, m, usq, j=1):
+    """Pure-functional Clenshaw for Q-2D derivatives (PyTorch backend)."""
+    n_max = len(cns) - 1
+    if n_max < 0:
+        shape = (
+            (j + 1, len(cns), *be.shape(usq))
+            if hasattr(usq, "shape")
+            else (j + 1, len(cns))
+        )
+        return be.zeros(shape)
 
-    # --- m=0 component ---
-    poly_sum_m0, d_poly_sum_m0_du = zeros, zeros
-    if cm0 is not None and any(c != 0 for c in cm0):
-        poly_sum_m0, d_poly_sum_m0_du = compute_z_zprime_Qbfs(cm0, u, usq)
+    ds = change_basis_q2d_to_pnm(cns, m)
+    alphas_j0_list = _clenshaw_q2d_functional(ds, m, usq)
+    all_alphas_tensors = [be.stack(alphas_j0_list)]
+    prev_alphas_j_list = alphas_j0_list
 
-    # --- m>0 components ---
-    poly_sum_m_gt0 = be.zeros_like(u)
-    dr_m_gt0 = be.zeros_like(u)
-    dt_m_gt0 = be.zeros_like(u)
-
-    m = 0
-    for a_coef, b_coef in zip(ams, bms, strict=False):
-        m = m + 1
-        has_a = a_coef is not None and any(c != 0 for c in a_coef)
-        has_b = b_coef is not None and any(c != 0 for c in b_coef)
-        if not has_a and not has_b:
-            continue
-
-        alphas_a = clenshaw_q2d_der(a_coef, m, usq, j=1) if has_a else None
-        alphas_b = clenshaw_q2d_der(b_coef, m, usq, j=1) if has_b else None
-
-        Sa, Sb, Sprimea, Sprimeb = 0, 0, 0, 0
-        if alphas_a is not None:
-            Sa = 0.5 * alphas_a[0][0]
-            Sprimea = 0.5 * alphas_a[1][0]
-            if m == 1 and len(a_coef) - 1 > 2:
-                Sa = Sa - 2 / 5 * alphas_a[0][3]
-                Sprimea = Sprimea - 2 / 5 * alphas_a[1][3]
-
-        if alphas_b is not None:
-            Sb = 0.5 * alphas_b[0][0]
-            Sprimeb = 0.5 * alphas_b[1][0]
-            if m == 1 and len(b_coef) - 1 > 2:
-                Sb = Sb - 2 / 5 * alphas_b[0][3]
-                Sprimeb = Sprimeb - 2 / 5 * alphas_b[1][3]
-
-        um = u**m
-        cost = be.cos(m * t)
-        sint = be.sin(m * t)
-
-        kernel = cost * Sa + sint * Sb
-        poly_sum_m_gt0 = poly_sum_m_gt0 + um * kernel
-
-        umm1 = u ** (m - 1) if m > 0 else be.ones_like(u)
-        twousq = 2 * usq
-
-        aterm = cost * (twousq * Sprimea + m * Sa)
-        bterm = sint * (twousq * Sprimeb + m * Sb)
-        dr_m_gt0 = dr_m_gt0 + umm1 * (aterm + bterm)
-        dt_m_gt0 = dt_m_gt0 + m * um * (-Sa * sint + Sb * cost)
-
-    return poly_sum_m0, d_poly_sum_m0_du, poly_sum_m_gt0, dr_m_gt0, dt_m_gt0
-
-
-def Q2d_nm_c_to_a_b(nms, coefs):
-    def factory():
-        return []
-
-    def expand_and_copy(cs, N):
-        cs2 = [0.0] * (N + 1)
-        for i, cc in enumerate(cs):
-            cs2[i] = cc
-        return cs2
-
-    cms = []
-    ac = defaultdict(factory)
-    bc = defaultdict(factory)
-
-    for (n, m), c in zip(nms, coefs, strict=False):
-        if m == 0:
-            if len(cms) < n + 1:
-                cms = expand_and_copy(cms, n)
-            cms[n] = c
-        elif m > 0:
-            if len(ac[m]) < n + 1:
-                ac[m] = expand_and_copy(ac[m], n)
-            ac[m][n] = c
-        else:  # m < 0
-            m_abs = -m
-            if len(bc[m_abs]) < n + 1:
-                bc[m_abs] = expand_and_copy(bc[m_abs], n)
-            bc[m_abs][n] = c
-
-    # Fill in missing zero coefficients
-    max_n_cm0 = max([n for (n, m) in nms if m == 0] or [-1])
-    if len(cms) < max_n_cm0 + 1:
-        cms = expand_and_copy(cms, max_n_cm0)
-
-    max_m_a = max([m for (n, m) in nms if m > 0] or [0])
-    max_m_b = max([abs(m) for (n, m) in nms if m < 0] or [0])
-    max_m = max(max_m_a, max_m_b)
-
-    ac_ret = []
-    bc_ret = []
-    for i in range(1, max_m + 1):
-        max_n_a = max([n for (n, m) in nms if m == i] or [-1])
-        max_n_b = max([n for (n, m) in nms if m == -i] or [-1])
-
-        a_list = ac.get(i, [])
-        if len(a_list) < max_n_a + 1:
-            a_list = expand_and_copy(a_list, max_n_a)
-        ac_ret.append(a_list)
-
-        b_list = bc.get(i, [])
-        if len(b_list) < max_n_b + 1:
-            b_list = expand_and_copy(b_list, max_n_b)
-        bc_ret.append(b_list)
-
-    return cms, ac_ret, bc_ret
+    for jj in range(1, j + 1):
+        alphas_jj_list = [be.zeros_like(usq) for _ in range(n_max + 1)]
+        if n_max - jj >= 0:
+            _, b, _ = abc_q2d_clenshaw(n_max - jj, m)
+            alphas_jj_list[n_max - jj] = jj * b * prev_alphas_j_list[n_max - jj + 1]
+            for n in range(n_max - jj - 1, -1, -1):
+                a, b, _ = abc_q2d_clenshaw(n, m)
+                _, _, c = abc_q2d_clenshaw(n + 1, m)
+                alphas_jj_list[n] = (
+                    jj * b * prev_alphas_j_list[n + 1]
+                    + (a + b * usq) * alphas_jj_list[n + 1]
+                    - c * alphas_jj_list[n + 2]
+                )
+        all_alphas_tensors.append(be.stack(alphas_jj_list))
+        prev_alphas_j_list = alphas_jj_list
+    return be.stack(all_alphas_tensors)

--- a/optiland/optimization/variable/forbes_coeff.py
+++ b/optiland/optimization/variable/forbes_coeff.py
@@ -1,6 +1,8 @@
-"""This module provides specialized variable handlers for Forbes polynomial
-coefficients, distinguishing between the rotationally symmetric Q-bfs
-surfaces and the freeform Q-2D surfaces.
+"""Specialized variable handlers for Forbes polynomial coefficients.
+
+This module provides handlers for Forbes polynomial coefficients,
+distinguishing between rotationally symmetric (Q-bfs) and freeform (Q-2D)
+surfaces.
 
 Manuel Fragata Mendes, August 2025
 """
@@ -12,19 +14,38 @@ from optiland.optimization.variable.base import VariableBehavior
 
 
 class ForbesQbfsCoeffVariable(VariableBehavior):
-    """
-    Represents a variable for a Forbes Q-bfs (rotationally symmetric) coefficient.
+    """Represents a variable for a Forbes Q-bfs coefficient.
+
     This variable targets a coefficient for a specific radial order `n`.
+
+    Attributes:
+        coeff_number (int): The radial order 'n' of the coefficient.
     """
 
     def __init__(
         self, optic, surface_number, coeff_number, apply_scaling=False, **kwargs
     ):
+        """Initializes the ForbesQbfsCoeffVariable.
+
+        Args:
+            optic: The optical system.
+            surface_number (int): The surface number to which the coefficient belongs.
+            coeff_number (int): The radial order 'n' of the coefficient.
+            apply_scaling (bool, optional): Whether to apply scaling. Defaults to False.
+            **kwargs: Additional keyword arguments.
+        """
         super().__init__(optic, surface_number, apply_scaling, **kwargs)
         self.coeff_number = coeff_number  # the radial order 'n'
 
     def get_value(self):
-        """Gets the value of the nth Q-bfs coefficient from the radial_terms dict."""
+        """Gets the value of the nth Q-bfs coefficient.
+
+        Returns:
+            float: The value of the coefficient.
+
+        Raises:
+            TypeError: If the geometry is not a ForbesQbfsGeometry.
+        """
         surf = self._surfaces.surfaces[self.surface_number]
         geom = surf.geometry
         if not isinstance(geom, ForbesQbfsGeometry):
@@ -37,7 +58,11 @@ class ForbesQbfsCoeffVariable(VariableBehavior):
         return value
 
     def update_value(self, new_value):
-        """Updates the value of the nth Q-bfs coefficient in the radial_terms dict."""
+        """Updates the value of the nth Q-bfs coefficient.
+
+        Args:
+            new_value (float): The new value for the coefficient.
+        """
         if self.apply_scaling:
             new_value = self.inverse_scale(new_value)
 
@@ -62,28 +87,35 @@ class ForbesQbfsCoeffVariable(VariableBehavior):
 
 
 class ForbesQ2dCoeffVariable(VariableBehavior):
-    """
-    Represents a variable for a Forbes Q-2D (freeform) coefficient.
+    """Represents a variable for a Forbes Q-2D (freeform) coefficient.
+
     This variable targets the coefficient `c` corresponding to a specific
     (type, m, n) term, following the Zemax convention.
+
+    Attributes:
+        attribute (str): The name of the attribute holding the coefficients.
+        m (int): The azimuthal frequency `m`.
+        n (int): The radial order `n`.
+        term_type (str): The type of term ('cos' or 'sin').
+        coeff_tuple (tuple): The identifier for the coefficient.
     """
 
     def __init__(
         self, optic, surface_number, coeff_tuple, apply_scaling=False, **kwargs
     ):
-        """
-        Initializes the ForbesQ2dCoeffVariable.
+        """Initializes the ForbesQ2dCoeffVariable.
 
-        Parameters
-        ----------
-        optic : Optic
-            The optical system.
-        surface_number : int
-            The surface number to which the coefficient belongs.
-        coeff_tuple : tuple
-            The identifier for the coefficient, following the Zemax convention:
-            - ('a', m, n) for a cosine term a_n^m
-            - ('b', m, n) for a sine term b_n^m
+        Args:
+            optic: The optical system.
+            surface_number (int): The surface number to which the coefficient belongs.
+            coeff_tuple (tuple): The identifier for the coefficient, following the
+                Zemax convention: `('a', m, n)` for a cosine term a_n^m, or
+                `('b', m, n)` for a sine term b_n^m.
+            apply_scaling (bool, optional): Whether to apply scaling. Defaults to False.
+            **kwargs: Additional keyword arguments.
+
+        Raises:
+            ValueError: If `coeff_tuple` is not in the correct format.
         """
         super().__init__(optic, surface_number, apply_scaling, **kwargs)
         self.attribute = "freeform_coeffs"
@@ -108,7 +140,14 @@ class ForbesQ2dCoeffVariable(VariableBehavior):
         self.coeff_tuple = coeff_tuple
 
     def get_value(self):
-        """Gets the value of the coefficient for the specified term."""
+        """Gets the value of the coefficient for the specified term.
+
+        Returns:
+            float: The value of the coefficient.
+
+        Raises:
+            TypeError: If the geometry is not a ForbesQ2dGeometry.
+        """
         surf = self._surfaces.surfaces[self.surface_number]
         geom = surf.geometry
         if not isinstance(geom, ForbesQ2dGeometry):
@@ -117,7 +156,11 @@ class ForbesQ2dCoeffVariable(VariableBehavior):
         return geom.freeform_coeffs.get(self.coeff_tuple, 0.0)
 
     def update_value(self, new_value):
-        """Updates the value of the coefficient for the specified term."""
+        """Updates the value of the coefficient for the specified term.
+
+        Args:
+            new_value (float): The new value for the coefficient.
+        """
         surf = self.optic.surface_group.surfaces[self.surface_number]
         geom = surf.geometry
 

--- a/optiland/surfaces/factories/geometry_factory.py
+++ b/optiland/surfaces/factories/geometry_factory.py
@@ -22,11 +22,12 @@ from optiland.geometries import (
     ForbesQbfsGeometry,
     OddAsphere,
     Plane,
+    PlaneGrating,
     PolynomialGeometry,
-    SolverConfig,
+    SolverConfig,  # forbes
     StandardGeometry,
-    # dataclass from forbes geometry
-    SurfaceConfig,
+    StandardGratingGeometry,
+    SurfaceConfig,  # forbes
     ToroidalGeometry,
     ZernikePolynomialGeometry,
 )
@@ -64,6 +65,9 @@ class GeometryConfig:
 
     radius: float = be.inf
     conic: float = 0.0
+    grating_order: int = 0
+    grating_period: float = be.inf
+    groove_orientation_angle: float = 0.0
     coefficients: list[float] = field(default_factory=list)
     tol: float = 1e-6
     max_iter: int = 100
@@ -177,6 +181,35 @@ def _create_polynomial(cs: CoordinateSystem, config: GeometryConfig):
         tol=config.tol,
         max_iter=config.max_iter,
         coefficients=config.coefficients,
+    )
+
+
+def _create_grating(cs: CoordinateSystem, config: GeometryConfig):
+    """
+    Create a grating geometry
+
+    Args:
+        cs (CoordinateSystem): coordinate system of the geometry.
+        config (GeometryConfig): configuration of the geometry.
+
+    Returns:
+        StandardGratingGeometry
+    """
+    # Use a Plane if the radius is infinity.
+    if be.isinf(config.radius):
+        return PlaneGrating(
+            cs,
+            config.grating_order,
+            config.grating_period,
+            config.groove_orientation_angle,
+        )
+    return StandardGratingGeometry(
+        cs,
+        config.radius,
+        config.grating_order,
+        config.grating_period,
+        config.groove_orientation_angle,
+        config.conic,
     )
 
 
@@ -331,6 +364,7 @@ geometry_mapper = {
     "biconic": _create_biconic,
     "chebyshev": _create_chebyshev,
     "even_asphere": _create_even_asphere,
+    "grating": _create_grating,
     "odd_asphere": _create_odd_asphere,
     "paraxial": _create_paraxial,
     "polynomial": _create_polynomial,

--- a/optiland/surfaces/factories/geometry_factory.py
+++ b/optiland/surfaces/factories/geometry_factory.py
@@ -11,7 +11,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import optiland.backend as be
 from optiland.geometries import (
@@ -20,14 +20,14 @@ from optiland.geometries import (
     EvenAsphere,
     ForbesQ2dGeometry,
     ForbesQbfsGeometry,
+    ForbesSolverConfig,  # forbes
+    ForbesSurfaceConfig,  # forbes
     OddAsphere,
     Plane,
     PlaneGrating,
     PolynomialGeometry,
-    SolverConfig,  # forbes
     StandardGeometry,
     StandardGratingGeometry,
-    SurfaceConfig,  # forbes
     ToroidalGeometry,
     ZernikePolynomialGeometry,
 )
@@ -45,6 +45,10 @@ class GeometryConfig:
         radius (float): radius of curvature of the geometry (R = 1/c).
                         Defaults to be.inf.
         conic (float): conic constant (k) of the geometry. Defaults to 0.0.
+        grating_order (int): order of the grating. Defaults to 0.
+        grating_period (float): period of the grating. Defaults to be.inf.
+        groove_orientation_angle (float): angle of the groove orientation.
+                                        Defaults to 0.0.
         coefficients (list): list of geometry coefficients. Defaults to empty list.
         tol (float): tolerance to use for Newton-Raphson method. Defaults to 1e-6.
         max_iter (int): maximum number of iterations to use for Newton-Raphson method.
@@ -61,6 +65,8 @@ class GeometryConfig:
         toroidal_coeffs_poly_y (list): toroidal YZ polynomial coefficients.
                                     Defaults to empty list.
         zernike_type (str): type of Zernike polynomial to use. Defaults to "fringe".
+        radial_terms (dict): radial terms for Forbes Q-BFS surfaces.
+        freeform_coeffs (dict): freeform coefficients for Forbes Q-2D surfaces.
     """
 
     radius: float = be.inf
@@ -83,9 +89,7 @@ class GeometryConfig:
     zernike_type: ZernikeType = "fringe"
     # Forbes parameters
     radial_terms: dict[int, float] = field(default_factory=dict)
-    freeform_coeffs: dict[tuple[int, int] | tuple[int, int, Literal["sin"]], float] = (
-        field(default_factory=dict)
-    )
+    freeform_coeffs: dict[tuple[str, int, int], float] = field(default_factory=dict)
 
 
 def _create_plane(cs: CoordinateSystem, config: GeometryConfig):
@@ -314,13 +318,13 @@ def _create_toroidal(cs: CoordinateSystem, config: GeometryConfig):
 
 def _create_forbes_qbfs(cs: CoordinateSystem, config: GeometryConfig):
     """Create a Forbes (Q-BFS) Geometry."""
-    surface_config = SurfaceConfig(
+    surface_config = ForbesSurfaceConfig(
         radius=config.radius,
         conic=config.conic,
         terms=config.radial_terms,
         norm_radius=config.norm_radius,
     )
-    solver_config = SolverConfig(tol=config.tol, max_iter=config.max_iter)
+    solver_config = ForbesSolverConfig(tol=config.tol, max_iter=config.max_iter)
 
     return ForbesQbfsGeometry(
         cs,
@@ -331,13 +335,13 @@ def _create_forbes_qbfs(cs: CoordinateSystem, config: GeometryConfig):
 
 def _create_forbes_q2d(cs: CoordinateSystem, config: GeometryConfig):
     """Create a Forbes (Q-2D) geometry."""
-    surface_config = SurfaceConfig(
+    surface_config = ForbesSurfaceConfig(
         radius=config.radius,
         conic=config.conic,
         terms=config.freeform_coeffs,
         norm_radius=config.norm_radius,
     )
-    solver_config = SolverConfig(tol=config.tol, max_iter=config.max_iter)
+    solver_config = ForbesSolverConfig(tol=config.tol, max_iter=config.max_iter)
 
     return ForbesQ2dGeometry(
         cs,

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -20,7 +20,6 @@ from optiland.surfaces.factories.coordinate_system_factory import (
 )
 from optiland.surfaces.factories.geometry_factory import GeometryConfig, GeometryFactory
 from optiland.surfaces.factories.material_factory import MaterialFactory
-from optiland.surfaces.grating_surface import GratingSurface
 from optiland.surfaces.object_surface import ObjectSurface
 from optiland.surfaces.paraxial_surface import ParaxialSurface
 from optiland.surfaces.standard_surface import Surface
@@ -112,16 +111,12 @@ class SurfaceFactory:
             norm_radius=kwargs.get("norm_radius", 1.0),
             radius_x=kwargs.get("radius_x", be.inf),
             radius_y=kwargs.get("radius_y", be.inf),
-            grating_order=kwargs.get("grating_order", 0),
-            grating_period=kwargs.get("grating_period", be.inf),
-            groove_orientation_angle=kwargs.get("groove_orientation_angle", 0.0),
             conic_x=kwargs.get("conic_x", 0.0),
             conic_y=kwargs.get("conic_y", 0.0),
             toroidal_coeffs_poly_y=kwargs.get("toroidal_coeffs_poly_y", []),
             zernike_type=kwargs.get("zernike_type", "fringe"),
             radial_terms=kwargs.get("radial_terms"),
             freeform_coeffs=kwargs.get("freeform_coeffs"),
-            forbes_norm_radius=kwargs.get("forbes_norm_radius", 1.0),
         )
 
         geometry = self._geometry_factory.create(
@@ -140,21 +135,6 @@ class SurfaceFactory:
         if surface_type == "paraxial":
             surface_obj = ParaxialSurface(
                 kwargs["f"],
-                geometry,
-                material_pre,
-                material_post,
-                is_stop,
-                is_reflective=is_reflective,
-                coating=coating,
-                surface_type=surface_type,
-                aperture=kwargs.get("aperture"),
-            )
-            surface_obj.thickness = kwargs.get("thickness", 0.0)
-            return surface_obj
-
-        # Create the appropriate surface type
-        if surface_type == "grating":
-            surface_obj = GratingSurface(
                 geometry,
                 material_pre,
                 material_post,

--- a/optiland/surfaces/factories/surface_factory.py
+++ b/optiland/surfaces/factories/surface_factory.py
@@ -20,6 +20,7 @@ from optiland.surfaces.factories.coordinate_system_factory import (
 )
 from optiland.surfaces.factories.geometry_factory import GeometryConfig, GeometryFactory
 from optiland.surfaces.factories.material_factory import MaterialFactory
+from optiland.surfaces.grating_surface import GratingSurface
 from optiland.surfaces.object_surface import ObjectSurface
 from optiland.surfaces.paraxial_surface import ParaxialSurface
 from optiland.surfaces.standard_surface import Surface
@@ -111,6 +112,9 @@ class SurfaceFactory:
             norm_radius=kwargs.get("norm_radius", 1.0),
             radius_x=kwargs.get("radius_x", be.inf),
             radius_y=kwargs.get("radius_y", be.inf),
+            grating_order=kwargs.get("grating_order", 0),
+            grating_period=kwargs.get("grating_period", be.inf),
+            groove_orientation_angle=kwargs.get("groove_orientation_angle", 0.0),
             conic_x=kwargs.get("conic_x", 0.0),
             conic_y=kwargs.get("conic_y", 0.0),
             toroidal_coeffs_poly_y=kwargs.get("toroidal_coeffs_poly_y", []),
@@ -135,6 +139,21 @@ class SurfaceFactory:
         if surface_type == "paraxial":
             surface_obj = ParaxialSurface(
                 kwargs["f"],
+                geometry,
+                material_pre,
+                material_post,
+                is_stop,
+                is_reflective=is_reflective,
+                coating=coating,
+                surface_type=surface_type,
+                aperture=kwargs.get("aperture"),
+            )
+            surface_obj.thickness = kwargs.get("thickness", 0.0)
+            return surface_obj
+
+        # Create the appropriate surface type
+        if surface_type == "grating":
+            surface_obj = GratingSurface(
                 geometry,
                 material_pre,
                 material_post,

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -4,7 +4,7 @@ import pytest
 
 import optiland.backend as be
 from optiland import geometries
-from optiland.geometries import BiconicGeometry, ForbesQbfsGeometry, ForbesQ2dGeometry, SurfaceConfig, SolverConfig
+from optiland.geometries import BiconicGeometry, ForbesQbfsGeometry, ForbesQ2dGeometry, ForbesSurfaceConfig, ForbesSolverConfig
 from optiland.coordinate_system import CoordinateSystem
 from optiland.geometries import BiconicGeometry
 from optiland.materials import IdealMaterial
@@ -2148,14 +2148,14 @@ class TestForbesQbfsGeometry:
         """Test the string representation of the geometry."""
         cs = CoordinateSystem()
         
-        config = SurfaceConfig(radius=100.0)
+        config = ForbesSurfaceConfig(radius=100.0)
         geometry = ForbesQbfsGeometry(cs, surface_config=config)
         assert str(geometry) == "ForbesQbfs"
 
     def test_sag_with_infinite_radius(self, set_test_backend):
         """Test sag calculation with an infinite radius (planar base)."""
         
-        config = SurfaceConfig(radius=be.inf, terms={1: 1e-3}, norm_radius=10.0)
+        config = ForbesSurfaceConfig(radius=be.inf, terms={1: 1e-3}, norm_radius=10.0)
         geometry = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=config
@@ -2174,7 +2174,7 @@ class TestForbesQbfsGeometry:
     def test_sag_outside_norm_radius(self, set_test_backend):
         """Test that sag departure is zero outside the normalization radius."""
         
-        config = SurfaceConfig(radius=100.0, terms={0: 1e-3}, norm_radius=10.0)
+        config = ForbesSurfaceConfig(radius=100.0, terms={0: 1e-3}, norm_radius=10.0)
         geometry = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=config
@@ -2193,7 +2193,7 @@ class TestForbesQbfsGeometry:
             pytest.skip("This test requires both numpy and torch backends to compare.")
 
         radial_terms = {0: 1.6e-4, 1: 0.3e-4, 2: 0.15e-4}
-        config = SurfaceConfig(radius=22.0, conic=-4.428, terms=radial_terms, norm_radius=6.336)
+        config = ForbesSurfaceConfig(radius=22.0, conic=-4.428, terms=radial_terms, norm_radius=6.336)
 
         be.set_backend("numpy")
         geometry_np = ForbesQbfsGeometry(
@@ -2245,7 +2245,7 @@ class TestForbesQbfsGeometry:
         )
 
        
-        config = SurfaceConfig(
+        config = ForbesSurfaceConfig(
             radius=zemax_radius,
             conic=zemax_conic,
             terms=radial_terms,
@@ -2269,7 +2269,7 @@ class TestForbesQbfsGeometry:
         It should always be [0, 0, -1] regardless of parameters.
         """
         
-        config = SurfaceConfig(radius=50.0, conic=-1.0, terms={2: 1e-4}, norm_radius=10.0)
+        config = ForbesSurfaceConfig(radius=50.0, conic=-1.0, terms={2: 1e-4}, norm_radius=10.0)
         geometry = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=config,
@@ -2376,8 +2376,8 @@ class TestForbesQbfsGeometry:
         cs = CoordinateSystem(x=1, y=-1, z=10, rx=0.01, ry=0.02, rz=-0.03)
         radial_terms = {0: 1e-3, 1: 2e-4, 2: -5e-5}
 
-        surface_config = SurfaceConfig(radius=123.4, conic=-0.9, terms=radial_terms, norm_radius=45.6)
-        solver_config = SolverConfig(tol=1e-12, max_iter=75)
+        surface_config = ForbesSurfaceConfig(radius=123.4, conic=-0.9, terms=radial_terms, norm_radius=45.6)
+        solver_config = ForbesSolverConfig(tol=1e-12, max_iter=75)
 
         original_geometry = ForbesQbfsGeometry(
             coordinate_system=cs,
@@ -2406,13 +2406,13 @@ class TestForbesQ2dGeometry:
     def test_str(self, set_test_backend):
         """Test the string representation of the geometry."""
         cs = CoordinateSystem()
-        config = SurfaceConfig(radius=100.0, conic=0.0)
+        config = ForbesSurfaceConfig(radius=100.0, conic=0.0)
         geometry = ForbesQ2dGeometry(cs, surface_config=config)
         assert str(geometry) == "ForbesQ2d"
 
     def test_init_no_coeffs(self, set_test_backend):
         """Test initialization with no freeform coefficients."""
-        config = SurfaceConfig(radius=100.0, conic=-0.5)
+        config = ForbesSurfaceConfig(radius=100.0, conic=-0.5)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(), surface_config=config
         )
@@ -2428,12 +2428,12 @@ class TestForbesQ2dGeometry:
         
         freeform_coeffs = {('a', 0, n): c for n, c in radial_terms.items()}
 
-        q2d_config = SurfaceConfig(radius=50.0, conic=0.0, terms=freeform_coeffs, norm_radius=10.0)
+        q2d_config = ForbesSurfaceConfig(radius=50.0, conic=0.0, terms=freeform_coeffs, norm_radius=10.0)
         geom_q2d = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=q2d_config
         )
-        qbfs_config = SurfaceConfig(radius=50.0, conic=0.0, terms=radial_terms, norm_radius=10.0)
+        qbfs_config = ForbesSurfaceConfig(radius=50.0, conic=0.0, terms=radial_terms, norm_radius=10.0)
         geom_qbfs = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=qbfs_config
@@ -2444,7 +2444,7 @@ class TestForbesQ2dGeometry:
     def test_sag_with_sine_term(self, set_test_backend):
         """Test sag with a sine term, which should be zero along the x-axis"""
         
-        config = SurfaceConfig(radius=100.0, conic=0.0, terms={('b', 1, 1): 1e-3}, norm_radius=10.0)
+        config = ForbesSurfaceConfig(radius=100.0, conic=0.0, terms={('b', 1, 1): 1e-3}, norm_radius=10.0)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=config,
@@ -2463,7 +2463,7 @@ class TestForbesQ2dGeometry:
             ('b', 1, 1): 3.0,   # Sine term b_1^1
             ('a', 0, 4): 4.0,   # Symmetric term a_4^0
         }
-        config = SurfaceConfig(radius=100.0, conic=0.0, terms=freeform_coeffs, norm_radius=10.0)
+        config = ForbesSurfaceConfig(radius=100.0, conic=0.0, terms=freeform_coeffs, norm_radius=10.0)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=config,
@@ -2484,7 +2484,7 @@ class TestForbesQ2dGeometry:
         cs = CoordinateSystem(x=1, y=-1, z=10)
         # UPDATED: Convert to the new Zemax-aligned format
         freeform_coeffs = {('a', 2, 2): 1e-4, ('b', 1, 1): -5e-5}
-        config = SurfaceConfig(radius=123.4, conic=-0.9, terms=freeform_coeffs, norm_radius=45.6)
+        config = ForbesSurfaceConfig(radius=123.4, conic=-0.9, terms=freeform_coeffs, norm_radius=45.6)
         original_geometry = ForbesQ2dGeometry(
             coordinate_system=cs,
             surface_config=config,
@@ -2517,7 +2517,8 @@ class TestForbesValidation:
         the explicit formulas published in the Forbes papers. This is the most
         fundamental check of the mathematical engine.
 
-        Reference: "Characterizing the shape of freeform optics" (2012), Fig. 3.
+        References: 
+            "Characterizing the shape of freeform optics" (2012), Fig. 3.
         """
         # We want to isolate a single polynomial Q_n^m. We do this by setting its
         # corresponding coefficient a_n^m or b_n^m to 1.0 and all others to zero
@@ -2628,7 +2629,7 @@ class TestForbesValidation:
             ('b', 1, 0): 0.5,
         }
 
-        config = SurfaceConfig(radius=21.709, conic=-4.428, terms=freeform_coeffs, norm_radius=6.0)
+        config = ForbesSurfaceConfig(radius=21.709, conic=-4.428, terms=freeform_coeffs, norm_radius=6.0)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
             surface_config=config,

--- a/tests/test_geometries.py
+++ b/tests/test_geometries.py
@@ -4,7 +4,7 @@ import pytest
 
 import optiland.backend as be
 from optiland import geometries
-from optiland.geometries import BiconicGeometry, ForbesQbfsGeometry, ForbesQ2dGeometry
+from optiland.geometries import BiconicGeometry, ForbesQbfsGeometry, ForbesQ2dGeometry, SurfaceConfig, SolverConfig
 from optiland.coordinate_system import CoordinateSystem
 from optiland.geometries import BiconicGeometry
 from optiland.materials import IdealMaterial
@@ -2126,7 +2126,7 @@ def forbes_system():
         radius=22,
         conic=conic_S2,
         radial_terms=radial_terms_S2,
-        forbes_norm_radius=norm_radius_S2,
+        norm_radius=norm_radius_S2,
         surface_type="forbes_qbfs",
     )
     lens.add_surface(index=4, thickness=7.0, radius=be.inf, material=H_ZLAF68C)
@@ -2136,7 +2136,7 @@ def forbes_system():
         radius=-31.0,
         conic=conic_S4,
         radial_terms=radial_terms_S4,
-        forbes_norm_radius=norm_radius_S4,
+        norm_radius=norm_radius_S4,
         surface_type="forbes_qbfs",
     )
     lens.add_surface(index=6)
@@ -2147,16 +2147,18 @@ class TestForbesQbfsGeometry:
     def test_str(self, set_test_backend):
         """Test the string representation of the geometry."""
         cs = CoordinateSystem()
-        geometry = ForbesQbfsGeometry(cs, radius=100.0)
+        
+        config = SurfaceConfig(radius=100.0)
+        geometry = ForbesQbfsGeometry(cs, surface_config=config)
         assert str(geometry) == "ForbesQbfs"
 
     def test_sag_with_infinite_radius(self, set_test_backend):
         """Test sag calculation with an infinite radius (planar base)."""
+        
+        config = SurfaceConfig(radius=be.inf, terms={1: 1e-3}, norm_radius=10.0)
         geometry = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=be.inf,
-            radial_terms={1: 1e-3},
-            norm_radius=10.0,
+            surface_config=config
         )
         # Base sag should be 0, total sag is just the departure term
         x, y = 5.0, 0.0
@@ -2171,11 +2173,11 @@ class TestForbesQbfsGeometry:
 
     def test_sag_outside_norm_radius(self, set_test_backend):
         """Test that sag departure is zero outside the normalization radius."""
+        
+        config = SurfaceConfig(radius=100.0, terms={0: 1e-3}, norm_radius=10.0)
         geometry = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=100.0,
-            radial_terms={0: 1e-3},
-            norm_radius=10.0,
+            surface_config=config
         )
         standard_geom = geometries.StandardGeometry(
             coordinate_system=CoordinateSystem(), radius=100.0
@@ -2191,23 +2193,18 @@ class TestForbesQbfsGeometry:
             pytest.skip("This test requires both numpy and torch backends to compare.")
 
         radial_terms = {0: 1.6e-4, 1: 0.3e-4, 2: 0.15e-4}
+        config = SurfaceConfig(radius=22.0, conic=-4.428, terms=radial_terms, norm_radius=6.336)
 
         be.set_backend("numpy")
         geometry_np = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=22.0,
-            conic=-4.428,
-            radial_terms=radial_terms,
-            norm_radius=6.336,
+            surface_config=config,
         )
 
         be.set_backend("torch")
         geometry_torch = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=22.0,
-            conic=-4.428,
-            radial_terms=radial_terms,
-            norm_radius=6.336,
+            surface_config=config,
         )
 
         x, y = 2.5, 1.5
@@ -2229,10 +2226,9 @@ class TestForbesQbfsGeometry:
         Tests the sag calculation for a Q-bfs surface. This test ensures the coefficient translation
         and sag calculations are correct.
         """
-
         zemax_radius = 21.723
         zemax_conic = -4.428
-        zemax_norm_radius = 6.336
+        zemex_norm_radius = 6.336
         # Coefficients for n=0, 1, 2 (A0, A1, A2, A3, A4)
         zemax_coeffs = [1.614, 0.348, 0.150, 0.033, 0.030]
         radial_terms = {n: c for n, c in enumerate(zemax_coeffs)}
@@ -2248,12 +2244,16 @@ class TestForbesQbfsGeometry:
             ]
         )
 
-        geometry = ForbesQbfsGeometry(
-            coordinate_system=CoordinateSystem(),
+       
+        config = SurfaceConfig(
             radius=zemax_radius,
             conic=zemax_conic,
-            radial_terms=radial_terms,
-            norm_radius=zemax_norm_radius,
+            terms=radial_terms,
+            norm_radius=zemex_norm_radius,
+        )
+        geometry = ForbesQbfsGeometry(
+            coordinate_system=CoordinateSystem(),
+            surface_config=config
         )
 
         # Calculate sag in Optiland at the same radial coordinates
@@ -2268,12 +2268,11 @@ class TestForbesQbfsGeometry:
         Tests the surface normal at the vertex (x=0, y=0).
         It should always be [0, 0, -1] regardless of parameters.
         """
+        
+        config = SurfaceConfig(radius=50.0, conic=-1.0, terms={2: 1e-4}, norm_radius=10.0)
         geometry = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=50.0,
-            conic=-1.0,
-            radial_terms={2: 1e-4},
-            norm_radius=10.0,
+            surface_config=config,
         )
 
         nx, ny, nz = geometry._surface_normal(x=0.0, y=0.0)
@@ -2330,7 +2329,7 @@ class TestForbesQbfsGeometry:
             thickness=60.0,
             material="air",
             radial_terms={0: 1.0, 1: 0.8, 2: 0.2},
-            forbes_norm_radius=30.0,
+            norm_radius=30.0,
         )
         optic.add_surface(index=4)
         return optic
@@ -2367,6 +2366,7 @@ class TestForbesQbfsGeometry:
         grad = coeffs_to_test.grad
         assert grad is not None, "Gradient should be computed"
         assert be.any(grad != 0), "Gradient should not be all zeros"
+        assert not be.any(be.isnan(grad)), "Gradient contains NaN values"
 
     def test_to_dict_from_dict(self, set_test_backend):
         """
@@ -2376,28 +2376,26 @@ class TestForbesQbfsGeometry:
         cs = CoordinateSystem(x=1, y=-1, z=10, rx=0.01, ry=0.02, rz=-0.03)
         radial_terms = {0: 1e-3, 1: 2e-4, 2: -5e-5}
 
+        surface_config = SurfaceConfig(radius=123.4, conic=-0.9, terms=radial_terms, norm_radius=45.6)
+        solver_config = SolverConfig(tol=1e-12, max_iter=75)
+
         original_geometry = ForbesQbfsGeometry(
             coordinate_system=cs,
-            radius=123.4,
-            conic=-0.9,
-            radial_terms=radial_terms,
-            norm_radius=45.6,
-            tol=1e-12,
-            max_iter=75,
+            surface_config=surface_config,
+            solver_config=solver_config,
         )
 
         geom_dict = original_geometry.to_dict()
 
-        # Check serialization
         assert geom_dict["type"] == "ForbesQbfsGeometry"
-        assert geom_dict["radius"] == 123.4
-        assert geom_dict["conic"] == -0.9
-        assert geom_dict["radial_terms"] == radial_terms
-        assert geom_dict["norm_radius"] == 45.6
-        assert geom_dict["tol"] == 1e-12
-        assert geom_dict["max_iter"] == 75
+        assert geom_dict["surface_config"]["radius"] == 123.4
+        assert geom_dict["surface_config"]["conic"] == -0.9
+        assert geom_dict["surface_config"]["terms"] == radial_terms
+        assert geom_dict["surface_config"]["norm_radius"] == 45.6
+        assert geom_dict["solver_config"]["tol"] == 1e-12
+        assert geom_dict["solver_config"]["max_iter"] == 75
 
-        # Check deserialization (from_dict still uses the internal format)
+
         reconstructed_geometry = ForbesQbfsGeometry.from_dict(geom_dict)
         assert reconstructed_geometry.radius == 123.4
         assert reconstructed_geometry.k == -0.9
@@ -2408,13 +2406,15 @@ class TestForbesQ2dGeometry:
     def test_str(self, set_test_backend):
         """Test the string representation of the geometry."""
         cs = CoordinateSystem()
-        geometry = ForbesQ2dGeometry(cs, radius=100.0, conic=0.0)
+        config = SurfaceConfig(radius=100.0, conic=0.0)
+        geometry = ForbesQ2dGeometry(cs, surface_config=config)
         assert str(geometry) == "ForbesQ2d"
 
     def test_init_no_coeffs(self, set_test_backend):
         """Test initialization with no freeform coefficients."""
+        config = SurfaceConfig(radius=100.0, conic=-0.5)
         geometry = ForbesQ2dGeometry(
-            coordinate_system=CoordinateSystem(), radius=100.0, conic=-0.5
+            coordinate_system=CoordinateSystem(), surface_config=config
         )
         assert len(geometry.coeffs_c) == 0
         assert len(geometry.coeffs_n) == 0
@@ -2425,90 +2425,82 @@ class TestForbesQ2dGeometry:
     def test_sag_symmetric_terms_only(self, set_test_backend):
         """Test sag with only m=0 terms, should match Q-bfs."""
         radial_terms = {0: 1e-3, 1: -2e-4}
-        freeform_coeffs = {(n, 0): c for n, c in radial_terms.items()}
+        
+        freeform_coeffs = {('a', 0, n): c for n, c in radial_terms.items()}
 
+        q2d_config = SurfaceConfig(radius=50.0, conic=0.0, terms=freeform_coeffs, norm_radius=10.0)
         geom_q2d = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=50.0,
-            conic=0.0,
-            freeform_coeffs=freeform_coeffs,
-            norm_radius=10.0,
+            surface_config=q2d_config
         )
+        qbfs_config = SurfaceConfig(radius=50.0, conic=0.0, terms=radial_terms, norm_radius=10.0)
         geom_qbfs = ForbesQbfsGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=50.0,
-            conic=0.0,
-            radial_terms=radial_terms,
-            norm_radius=10.0,
+            surface_config=qbfs_config
         )
         x, y = 3.0, 4.0
         assert_allclose(geom_q2d.sag(x, y), geom_qbfs.sag(x, y))
 
     def test_sag_with_sine_term(self, set_test_backend):
-        """Test sag with a sine term, which should be zero along the x-axis."""
+        """Test sag with a sine term, which should be zero along the x-axis"""
+        
+        config = SurfaceConfig(radius=100.0, conic=0.0, terms={('b', 1, 1): 1e-3}, norm_radius=10.0)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=100.0,
-            conic=0.0,
-            freeform_coeffs={(1, 1, "sin"): 1e-3},
-            norm_radius=10.0,
+            surface_config=config,
         )
-        # Along x-axis, theta=0, so sin(m*theta)=0
         x, y = 5.0, 0.0
-        # Sag should be just the base conic sag
         base_geom = geometries.StandardGeometry(
             coordinate_system=CoordinateSystem(), radius=100.0
         )
         assert_allclose(geometry.sag(x, y), base_geom.sag(x, y))
 
     def test_prepare_coeffs(self, set_test_backend):
-        """Test the internal _prepare_coeffs method."""
+     
         freeform_coeffs = {
-            (0, 0): 1.0,
-            (1, 1): 2.0,
-            (1, 1, "sin"): 3.0,
-            (0, 2): 4.0,
+            ('a', 0, 0): 1.0,   # Symmetric term a_0^0
+            ('a', 1, 1): 2.0,   # Cosine term a_1^1
+            ('b', 1, 1): 3.0,   # Sine term b_1^1
+            ('a', 0, 4): 4.0,   # Symmetric term a_4^0
         }
+        config = SurfaceConfig(radius=100.0, conic=0.0, terms=freeform_coeffs, norm_radius=10.0)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=100.0,
-            conic=0.0,
-            freeform_coeffs=freeform_coeffs,
-            norm_radius=10.0,
+            surface_config=config,
         )
-        # cm0 should have a_0^0
-        assert_allclose(geometry.cm0_coeffs, [1.0])
-        # ams should have a_1^1 and a_0^2
-        assert len(geometry.ams_coeffs) == 2
-        assert_allclose(geometry.ams_coeffs[0], [0.0, 2.0])  # a_n^1
-        assert_allclose(geometry.ams_coeffs[1], [4.0])  # a_n^2
-        # bms should have b_1^1
-        assert len(geometry.bms_coeffs) == 2
-        assert_allclose(geometry.bms_coeffs[0], [0.0, 3.0])  # b_n^1
+
+        # symmetric terms (m=0) are parsed correctly, with zero-padding
+        assert_allclose(geometry.cm0_coeffs, [1.0, 0.0, 0.0, 0.0, 4.0])
+
+        # ams should have a_1^1
+        assert len(geometry.ams_coeffs) == 1
+        assert_allclose(geometry.ams_coeffs[0], [0.0, 2.0])  # a_n^1 list for m=1
+        
+        assert len(geometry.bms_coeffs) == 1
+        assert_allclose(geometry.bms_coeffs[0], [0.0, 3.0]) 
 
     def test_to_dict_from_dict(self, set_test_backend):
         """Test serialization and deserialization."""
         cs = CoordinateSystem(x=1, y=-1, z=10)
-        freeform_coeffs = {(2, 2): 1e-4, (1, 1, "sin"): -5e-5}
+        # UPDATED: Convert to the new Zemax-aligned format
+        freeform_coeffs = {('a', 2, 2): 1e-4, ('b', 1, 1): -5e-5}
+        config = SurfaceConfig(radius=123.4, conic=-0.9, terms=freeform_coeffs, norm_radius=45.6)
         original_geometry = ForbesQ2dGeometry(
             coordinate_system=cs,
-            radius=123.4,
-            conic=-0.9,
-            freeform_coeffs=freeform_coeffs,
-            norm_radius=45.6,
+            surface_config=config,
         )
         geom_dict = original_geometry.to_dict()
         reconstructed_geometry = ForbesQ2dGeometry.from_dict(geom_dict)
         assert reconstructed_geometry.to_dict() == geom_dict
 
 
-from optiland.geometries.forbes.qpoly import Q2d_nm_c_to_a_b, compute_z_zprime_Q2d
+from optiland.geometries.forbes.qpoly import q2d_nm_coeffs_to_ams_bms, compute_z_zprime_q2d
 
 
 class TestForbesValidation:
     """
     Unit tests to validate the Forbes geometry implementation directly against
-    the mathematical formulas published in the foundational research papers.
+    the mathematical formulas in the reference papers
     """
 
     @pytest.mark.parametrize(
@@ -2532,14 +2524,14 @@ class TestForbesValidation:
         coeffs_n = [(n, m)]
         coeffs_c = [1.0]
 
-        cm0, ams, bms = Q2d_nm_c_to_a_b(coeffs_n, coeffs_c)
+        cm0, ams, bms = q2d_nm_coeffs_to_ams_bms(coeffs_n, coeffs_c)
 
         # The input to the Q polynomials is u^2, which we call x_val here.
         u = np.sqrt(x_val)
         theta = 0
 
         # raw polynomial sums from the implementation
-        poly_sum_m0, _, poly_sum_m_gt0, _, _ = compute_z_zprime_Q2d(
+        poly_sum_m0, _, poly_sum_m_gt0, _, _ = compute_z_zprime_q2d(
             cm0, ams, bms, u, theta
         )
 
@@ -2558,68 +2550,216 @@ class TestForbesValidation:
             else:
                 pytest.skip("Skipping test at u=0 for m>0.")
 
-    def test_q2d_sag_reconstruction_against_implementation(self):
-        """
-        Validates the final ForbesQ2dGeometry.sag() method by reconstructing
-        the calculation step-by-step using the explicit formulas from the paper
-        and asserting that the result matches the all-in-one .sag() method.
-        This confirms the correct assembly of all components.
+    def test_qnm_values_against_analytical_formula(self, set_test_backend):
+        n, m = 1, 2
+        x = 0.4
+        P_n_m_canonical = 1.5 - x
+        from optiland.geometries.forbes.qpoly import f_q2d, g_q2d
+        P_0_m = 0.5
+        f0 = f_q2d(n=0, m=m)
+        Q_0_m_canonical = P_0_m / f0
+        g0 = g_q2d(n=0, m=m)
+        f1 = f_q2d(n=1, m=m)
+        Q_n_m_canonical = (P_n_m_canonical - g0 * Q_0_m_canonical) / f1
+        coeffs_to_test = [0.0] * (n + 1)
+        coeffs_to_test[n] = 1.0
+        from optiland.geometries.forbes.qpoly import clenshaw_q2d
+        alphas = clenshaw_q2d(coeffs_to_test, m=m, usq=x)
+        Q_n_m_optiland = 0.5 * alphas[0]
+        assert np.allclose(Q_n_m_optiland, Q_n_m_canonical, atol=1e-9)
 
-        Reference: "Characterizing the shape of freeform optics" (2012), Eq. 2.2.
+    def test_qnm_values_against_analytical_formula(self, set_test_backend):
         """
-        radius = 37.405283
-        conic = 0.0
-        norm_radius = 10.0
+        Validates that a single Q polynomial from the qpoly implementation matches
+        a value calculated directly from the analytical formula derived from the
+        Forbes papers.
+        """
+        # Q_n^m for n=1, m=2
+        n, m = 1, 2
+        x = 0.4  # An arbitrary value for u^2 between 0 and 1
 
+        # calculate the ground truth using the analytical formula 
+        # From the Forbes papers (e.g. 2012 paper), we know
+        # that for m>1, P_1^m(x) = m - 0.5 - (m-1)x.
+        # for m=2:
+        P_n_m_canonical = 1.5 - x
+
+        # Now, we convert this P_n^m value to a Q_n^m value using the
+        # recurrence relation from the paper.
+        # Q_n^m = (P_n^m - g_{n-1}^m * Q_{n-1}^m) / f_n^m
+        from optiland.geometries.forbes.qpoly import f_q2d, g_q2d
+
+        # we need Q_0^2 and the f and g coefficients from qpoly
+        # Q_0^m = P_0^m / f_0^m. P_0^m is always 0.5.
+        P_0_m = 0.5
+        f0 = f_q2d(n=0, m=m)
+        Q_0_m_canonical = P_0_m / f0
+
+        g0 = g_q2d(n=0, m=m)
+        f1 = f_q2d(n=1, m=m)
+
+        # final ground truth for Q_1^2(x)
+        Q_n_m_canonical = (P_n_m_canonical - g0 * Q_0_m_canonical) / f1
+
+        # calculate the value using the qpoly implementation
+        # we isolate the Q_n^m polynomial by setting its coefficient to 1
+        coeffs_to_test = [0.0] * (n + 1)
+        coeffs_to_test[n] = 1.0
+
+        from optiland.geometries.forbes.qpoly import clenshaw_q2d
+
+        # The clenshaw function returns the sum of the series. Since only one
+        # coefficient is 1, the sum is equal to the value of that polynomial.
+        alphas = clenshaw_q2d(coeffs_to_test, m=m, usq=x)
+        # The sum S(x) = 0.5 * alpha_0 for the Q2D polynomials
+        Q_n_m_optiland = 0.5 * alphas[0]
+
+        assert np.allclose(Q_n_m_optiland, Q_n_m_canonical, atol=1e-9)
+
+
+    def test_q2d_normal_against_numerical_derivative(self):
+        """
+        Validates the analytical surface normal for the non-vertex case against
+        a numerical derivative (finite difference)
+        """
+        
         freeform_coeffs = {
-            (0, 0): -11509e-6,
-            (1, 1): 187947e-6,
-            (0, 2): -592756e-6,
-            (0, 4): -6311e-6,
+            ('a', 1, 1): -0.25,
+            ('b', 1, 0): 0.5,
         }
 
+        config = SurfaceConfig(radius=21.709, conic=-4.428, terms=freeform_coeffs, norm_radius=6.0)
         geometry = ForbesQ2dGeometry(
             coordinate_system=CoordinateSystem(),
-            radius=radius,
-            conic=conic,
-            freeform_coeffs=freeform_coeffs,
-            norm_radius=norm_radius,
+            surface_config=config,
         )
 
-        x, y = 5.0, -3.0
+        x, y = 1.0, 0.5
+        h = 1e-6 
 
-        sag_from_method = geometry.sag(x, y)
+        # Calculate sag at points surrounding (x, y)
+        sag_center = geometry.sag(x, y)
+        sag_x_plus = geometry.sag(x + h, y)
+        sag_x_minus = geometry.sag(x - h, y)
+        sag_y_plus = geometry.sag(x, y + h)
+        sag_y_minus = geometry.sag(x, y - h)
 
-        rho = np.sqrt(x**2 + y**2)
-        rho2 = rho**2
-        u = rho / norm_radius
-        usq = u**2
-        theta = np.arctan2(y, x)
-        c = 1 / radius
+        # approximate the partial derivatives using the central difference formula
+        df_dx_numerical = (sag_x_plus - sag_x_minus) / (2 * h)
+        df_dy_numerical = (sag_y_plus - sag_y_minus) / (2 * h)
 
-        base_conic_geometry = ForbesQ2dGeometry(
-            coordinate_system=CoordinateSystem(),
-            radius=radius,
-            conic=conic,
-            freeform_coeffs={},
-            norm_radius=norm_radius,
-        )
-        z_base = base_conic_geometry.sag(x, y)
-
-        cm0, ams, bms = Q2d_nm_c_to_a_b(geometry.coeffs_n, geometry.coeffs_c)
-        poly_sum_m0, _, poly_sum_m_gt0, _, _ = compute_z_zprime_Q2d(
-            cm0, ams, bms, u, theta
+        # calculate the direvatives using the analytical method
+        df_dx_analytical, df_dy_analytical = geometry._surface_normal_analytical(
+            be.array(x), be.array(y)
         )
 
-        normal_departure_m0 = usq * (1 - usq) * poly_sum_m0
-        normal_departure_m_gt0 = poly_sum_m_gt0
-        total_normal_departure = normal_departure_m0 + normal_departure_m_gt0
+        # compare
+        assert np.allclose(df_dx_analytical, df_dx_numerical, atol=1e-6)
+        assert np.allclose(df_dy_analytical, df_dy_numerical, atol=1e-6)
+        
+        
+    def test_complex_ray_tracing(self, set_test_backend):
+        """
+        Tests the ray tracing through a complex Forbes geometry with multiple
+        coefficients and terms to ensure the full system behaves as expected.
+        """
+        # Create a complex system: Q-2d and Qbfs 
+        optic = Optic()
+        optic.set_aperture(aperture_type="EPD", value=4.0)
 
-        correction_factor = 1 / np.sqrt(1 - c**2 * rho2)
+        optic.set_field_type(field_type="angle")
+        optic.add_field(y=0)
 
-        sag_departure = correction_factor * total_normal_departure
-        sag_reconstructed = z_base + sag_departure
+        optic.add_wavelength(value=1.550, is_primary=True)
 
-        np.testing.assert_allclose(
-            sag_from_method, sag_reconstructed, rtol=1e-5, atol=1e-5
+        H_K3 = IdealMaterial(n=1.50, k=0)
+        H_ZLAF68C = Material("H-ZLAF68C", reference='cdgm')
+
+        norm_radius = 10.0
+        freeform_coeffs = {
+            ('b',1,0): 0.23,
+            ('a',1,1): -0.25,
+            ('a',1,3): -2.0,
+            ('b',2,0): 0.4,
+            ('b',3,1): 0.5
+            
+        }
+
+        radial_terms = {0: -0.334, 1: 0.130, 2: -0.099, 3: 0.082, 4: -0.093}
+
+
+        optic.add_surface(index=0, thickness=be.inf)
+        optic.add_surface(index=1, thickness=26.5)
+        optic.add_surface(index=2, thickness=4.0, radius=be.inf, material=H_K3, is_stop=True, aperture=6.0)
+        optic.add_surface(index=3, thickness=25.0, radius=21.7, conic=-4.428, freeform_coeffs=freeform_coeffs, norm_radius=6.0, surface_type="forbes_q2d", aperture=6.0) 
+        optic.add_surface(index=4, thickness=7.0, radius=be.inf, material=H_ZLAF68C, aperture=16.0)
+        optic.add_surface(index=5, thickness=10.0, radius=-31.408, conic=-0.334, radial_terms=radial_terms, norm_radius=10.0, surface_type="forbes_qbfs", aperture=16.0)
+        optic.add_surface(index=6)
+
+        # Create rays to trace through this geometry
+        rays_1 = RealRays(
+            x=be.array([-2.0, 0.0, 2.0]),
+            y=be.array([0.0, 0.0, 0.0]),
+            z=be.array([0.0, 0.0, 0.0]),
+            L=be.array([0.0, 0.0, 0.0]),
+            M=be.array([0.0, 0.0, 0.0]),
+            N=be.array([1.0, 1.0, 1.0]),
+            wavelength=be.ones(3) * 1.550,
+            intensity=be.ones(3),
         )
+        rays_2 = RealRays(
+            x=be.array([0.0, 0.0, 0.0]),
+            y=be.array([-2.0, 0.0, 2.0]),
+            z=be.array([0.0, 0.0, 0.0]),
+            L=be.array([0.0, 0.0, 0.0]),
+            M=be.array([0.0, 0.0, 0.0]),
+            N=be.array([1.0, 1.0, 1.0]),
+            wavelength=be.ones(3) * 1.550,
+            intensity=be.ones(3),
+        )
+        rays_3 = RealRays(
+            x=be.array([-1.8, 0.5, -0.5]),
+            y=be.array([-2.0, -1.5, 1.5]),
+            z=be.array([0.0, 0.0, 0.0]),
+            L=be.array([0.0, 0.0, 0.0]),
+            M=be.array([0.0, 0.0, 0.0]),
+            N=be.array([1.0, 1.0, 1.0]),
+            wavelength=be.ones(3) * 1.550,
+            intensity=be.ones(3),
+        )
+
+        # trace and group for comparison
+        rays_out_1 = optic.surface_group.trace(rays_1)
+        rays_out_2 = optic.surface_group.trace(rays_2)
+        rays_out_3 = optic.surface_group.trace(rays_3)
+        
+        rays_out_1 = be.stack([rays_out_1.x, rays_out_1.y, rays_out_1.z, rays_out_1.L, rays_out_1.M, rays_out_1.N])
+        rays_out_2 = be.stack([rays_out_2.x, rays_out_2.y, rays_out_2.z, rays_out_2.L, rays_out_2.M, rays_out_2.N])
+        rays_out_3 = be.stack([rays_out_3.x, rays_out_3.y, rays_out_3.z, rays_out_3.L, rays_out_3.M, rays_out_3.N])
+        
+        # from zmx
+        rays_zmx_1 = be.array([[2.262266099465996E+000, -7.611636358380779E+000, 8.507340277857841E+000], 
+                               [7.011812112445810E-001, 6.351818041247482E-001, 1.844219290499702E+000],
+                               [72.5, 72.5, 72.5],
+                               [7.394271933375213E-002, -4.741197708598330E-002, 1.144444436877695E-003],
+                               [1.760669468507115E-003, 3.956471870787390E-003, 1.390619028086458E-002],
+                               [9.972609359142435E-001, 9.988675841967912E-001, 9.999026493208244E-001]])
+
+        rays_zmx_2 = be.array([[-2.908637501241161E+000, -7.611636358380779E+000, -1.909625498103998E+000], 
+                               [-2.833834953431557E+000, 6.351818041247482E-001, 2.879512384120351E+000],
+                               [72.5, 72.5, 72.5],
+                               [-2.028167761942454E-002, -4.741197708598330E-002, -1.395817128850889E-002],
+                               [4.487436493546904E-002, 3.956471870787390E-003, -4.367333651449654E-002],
+                               [9.987867364580793E-001, 9.988675841967912E-001, 9.989483515837905E-001]])
+        
+        rays_zmx_3 = be.array([[1.995705116576431E+000, -3.353247609431453E+000, -4.016958077970503E+000], 
+                               [1.568402524873438E+000, -3.440142525503505E+000, 6.226900552306260E-001],
+                               [72.5, 72.5, 72.5],
+                               [6.464067747819106E-002, -3.675345849055221E-002, -1.314936805201002E-002],
+                               [7.066054530137703E-002, 2.733014103973235E-002, -4.397208974806662E-002],
+                               [9.954037724224643E-001, 9.989505726910273E-001, 9.989462194948339E-001]])
+
+        # validate
+        assert be.allclose(rays_out_1, rays_zmx_1, rtol=1e-7, atol=1e-7)
+        assert be.allclose(rays_out_2, rays_zmx_2, rtol=1e-7, atol=1e-7)
+        assert be.allclose(rays_out_3, rays_zmx_3, rtol=1e-7, atol=1e-7)

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -9,7 +9,7 @@ from optiland.geometries import (
     ForbesQ2dGeometry,
     PolynomialGeometry,
     ZernikePolynomialGeometry,
-    SurfaceConfig, # forbes dataclass
+    ForbesSurfaceConfig, 
 )
 from optiland.optimization import variable, OptimizationProblem, OptimizerGeneric
 from optiland.samples.microscopes import Objective60x, UVReflectingMicroscope
@@ -515,7 +515,7 @@ class TestForbesQbfsCoeffVariable:
     def setup(self):
         self.optic = AsphericSinglet()
         
-        surface_config = SurfaceConfig(
+        surface_config = ForbesSurfaceConfig(
             radius=100,
             terms={1: 0.1, 2: 0.2, 3: 0.3},
             norm_radius=15.0
@@ -581,7 +581,7 @@ class TestForbesQ2dCoeffVariable:
             ('a', 2, 2): 0.2,
             ('b', 1, 1): 0.3,
         }
-        surface_config = SurfaceConfig(
+        surface_config = ForbesSurfaceConfig(
             radius=100,
             conic=0.0,
             terms=freeform_coeffs,

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -9,6 +9,7 @@ from optiland.geometries import (
     ForbesQ2dGeometry,
     PolynomialGeometry,
     ZernikePolynomialGeometry,
+    SurfaceConfig, # forbes dataclass
 )
 from optiland.optimization import variable, OptimizationProblem, OptimizerGeneric
 from optiland.samples.microscopes import Objective60x, UVReflectingMicroscope
@@ -54,7 +55,6 @@ class TestReciprocalRadiusVariable:
         )
 
     def test_get_value(self, set_test_backend):
-        # Expected reciprocal = 1 / radius; radius from TestRadiusVariable ≈ 553.260
         expected = self.scaling * (1.0 / self.radius_var.get_value())
         assert_allclose(self.reciprocal_radius_var.get_value(), expected, atol=1e-4)
         a = str(self.reciprocal_radius_var)
@@ -74,60 +74,37 @@ class TestReciprocalRadiusVariable:
         )
 
     def test_update_value(self, set_test_backend):
-        # Update reciprocal value to 0.25, expect new radius = 1/0.25 = 4.0
         self.reciprocal_radius_var.update_value(0.25)
         expected_radius = self.scaling * (1.0 / 0.25)
         assert_allclose(self.radius_var.get_value(), expected_radius, atol=1e-4)
         assert_allclose(self.reciprocal_radius_var.get_value(), 0.25, atol=1e-4)
 
     def test_get_value_infinity(self, set_test_backend):
-        # Set the surface radius to 0 so reciprocal becomes infinity (division by zero)
         self.radius_var.update_value(0.0)
         val = self.reciprocal_radius_var.get_value()
         assert val == be.inf
 
     def test_update_value_zero(self, set_test_backend):
-        # Update reciprocal value to 0 -> new radius set to infinity, so reciprocal becomes 0
         self.reciprocal_radius_var.update_value(0.0)
         assert_allclose(self.reciprocal_radius_var.get_value(), 0.0)
 
-    def test_optimization(self):  # do not test for torch backend
-        # Add the reciprocal radius variable for the first surface
+    def test_optimization(self):
         self.problem.add_variable(self.optic, "reciprocal_radius", surface_number=1)
-
-        # Run the optimization
         optimizer = OptimizerGeneric(self.problem)
-
-        # this will set the radius of surface 1 to scale*(1/0.1) = 10*(10) = 100
         self.reciprocal_radius_var.update_value(0.1)
         optimizer.optimize(tol=1e-9)
-
-        # Check if the radius of the first surface is close to the expected value
-        expected_radius = 19.93  # Expected value from the initial definition
+        expected_radius = 19.93
         optimized_radius = self.radius_var.get_value()
-        # just make sure the final value is in the ballpark, and there were no exceptions thrown
         assert_allclose(optimized_radius, expected_radius, atol=5)
 
-    def test_optimization_with_flat_surface(self):  # do not test for torch backend
-        # Add the reciprocal radius variable for the first surface
+    def test_optimization_with_flat_surface(self):
         self.problem.add_variable(self.optic, "reciprocal_radius", surface_number=1)
-
-        # Make the first surface mathematically flat
         self.radius_var.update_value(-be.inf)
-
-        # Run the optimization
         optimizer = OptimizerGeneric(self.problem)
         optimizer.optimize(tol=1e-9)
-
-        # the optimization above stops prematurely, so we have to try again.
-        # TODO: understand the problem and fix it or at least properly document it.
-        # trying again:
         optimizer.optimize(tol=1e-9)
-
-        # Check if the radius of the first surface is close to the expected value
-        expected_radius = 19.93  # Expected value from the initial definition
+        expected_radius = 19.93
         optimized_radius = self.radius_var.get_value()
-        # just make sure the final value is in the ballpark, and there were no exceptions thrown
         assert_allclose(optimized_radius, expected_radius, atol=5)
 
 
@@ -226,14 +203,12 @@ class TestMaterialVariable:
         assert self.material_var.get_value() == "F5"
 
     def test_scale(self, set_test_backend):
-        # Does not make much sense, scale() doesn't do anything
         assert self.material_var.scale("F5") == "F5"
 
     def test_string_representation(self, set_test_backend):
         assert str(self.material_var) == "Material, Surface 1"
 
     def test_init_with_abbe_material(self):
-        # Force surface 1 to use an AbbeMaterial
         abbe = AbbeMaterial(n=(1.5168,), abbe=(64.17,))
         self.optic.surface_group.surfaces[self.surface_number].material_post = abbe
 
@@ -253,8 +228,6 @@ class TestMaterialVariable:
                 surface_number=self.surface_number,
                 glass_selection=self.glass_selection,
             )
-
-            # Confirm conversion occurred
             assert mat_var.get_value() == "N-BK7"
             mock_print.assert_called()
             printed = mock_print.call_args[0][0]
@@ -541,11 +514,15 @@ class TestForbesQbfsCoeffVariable:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.optic = AsphericSinglet()
+        
+        surface_config = SurfaceConfig(
+            radius=100,
+            terms={1: 0.1, 2: 0.2, 3: 0.3},
+            norm_radius=15.0
+        )
         forbes_geo = ForbesQbfsGeometry(
             CoordinateSystem(),
-            100,
-            radial_terms={1: 0.1, 2: 0.2, 3: 0.3},
-            norm_radius=15.0,
+            surface_config=surface_config
         )
         self.optic.surface_group.surfaces[1].geometry = forbes_geo
         self.forbes_var = variable.ForbesQbfsCoeffVariable(
@@ -598,49 +575,57 @@ class TestForbesQ2dCoeffVariable:
     @pytest.fixture(autouse=True)
     def setup(self):
         self.optic = AsphericSinglet()
+        
+        freeform_coeffs = {
+            ('a', 1, 1): 0.1,
+            ('a', 2, 2): 0.2,
+            ('b', 1, 1): 0.3,
+        }
+        surface_config = SurfaceConfig(
+            radius=100,
+            conic=0.0,
+            terms=freeform_coeffs,
+            norm_radius=15.0
+        )
         forbes_geo = ForbesQ2dGeometry(
             CoordinateSystem(),
-            100,
-            conic=0.0,
-            freeform_coeffs={
-                (1, 1): 0.1,
-                (2, 2): 0.2,
-                (1, 1, "sin"): 0.3,
-            },
-            norm_radius=15.0,
+            surface_config=surface_config,
         )
         self.optic.surface_group.surfaces[1].geometry = forbes_geo
-        # Variable for the (2, 2) cosine term
+        
         self.forbes_var = variable.ForbesQ2dCoeffVariable(
-            self.optic, 1, (2, 2), apply_scaling=False
+            self.optic, 1, ('a', 2, 2), apply_scaling=False
         )
 
     def test_get_value(self, set_test_backend):
         assert_allclose(self.forbes_var.get_value(), 0.2)
 
     def test_get_value_nonexistent(self, set_test_backend):
+        
         forbes_var_new = variable.ForbesQ2dCoeffVariable(
-            self.optic, 1, (3, 1), apply_scaling=False
+            self.optic, 1, ('a', 1, 3), apply_scaling=False
         )
         assert_allclose(forbes_var_new.get_value(), 0.0)
 
     def test_update_value_existing(self, set_test_backend):
         self.forbes_var.update_value(0.5)
         assert_allclose(self.forbes_var.get_value(), 0.5)
-        # Test the public API, not the internal implementation detail
+        
         assert_allclose(
-            self.optic.surface_group.surfaces[1].geometry.freeform_coeffs[(2, 2)], 0.5
+            self.optic.surface_group.surfaces[1].geometry.freeform_coeffs[('a', 2, 2)], 0.5
         )
 
     def test_update_value_new(self, set_test_backend):
+        
+        key = ('a', 1, 3)
         forbes_var_new = variable.ForbesQ2dCoeffVariable(
-            self.optic, 1, (3, 1), apply_scaling=False
+            self.optic, 1, key, apply_scaling=False
         )
         forbes_var_new.update_value(0.9)
         assert_allclose(forbes_var_new.get_value(), 0.9)
-        assert (3, 1) in self.optic.surface_group.surfaces[1].geometry.freeform_coeffs
+        assert key in self.optic.surface_group.surfaces[1].geometry.freeform_coeffs
         assert_allclose(
-            self.optic.surface_group.surfaces[1].geometry.freeform_coeffs[(3, 1)], 0.9
+            self.optic.surface_group.surfaces[1].geometry.freeform_coeffs[key], 0.9
         )
 
     def test_string_representation(self, set_test_backend):
@@ -650,28 +635,25 @@ class TestForbesQ2dCoeffVariable:
         with pytest.raises(ValueError):
             variable.ForbesQ2dCoeffVariable(self.optic, 1, (1))
 
-    def test_invalid_coeff_tuple(self, set_test_backend):
-        with pytest.raises(ValueError):
-            variable.ForbesQ2dCoeffVariable(self.optic, 1, (1))
-
     def test_get_and_update_sine_term(self, set_test_backend):
+        
+        key = ('b', 1, 1)
         var_sin = variable.ForbesQ2dCoeffVariable(
-            self.optic, 1, (1, 1, "sin"), apply_scaling=False
+            self.optic, 1, key, apply_scaling=False
         )
         assert_allclose(var_sin.get_value(), 0.3)
 
         var_sin.update_value(-0.5)
         assert_allclose(var_sin.get_value(), -0.5)
         assert_allclose(
-            self.optic.surface_group.surfaces[1].geometry.freeform_coeffs[
-                (1, 1, "sin")
-            ],
+            self.optic.surface_group.surfaces[1].geometry.freeform_coeffs[key],
             -0.5,
         )
 
     def test_string_representation_sine(self, set_test_backend):
         """Test the string representation for a sine term."""
-        var_sin = variable.ForbesQ2dCoeffVariable(self.optic, 1, (1, 1, "sin"))
+        
+        var_sin = variable.ForbesQ2dCoeffVariable(self.optic, 1, ('b', 1, 1))
         assert str(var_sin) == "Forbes Q-2D Coeff (n=1, m=1, sin), Surface 1"
 
 


### PR DESCRIPTION
# Refactoring geometry.py for Better Clarity and Maintenance

Hi team!

I've just refactored the `ForbesQbfsGeometry` and `ForbesQ2dGeometry` classes to improve our code quality - I am trying to be more careful about that, especially after the bad technical dept introduced by the gui. Here’s a quick summary of the changes and why they were made. OPen to feedback, but i do like the use of dataclasses here - might be worth considering following the same for the other `NewtonRaphson` geometries.

### The Problem

The old `__init__` methods for our geometry classes were becoming difficult to manage. They accepted up to 7-8 individual parameters, which led to a few issues:

* **Hard to Read**: Long function calls where it was easy to lose track of which parameter was which.
* **Error-Prone**: High risk of mixing up the order of arguments.
* **Poor Maintainability**: Adding a new parameter required changing the signature in every class and updating every single place where it was called.

### The Solution: Using Dataclasses

To solve this, I've grouped the parameters into two logical dataclasses:

* **`SurfaceConfig`**: Holds all parameters that define the **shape** of the surface (like `radius`, `conic`, `terms`, and `norm_radius`).
* **`SolverConfig`**: Holds all parameters related to the **numerical solver** (`tol` and `max_iter`).

Now, instead of passing a long list of arguments, we pass these two clean, organized objects.

### Key Benefits

* **Clarity**: The code now clearly separates the *what* (the surface shape) from the *how* (the solver settings).
* **Simplicity**: The `__init__` signatures are much cleaner and easier to understand.
* **Future-Proofing**: If we need to add a new solver setting in the future, we only need to add it to the `SolverConfig` dataclass. No other part of the code needs to change.

This new structure directly addresses the code smells identified by our quality tools and makes the module much easier to work with going forward.




# Bug Fixes for Forbes Geometries and Polynomial Engine

This PR also includes several critical bug fixes that were identified during testing of the refactored `geometry.py` module.

### 1. Corrected Zemax API Convention for Q2D Surfaces

The initial refactor for `ForbesQ2dGeometry` did not fully align with the Zemax UI for coefficient input. This has been corrected.

* **The Bug**: The code incorrectly assumed cosine terms (`a`) were input as `(n, m)`.
* **The Fix**: Based on the official Zemax documentation, the API now correctly expects **both cosine and sine terms** to be input with the azimuthal frequency `m` first:
    * Cosine term $a_n^m$ is now input as `('a', m, n)`.
    * Sine term $b_n^m$ is now input as `('b', m, n)`.
* The `_prepare_coeffs` method now handles this index swap internally, making the user-facing API intuitive for optical designers.

### 2. Fixed Incorrect Vertex Ray Tracing

A series of subtle bugs were causing rays that hit the surface vertex (`x=0, y=0`) to be traced incorrectly.

* **The Bug**: The analytical derivative calculation in `_surface_normal_analytical` was numerically unstable at the origin. This was caused by a combination of a `NaN` gradient from the PyTorch backend and a missed special-case calculation for `m=1` terms, which define the vertex slope.
* **The Fix**: The `_surface_normal_analytical` method has been rewritten to be fully vectorized and robust. It now explicitly calculates the correct derivative for the vertex using a stable analytical formula (including the required `m=1` special case) and uses a tolerance-based `be.where` to select the correct result for each ray. This ensures correct and stable behavior for all backends.

### 3. Fixed Bugs in `qpoly.py`

Two underlying bugs in the polynomial engine were fixed to support the refactoring:

* **`TypeError`**: The `clenshaw_q2d` function was incorrectly returning `None` when using the `torch` backend. This has been corrected to return the proper tensor.
* **`ValueError`**: A check on the "truthiness" of a NumPy array was ambiguous and has been replaced with an explicit `len()` check to ensure correctness.