### PR TITLE
Fix: Handle on-axis case in third-order aberrations

### DIFF
--- a/tests/test_aberrations.py
+++ b/tests/test_aberrations.py
@@ -247,6 +247,12 @@ class TestSingletStopTwo:
 
 
 class TestSimpleSinglet:
-    def test_seidels(self, set_test_backend, simple_singlet):
+    def test_on_axis_seidels_are_not_zero(self, set_test_backend, simple_singlet):
+        """Test that Seidel coefficients are computed correctly for on-axis field"""
         S = simple_singlet.aberrations.seidels()
-        assert_allclose(S, [0, 0, 0, 0, 0])
+        # Spherical aberration should be non-zero
+        assert not be.isclose(S[0], 0)
+        assert_allclose(S[0], -0.675281089)
+
+        # Other Seidel coefficients are expected to be zero for on-axis field
+        assert_allclose(S[1:], [0, 0, 0, 0], atol=1e-8)


### PR DESCRIPTION
The calculation of third-order aberrations failed for systems with only a single on-axis field. This was due to the Lagrange invariant being zero, which led to a division by zero that was incorrectly handled by setting the spherical aberration term to zero.

This commit fixes the issue by:
- Introducing a check for the on-axis case in `_precalculations`.
- Adding a dedicated method to calculate the transverse spherical aberration for the on-axis case using a formula that does not depend on the Lagrange invariant.
- Updating the test suite to verify that spherical aberration is correctly calculated for a simple on-axis singlet.

Fixes #260 