### PR TITLE
Feature: MMDFT PSF, for accurate PSF calculation regardless of wavelength

### DIFF
--- a/optiland/psf/__init__.py
+++ b/optiland/psf/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 
 from .fft import FFTPSF
+from .mmdft import MMDFTPSF
 from .huygens_fresnel import HuygensPSF

--- a/optiland/psf/mmdft.py
+++ b/optiland/psf/mmdft.py
@@ -1,3 +1,14 @@
+"""MMDFT Point Spread Function (PSF) Module
+
+This module provides functionality for simulating and analyzing the Point
+Spread Function (PSF) of optical systems using the Matrix Multiply Discrete Fourier
+Transform. It includes capabilities for generating a monochromatic PSF at a desired
+image size and pixel pitch from given wavefront aberrations and calculating the
+Strehl ratio. Visualization is handled by the base class.
+
+Scott Paine, 2025
+"""
+
 from __future__ import annotations
 
 import optiland.backend as be

--- a/optiland/psf/mmdft.py
+++ b/optiland/psf/mmdft.py
@@ -4,6 +4,7 @@ import optiland.backend as be
 from optiland.psf.base import BasePSF
 from optiland.psf.fft import calculate_grid_size
 
+
 class MMDFTPSF(BasePSF):
     """Class representing the Matrix Multiply Discrete Fourier Transform (MMDFT) PSF.
 
@@ -90,9 +91,7 @@ class MMDFTPSF(BasePSF):
             if image_size is None:
                 # Use grid_size above to set Q and therefore pixel pitch
                 image_size = grid_size
-            pixel_pitch = (
-                    wavelength * self._get_working_FNO() * clear_size / image_size
-            )
+            pixel_pitch = wavelength * self._get_working_FNO() * clear_size / image_size
 
         # Below triggers only if pixel_pitch was given but image_size was not
         if image_size is None:
@@ -129,8 +128,8 @@ class MMDFTPSF(BasePSF):
         y = y.ravel()
         R2 = x**2 + y**2
 
-        field = self.fields[0]   # PSF contains a single field.
-        wl = self.wavelengths[0] # PSF contains a single wavelength.
+        field = self.fields[0]  # PSF contains a single field.
+        wl = self.wavelengths[0]  # PSF contains a single wavelength.
 
         wavefront_data = self.get_data(field, wl)
         P = be.to_complex(be.zeros_like(x))
@@ -233,13 +232,17 @@ class MMDFTPSF(BasePSF):
         """
         # Assume clear aperture is defined as (num_rays - 1) - done in FFTPSF
         clear_size = self.num_rays - 1
-        pad_size = (self.wavelengths[0] * self._get_working_FNO() * clear_size /
-                    self.pixel_pitch)
+        pad_size = (
+            self.wavelengths[0]
+            * self._get_working_FNO()
+            * clear_size
+            / self.pixel_pitch
+        )
 
         # Check to make sure we aren't sampling outside the max extent of the image
         # domain (defined by pad_size)
         if self.image_size > pad_size:
-            max_size = int(pad_size) # truncate
+            max_size = int(pad_size)  # truncate
             raise ValueError(
                 f"Supplied image_size of {self.image_size} not less than or equal to "
                 f"calculated pad size of {max_size}. Consider increasing num_rays."

--- a/optiland/psf/mmdft.py
+++ b/optiland/psf/mmdft.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import numpy as np
+
+import optiland.backend as be
+from optiland.psf.fft import FFTPSF, calculate_grid_size
+
+class MMDFTPSF(FFTPSF):
+    """Class representing the Matrix Multiply Discrete Fourier Transform (MMDFT) PSF.
+
+    This class computes the PSF of an optical system by taking the Fourier
+    Transform of the pupil function. It inherits common visualization and
+    initialization functionalities from `BasePSF`.
+
+    If no grid size is specified, OpticStudio's FFT PSF sampling behavior is
+    emulated by scaling down the number of rays in the pupil and using a
+    grid size of `num_rays * 2`.
+
+    Args:
+        optic (Optic): The optical system object, containing properties like
+            paraxial data and surface information.
+        field (tuple): The field point (e.g., (Hx, Hy) in normalized field
+            coordinates) at which to compute the PSF.
+        wavelength (float): The wavelength of light in micrometers.
+        num_rays (int, optional): The number of rays used to sample the pupil
+            plane along one dimension. The pupil will be a grid of
+            `num_rays` x `num_rays`. Defaults to 128.
+        grid_size (int, optional): The size of the grid used for FFT
+            computation (includes zero-padding). This determines the
+            resolution of the PSF. Defaults to 1024. If not specified,
+            it is calculated based on `num_rays`.
+        strategy (str): The calculation strategy to use. Supported options are
+            "chief_ray", "centroid_sphere", and "best_fit_sphere".
+            Defaults to "chief_ray".
+        remove_tilt (bool): If True, removes tilt and piston from the OPD data.
+            Defaults to False.
+        **kwargs: Additional keyword arguments passed to the strategy.
+
+    Attributes:
+        pupils (list[be.ndarray]): A list of complex-valued pupil functions,
+            one for each wavelength used in the `Wavefront` parent. Each pupil
+            is a 2D array.
+        psf (be.ndarray): The computed Point Spread Function. This is a 2D
+            array representing the intensity distribution in the image plane,
+            normalized such that a diffraction-limited system has a peak of 100.
+        grid_size (int): The size of the grid used for FFT computation.
+        num_rays (int): The number of rays used to sample the pupil. This is
+                        the `num_rays` passed during initialization and used
+                        by `Wavefront` for generating OPD/intensity data.
+    """
+
+    # TODO: Documentation
+    def __init__(
+        self,
+        optic,
+        field,
+        wavelength,
+        num_rays=128,
+        grid_size=None,
+        pixel_pitch=None,
+        strategy="chief_ray",
+        remove_tilt=False,
+        **kwargs,
+    ):
+        if grid_size is None:
+            if num_rays < 32:
+                raise ValueError(
+                    "num_rays must be at least 32 if grid_size is not specified."
+                )
+            num_rays, grid_size = calculate_grid_size(num_rays)
+
+        super().__init__(
+            optic=optic,
+            field=field,
+            wavelength=wavelength,
+            num_rays=num_rays,
+            strategy=strategy,
+            remove_tilt=remove_tilt,
+            **kwargs,
+        )
+
+        if pixel_pitch is None:
+            pixel_pitch = be.min(self.wavelengths) * self._get_working_FNO() / 2
+
+        self.grid_size = grid_size
+        self.pixel_pitch = pixel_pitch
+        self.pupils = self._generate_pupils()
+        self.psf = self._compute_psf()
+
+    def _compute_psf(self):
+        #TODO: Documentation
+        if not self.pupils:
+            raise ValueError(
+                "Pupil functions have not been generated prior to _compute_psf call."
+            )
+
+        left_kernels, right_kernels = self._compute_base_kernels()
+        psf = []
+        for p, lk, rk in zip(self.pupils, left_kernels, right_kernels):
+            image_plane = be.matmul(lk, be.matmul(p, rk))
+            psf.append(image_plane * be.conj(image_plane))
+        psf = be.stack(psf)
+
+        # TODO: Normalization??
+        return be.real(be.sum(psf, axis=0))
+
+    # TODO: Strehl Ratio Calculations (ties in with normalization)
+
+    def _compute_base_kernels(self):
+        # TODO: Documentation
+        # clear_size is a reference to the number of pixels in the pupil grid
+        # covering the pupil. The assumption here is that num_rays spans the X and Y
+        # extend of the pupil with no pixels inside having an amplitude of zero.
+        clear_size = self.num_rays
+        Qs = self.wavelengths * self._get_working_FNO() / self.pixel_pitch
+        pad_sizes = Qs * clear_size
+
+        # MMDFT generates 2 kernels:
+        # right kernel = exp[-2 pi (u x) / pad_size_x]
+        # left kernel = exp[-2 pi (v y) / pad_size_y]
+        # We do an outer product to create the (u x) and (v y) products
+        # For non-square arrays, use the following:
+        # [a, b] = pupil.shape (pupil plane)
+        # [c, d] = psf.shape   (image plane)
+        # (u x) = np.outer(a, c)
+        # (v y) = np.outer(d, b)
+        # This ensures that the shape of the kernels is correct
+        in_units = be.arange(self.num_rays) - self.num_rays//2
+        out_units = be.arange(self.grid_size) - self.grid_size//2
+
+        right_vector_product = be.outer(in_units, out_units)
+        left_vector_product = be.outer(out_units, in_units)
+
+        right_kernels = []
+        left_kernels = []
+
+        for pad_size in pad_sizes:
+            right_kernel = be.to_complex(
+                be.exp(-2j * np.pi * right_vector_product / pad_size)
+            )
+            right_kernel = right_kernel / be.sqrt(pad_size)
+            right_kernels.append(right_kernel)
+            left_kernel = be.to_complex(
+                be.exp(-2j * np.pi * left_vector_product / pad_size)
+            )
+            left_kernel = left_kernel / be.sqrt(pad_size)
+            left_kernels.append(left_kernel)
+        return left_kernels, right_kernels
+
+# QUESTIONS FOR THE GROUP:
+# 1) Are we worried about spectral weightings at all?
+# 2) When we calculate a polychromatic PSF, do we consider the normalization factor
+# for each wavelength separately, or only compared to the primary wavelength?
+# 3) What do we do in polychromatic calculations about the 1/lambda*F factor?
+# 4) Is an option for normalization simply energy_in = energy_out?
+#    Ex: For a Q=2 or greater PSF, sum(abs(pupil)**2) = sum(psf) over all pixels in
+#    pad_size. Can we then use sum(abs(pupil)**2) as a norm factor?
+# 5) Does all this talk of normalization fuck with the Strehl calculation?
+# 6) Check assumptions:
+#    - The total size of the nonzero aperture is num_rays x num_rays
+#    - Working_FNO is a valid way to calculate Q (versus image_FNO - I think this is
+#    fine)
+# 7) Simplifying kernels/memory - have one single kernel and then modify by raising
+#    kernels to power based on wavelength
+#    pad_size(lambda) = Q * clear_size = lambda * fno * clear_size / pixel_pitch
+#    pad_size(lambda1)/pad_size(lambda2) = lambda1/lambda2
+#    k(lambda1) = exp[-2 pi u x / pad_size(lambda1)]
+#    k(lambda2) = k(lambda1) ** (lambda1/lambda2)

--- a/tests/test_mmdft_psf.py
+++ b/tests/test_mmdft_psf.py
@@ -1,0 +1,304 @@
+from unittest.mock import patch
+
+import matplotlib
+import matplotlib.pyplot as plt
+import optiland.backend as be
+import pytest
+
+from contextlib import nullcontext as does_not_raise
+
+from optiland.psf import MMDFTPSF, FFTPSF
+from optiland.samples.objectives import CookeTriplet
+from .utils import assert_allclose
+
+matplotlib.use("Agg")  # use non-interactive backend for testing
+
+@pytest.fixture
+def make_mmdftpsf(set_test_backend):
+    def _factory(
+        field=(0, 0),
+        wavelength=0.55,
+        num_rays=128,
+        image_size=128,
+        pixel_pitch=None,
+        tweak_optic=None,
+    ):
+        optic = CookeTriplet()
+        if tweak_optic:
+            tweak_optic(optic)
+        return MMDFTPSF(
+            optic, field, wavelength,
+            num_rays=num_rays, image_size=image_size, pixel_pitch=pixel_pitch
+        )
+
+    return _factory
+
+@pytest.fixture
+def make_mmdftpsf_and_fftpsf(set_test_backend):
+    def _factory(
+        field=(0, 0),
+        wavelength=0.55,
+        num_rays=128,
+        image_size=128,
+        pixel_pitch=None,
+        tweak_optic=None,
+    ):
+        optic = CookeTriplet()
+        if tweak_optic:
+            tweak_optic(optic)
+        fftpsf = FFTPSF(optic,
+                        field,
+                        wavelength,
+                        num_rays=num_rays,
+                        grid_size=image_size)
+        dx = (
+                fftpsf.wavelengths[0] *
+                fftpsf._get_working_FNO() *
+                (fftpsf.num_rays - 1) / fftpsf.grid_size
+        )
+        mmdftpsf = MMDFTPSF(optic,
+                            field,
+                            wavelength,
+                            num_rays=fftpsf.num_rays,
+                            image_size=fftpsf.grid_size,
+                            pixel_pitch=dx)
+        return fftpsf, mmdftpsf
+
+    return _factory
+
+def test_initialization(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(image_size=1024)
+    assert mmdftpsf.image_size == 1024
+    assert mmdftpsf.psf.shape == (1024, 1024)
+
+
+@pytest.mark.parametrize(
+    "num_rays,expected_pupil_sampling, expected_pixel_pitch",
+    [
+        (  32,  32, 1.32622273171),
+        (  64,  45, 0.94119032573),
+        ( 128,  64, 0.67380671047),
+        ( 256,  90, 0.47594283517),
+        (1024, 181, 0.24064525374),
+    ],
+)
+def test_calcs_from_num_rays(make_mmdftpsf,
+                            num_rays,
+                            expected_pupil_sampling,
+                            expected_pixel_pitch):
+    mmdftpsf = make_mmdftpsf(num_rays=num_rays, image_size=None)
+
+    assert mmdftpsf.num_rays == expected_pupil_sampling
+    assert mmdftpsf.image_size == 2 * num_rays
+    assert_allclose(mmdftpsf.pixel_pitch, expected_pixel_pitch)
+
+@pytest.mark.parametrize(
+    "pixel_pitch, expected_image_size",
+    [
+        (0.25, 1390),
+        (0.50,  695),
+        (0.75,  463),
+        (1.00,  347),
+        (1.50,  231),
+        (2.00,  173)
+    ],
+)
+def test_calcs_from_pixel_pitch(make_mmdftpsf, pixel_pitch, expected_image_size):
+    mmdftpsf = make_mmdftpsf(pixel_pitch=pixel_pitch, image_size=None)
+
+    assert mmdftpsf.image_size == expected_image_size
+
+@pytest.mark.parametrize(
+    "image_size, expected_pixel_pitch",
+    [
+        ( 128, 2.71661753109),
+        ( 256, 1.35830876554),
+        ( 512, 0.67915438277),
+        (1024, 0.33957719139),
+        (2048, 0.16978859569),
+        (4096, 0.08489429785),
+    ],
+)
+def test_calcs_from_image_size(make_mmdftpsf, image_size, expected_pixel_pitch):
+    mmdftpsf = make_mmdftpsf(image_size=image_size, pixel_pitch=None)
+
+    assert_allclose(expected_pixel_pitch, mmdftpsf.pixel_pitch)
+
+@pytest.mark.parametrize(
+    "num_rays,image_size,expectation",
+    [
+        (32, None, does_not_raise()),
+        (64, None, does_not_raise()),
+        (12, 16, does_not_raise()),
+        (
+            16,
+            None,
+            pytest.raises(
+                ValueError,
+                match="num_rays must be at least 32 if image_size and pixel_pitch are "
+                      "not specified.",
+            ),
+        ),
+    ],
+)
+def test_num_rays_below_32(make_mmdftpsf, num_rays, image_size, expectation):
+    with expectation:
+        make_mmdftpsf(num_rays=num_rays, image_size=image_size)
+
+@pytest.mark.parametrize(
+    "num_rays, image_size",
+    [
+        (64, 128),
+        (65, 256),
+        (64, 257),
+    ],
+)
+def test_image_size(make_mmdftpsf, num_rays, image_size):
+    mmdftpsf = make_mmdftpsf(num_rays=num_rays, image_size=image_size)
+
+    assert mmdftpsf.psf.shape == (image_size, image_size)
+
+def test_invalid_image_size(make_mmdftpsf):
+    with pytest.raises(
+        ValueError,
+        match=r"Supplied image_size of \d+ not less than or equal to calculated "
+              r"pad size of \d+",
+    ):
+        make_mmdftpsf(image_size=400, pixel_pitch=1)
+
+def test_strehl_ratio(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(image_size=256)
+    strehl_ratio = mmdftpsf.strehl_ratio()
+    assert 0 <= strehl_ratio <= 1
+
+
+@pytest.mark.parametrize(
+    "projection, log",
+    [
+        ("2d", False),
+        ("3d", False),
+        ("2d", True),
+        ("3d", True),
+    ],
+)
+def test_view(projection, log, make_mmdftpsf, set_test_backend):
+    # Skip for torch since view isn't implemented there
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+    fig, ax = mmdftpsf.view(projection=projection, log=log)
+    assert fig is not None
+    assert ax is not None
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, plt.Axes)
+    plt.close(fig)
+
+
+def test_find_bounds(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+
+    psf = be.to_numpy(mmdftpsf.psf)
+    min_x, min_y, max_x, max_y = mmdftpsf._find_bounds(psf, threshold=0.05)
+    assert min_x >= 0
+    assert min_y >= 0
+    assert max_x <= 128
+    assert max_y <= 128
+
+
+def test_view_invalid_projection(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+    with pytest.raises(ValueError):
+        mmdftpsf.view(projection="invalid", log=True)
+
+
+@pytest.mark.parametrize(
+    "projection",
+    [
+        "2d",
+        "3d",
+    ],
+)
+@patch("matplotlib.figure.Figure.text")
+def test_view_annotate_sampling(mock_text, projection, make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+    mmdftpsf.view(projection=projection, num_points=32)
+
+    mock_text.assert_called_once()
+
+    plt.close("all")
+
+
+@pytest.mark.parametrize(
+    "projection",
+    [
+        "2d",
+        "3d",
+    ],
+)
+def test_view_oversampling(projection, make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+
+    with pytest.warns(UserWarning, match="The PSF view has a high oversampling factor"):
+        mmdftpsf.view(projection=projection, log=False, num_points=128)
+
+
+def test_get_units_finite_obj(make_mmdftpsf):
+    def tweak(optic):
+        optic.surface_group.surfaces[0].geometry.cs.z = -be.array(1e6)
+
+    mmdftpsf = make_mmdftpsf(field=(0, 1), tweak_optic=tweak)
+    image = be.zeros((128, 128))
+    x, y = mmdftpsf._get_psf_units(image)
+    assert_allclose(x, 382.82764038)
+    assert_allclose(y, 382.82764038)
+
+
+def test_psf_log_tick_formatter(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+    assert mmdftpsf._log_tick_formatter(10) == "$10^{10}$"
+    assert mmdftpsf._log_tick_formatter(1) == "$10^{1}$"
+    assert mmdftpsf._log_tick_formatter(0) == "$10^{0}$"
+    assert mmdftpsf._log_tick_formatter(-1) == "$10^{-1}$"
+    assert mmdftpsf._log_tick_formatter(-10) == "$10^{-10}$"
+
+
+def test_invalid_working_FNO(make_mmdftpsf):
+    def tweak(optic):
+        optic.surface_group.surfaces[0].geometry.cs.z = -be.array(1e100)
+
+    with pytest.raises(ValueError):
+        mmdftpsf = make_mmdftpsf(field=(0, 1), tweak_optic=tweak)
+        fig, ax = mmdftpsf.view()
+        plt.close(fig)
+
+
+def test_interpolate_zoom_factor_one(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+    assert mmdftpsf._interpolate_psf(mmdftpsf.psf) is mmdftpsf.psf
+
+
+def test_large_threshold(make_mmdftpsf):
+    mmdftpsf = make_mmdftpsf(field=(0, 1))
+    psf = be.to_numpy(mmdftpsf.psf)
+    min_x, min_y, max_x, max_y = mmdftpsf._find_bounds(psf, threshold=100)
+    assert min_x == 0
+    assert min_y == 0
+    assert max_x == 128
+    assert max_y == 128
+
+@pytest.mark.parametrize(
+    "num_rays, image_size",
+    [
+        (32, 64),
+        (45, 128),
+        (64, 256),
+        (90, 512),
+        (181, 2048),
+        (128, 128),
+        (256, 256),
+        (512, 512)
+    ],
+)
+def test_fft_agreement(make_mmdftpsf_and_fftpsf, num_rays, image_size):
+    fftpsf, mmdftpsf = make_mmdftpsf_and_fftpsf(num_rays=num_rays,
+                                                image_size=image_size)
+    assert_allclose(fftpsf.psf, mmdftpsf.psf)
+    assert_allclose(fftpsf.strehl_ratio(), mmdftpsf.strehl_ratio())


### PR DESCRIPTION
**THIS PULL REQUEST IS NOT COMPLETE YET. WARNING: WALL OF TEXT BELOW**

I'm presenting code that I wrote to compute PSFs using the matrix-multiply discrete Fourier transform method. This method requires no padding, and computes the FT at specific output points selected by the user. This means the user can supply the pixel pitch directly. 

In an FFT-based PSF, the output sample spacing is determined by the pad size of the input as well as the product of the F-number and the wavelength. If the user desires a specific output sample spacing, chances are there is not an integer pad size that corresponds to this spacing. This means simulation with a specific pixel pitch using an FFT requires interpolation. Similarly, the output sample spacing is dependent on wavelength, and so a polychromatic PSF requires different pad sizes and interpolation for the spacing between pixels to be consistent with wavelength.

The MMDFT directly computes the Fourier Kernel based on the desired sample spacing, and therefore has no limitations brought on by pad size. You could think of the MMDFT as allowing non-integer pad sizes. The MMDFT's complexity is (I think) O(n^2), which means it scales worse than the FFT which is O(n log(n)), but for large pad sizes (which comes about with a desire for small pixel pitch), the MMDFT is faster since there are fewer pixels to push through the FT.

Before the pull request is in, I do want some input from the team, based mostly around polychromatic PSF. Here are my big questions that need answered:

- Polychromatic PSFs are presently generated assuming all wavelengths have equal intensity. Do we want to leave it this way for now, or invent some way to add in wavelength weightings?
- Normalization now is done by generating the unaberrated PSF of the primary wavelength and considering its peak value. Right now, if you make a polychromatic PSF, you can have a Strehl ratio greater than 1, since you add all of the monochromatic PSFs together and then normalize just based on one PSF. The alternatives are:
    - Compute an unaberrated polychromatic PSF and use its peak value as the normalization factor (I would change this in FFTPSF too, for now HuygensPSF looks to be monochromatic)
    - Use energy conservation to say that PSF(0,0) = sum[wl_weight * sum(ideal_amplitude^2)]. This is taking advantage of the fact that when (x,y) = (0,0) in the image plane, the Fourier calculation is just sum(pupil_field) since the kernel is 1. This is much faster since it requires only summation, but falls apart if your calculated PSF does not include the point (0,0).
 - FFTPSF does not presently do padding correctly for polychromatic PSF evaluation. Right now it is just set to pad to `grid_size`, which means the spacing in the image plane is not consistent across all wavelengths (dx = wavelength * FNO / Q). The MMDFT does this appropriately with a different pad size for each wavelength. How would the team like to fix FFTPSF for this?

Things that I still have to do:
 - [ ] Lint the code with ruff
 - [ ] Documentation everywhere
 - [ ] Make everything more readable and self-documenting
 - [ ] Implement team-approved normalization and Strehl calculations
 - [ ] Implement any team-approved changes to other PSF files