### PR TITLE
Fix(fileio): Update `load_optiland_file` for `field_definition`

### DIFF
--- a/optiland/optic/optic.py
+++ b/optiland/optic/optic.py
@@ -677,11 +677,14 @@ class Optic:
         optic.solves = SolveManager.from_dict(optic, data["solves"])
 
         optic.polarization = data["wavelengths"]["polarization"]
-        optic.field_definition = (
-            BaseFieldDefinition.from_dict(data["fields"]["field_definition"])
-            if data["fields"].get("field_definition")
-            else None
-        )
+        if data["fields"].get("field_definition"):
+            optic.field_definition = BaseFieldDefinition.from_dict(
+                data["fields"]["field_definition"]
+            )
+        elif data["fields"].get("field_type"):
+            optic.set_field_type(data["fields"]["field_type"])
+        else:
+            optic.field_definition = None
         optic.obj_space_telecentric = data["fields"]["object_space_telecentric"]
 
         optic.paraxial = Paraxial(optic)


### PR DESCRIPTION
This commit addresses a bug in `load_optiland_file` that occurred when loading Optiland-native JSON files using the legacy `field_type` key. The recent introduction of the `field_definition` attribute in `optilc.Optic` caused backward compatibility issues.

The `Optic.from_dict` method has been updated to first check for the `field_definition` key. If it is not present, the method falls back to using the `field_type` key, ensuring that older files can still be loaded correctly.

A new test, `test_load_legacy_optiland_file_with_field_type`, has been added to `tests/test_fileio.py` to verify this fix. The test confirms that a legacy file is loaded correctly and that the `field_definition` attribute is properly populated.

Fixes #338 