### PR TITLE
Fix wavelength handling in Rays2D.plot and refactor for consistency

### DIFF
--- a/optiland/analysis/angle_vs_height.py
+++ b/optiland/analysis/angle_vs_height.py
@@ -17,6 +17,7 @@ import numpy as np
 from matplotlib.collections import LineCollection
 
 import optiland.backend as be
+from optiland.utils import resolve_wavelength
 
 from .base import BaseAnalysis
 
@@ -127,22 +128,8 @@ class BaseAngleVsHeightAnalysis(BaseAnalysis, abc.ABC):
         self.axis = axis
         self.num_points = num_points
 
-        if isinstance(wavelength, str):
-            if wavelength == "primary":
-                processed_wavelength = "primary"
-            else:
-                raise ValueError(
-                    "Invalid wavelength string for Angle vs. Height Analysis, only "
-                    "'primary' is supported as a string."
-                )
-        elif isinstance(wavelength, float | int):
-            processed_wavelength = [float(wavelength)]
-        else:
-            raise TypeError(
-                "wavelength argument must be 'primary' or a number (in microns)"
-            )
-
-        super().__init__(optic, wavelengths=processed_wavelength)
+        # The resolved wavelength is passed as a list to the parent constructor
+        super().__init__(optic, wavelengths=[resolve_wavelength(optic, wavelength)])
 
     @abc.abstractmethod
     def _get_trace_coordinates(self, scan_range):

--- a/optiland/analysis/base.py
+++ b/optiland/analysis/base.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import abc
 
+from optiland.utils import resolve_wavelengths
+
 
 class BaseAnalysis(abc.ABC):
     """Base class for all analysis routines.
@@ -29,23 +31,7 @@ class BaseAnalysis(abc.ABC):
 
     def __init__(self, optic, wavelengths="all"):
         self.optic = optic
-
-        if isinstance(wavelengths, str):
-            if wavelengths == "all":
-                self.wavelengths = self.optic.wavelengths.get_wavelengths()
-            elif wavelengths == "primary":
-                self.wavelengths = [self.optic.primary_wavelength]
-            else:
-                raise ValueError(
-                    "Invalid wavelength string. Must be 'all' or 'primary'."
-                )
-        elif isinstance(wavelengths, list):
-            self.wavelengths = wavelengths
-        else:
-            raise TypeError(
-                "Wavelengths must be a string ('all', 'primary') or a list."
-            )
-
+        self.wavelengths = resolve_wavelengths(optic, wavelengths)
         self.data = self._generate_data()
 
     @abc.abstractmethod

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -15,8 +15,8 @@ import numpy as np
 from matplotlib import patches
 
 import optiland.backend as be
-from optiland.utils import resolve_fields
 from optiland.visualization.system.utils import transform
+from optiland.utils import resolve_fields
 
 from .base import BaseAnalysis
 

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -16,6 +16,7 @@ from matplotlib import patches
 
 import optiland.backend as be
 from optiland.visualization.system.utils import transform
+from optiland.utils import resolve_fields
 
 from .base import BaseAnalysis
 
@@ -56,8 +57,8 @@ class SpotDiagram(BaseAnalysis):
     def __init__(
         self,
         optic,
-        fields: str | tuple = "all",
-        wavelengths: str | tuple[float, ...] = "all",
+        fields: str | list = "all",
+        wavelengths: str | list = "all",
         num_rings: int = 6,
         distribution: str = "hexapolar",
         coordinates: Literal["global", "local"] = "local",
@@ -83,10 +84,7 @@ class SpotDiagram(BaseAnalysis):
         Raises:
             ValueError: If `coordinates` is not 'global' or 'local'.
         """
-        if fields == "all":
-            self.fields = optic.fields.get_field_coords()
-        else:
-            self.fields = fields
+        self.fields = resolve_fields(optic, fields)
 
         if coordinates not in ["global", "local"]:
             raise ValueError("Coordinates must be 'global' or 'local'.")

--- a/optiland/analysis/spot_diagram.py
+++ b/optiland/analysis/spot_diagram.py
@@ -15,8 +15,8 @@ import numpy as np
 from matplotlib import patches
 
 import optiland.backend as be
-from optiland.visualization.system.utils import transform
 from optiland.utils import resolve_fields
+from optiland.visualization.system.utils import transform
 
 from .base import BaseAnalysis
 

--- a/optiland/mtf/base.py
+++ b/optiland/mtf/base.py
@@ -14,7 +14,7 @@ import abc
 import matplotlib.pyplot as plt
 
 import optiland.backend as be
-from optiland.utils import get_working_FNO
+from optiland.utils import get_working_FNO, resolve_fields, resolve_wavelength
 
 
 class BaseMTF(abc.ABC):
@@ -31,8 +31,8 @@ class BaseMTF(abc.ABC):
     def __init__(
         self,
         optic,
-        fields,
-        wavelength,
+        fields: str | list,
+        wavelength: str | float,
         strategy="chief_ray",
         remove_tilt=False,
         **kwargs,
@@ -60,15 +60,8 @@ class BaseMTF(abc.ABC):
         self.remove_tilt = remove_tilt
         self.strategy_kwargs = kwargs
 
-        if fields == "all":
-            self.resolved_fields = optic.fields.get_field_coords()
-        else:
-            self.resolved_fields = fields
-
-        if wavelength == "primary":
-            self.resolved_wavelength = optic.primary_wavelength
-        else:
-            self.resolved_wavelength = wavelength
+        self.resolved_fields = resolve_fields(optic, fields)
+        self.resolved_wavelength = resolve_wavelength(optic, wavelength)
 
         self._calculate_psf()
         self.mtf = self._generate_mtf_data()

--- a/optiland/mtf/fft.py
+++ b/optiland/mtf/fft.py
@@ -53,8 +53,8 @@ class FFTMTF(BaseMTF):
     def __init__(
         self,
         optic,
-        fields="all",
-        wavelength="primary",
+        fields: str | list = "all",
+        wavelength: str | float = "primary",
         num_rays=128,
         grid_size=None,
         max_freq="cutoff",

--- a/optiland/mtf/geometric.py
+++ b/optiland/mtf/geometric.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 
 import optiland.backend as be
 from optiland.analysis import SpotDiagram
+from optiland.utils import resolve_wavelength
 
 
 class GeometricMTF(SpotDiagram):
@@ -59,8 +60,8 @@ class GeometricMTF(SpotDiagram):
     def __init__(
         self,
         optic,
-        fields="all",
-        wavelength="primary",
+        fields: str | list = "all",
+        wavelength: str | float = "primary",
         num_rays=100,
         distribution="uniform",
         num_points=256,
@@ -70,16 +71,15 @@ class GeometricMTF(SpotDiagram):
         self.num_points = num_points
         self.scale = scale
 
-        if wavelength == "primary":
-            wavelength = optic.primary_wavelength
+        resolved_wavelength = resolve_wavelength(optic, wavelength)
         if max_freq == "cutoff":
             # wavelength must be converted to mm for frequency units cycles/mm
-            self.max_freq = 1 / (wavelength * 1e-3 * optic.paraxial.FNO())
+            self.max_freq = 1 / (resolved_wavelength * 1e-3 * optic.paraxial.FNO())
         else:
             # If a specific max_freq is provided, use it directly
             self.max_freq = max_freq
 
-        super().__init__(optic, fields, [wavelength], num_rays, distribution)
+        super().__init__(optic, fields, [resolved_wavelength], num_rays, distribution)
 
         self.freq = be.linspace(0, self.max_freq, num_points)
         self.mtf, self.diff_limited_mtf = self._generate_mtf_data()

--- a/optiland/mtf/huygens_fresnel.py
+++ b/optiland/mtf/huygens_fresnel.py
@@ -52,8 +52,8 @@ class HuygensMTF(BaseMTF):
     def __init__(
         self,
         optic,
-        fields="all",
-        wavelength="primary",
+        fields: str | list = "all",
+        wavelength: str | float = "primary",
         num_rays=128,
         image_size=128,
         max_freq="cutoff",

--- a/optiland/mtf/sampled.py
+++ b/optiland/mtf/sampled.py
@@ -9,6 +9,7 @@ Kramer Harrison, 2025
 from __future__ import annotations
 
 import optiland.backend as be
+from optiland.utils import resolve_wavelength
 from optiland.wavefront import Wavefront
 from optiland.zernike import ZernikeFit
 
@@ -61,7 +62,7 @@ class SampledMTF:
         self,
         optic,
         field,
-        wavelength,
+        wavelength: str | float,
         num_rays=128,
         distribution="uniform",
         zernike_terms=37,
@@ -70,14 +71,11 @@ class SampledMTF:
         """Initializes the SampledMTF instance."""
         self.optic = optic
         self.field = field
-        self.wavelength = wavelength
+        self.wavelength = resolve_wavelength(optic, wavelength)
         self.num_rays = num_rays
         self.distribution = distribution
         self.zernike_terms = zernike_terms
         self.zernike_type = zernike_type
-
-        if wavelength == "primary":
-            self.wavelength = optic.primary_wavelength
 
         wf = Wavefront(
             optic,

--- a/optiland/psf/base.py
+++ b/optiland/psf/base.py
@@ -17,7 +17,7 @@ from matplotlib.colors import LogNorm
 from scipy.ndimage import zoom
 
 import optiland.backend as be
-from optiland.utils import get_working_FNO
+from optiland.utils import get_working_FNO, resolve_wavelength
 from optiland.wavefront import Wavefront
 
 
@@ -45,7 +45,8 @@ class BasePSF(Wavefront):
     Args:
         optic (Optic): The optical system.
         field (tuple): The field as (x, y) at which to compute the PSF.
-        wavelength (float): The wavelength of light.
+        wavelength (str | float): The wavelength of light. Can be 'primary' or a
+            float value.
         num_rays (int, optional): The number of rays used for wavefront
             computation. Defaults to 128.
         strategy (str): The calculation strategy to use. Supported options are
@@ -67,16 +68,17 @@ class BasePSF(Wavefront):
         self,
         optic,
         field,
-        wavelength,
+        wavelength: str | float,
         num_rays=128,
         strategy="chief_ray",
         remove_tilt=True,
         **kwargs,
     ):
+        resolved_wavelength = resolve_wavelength(optic, wavelength)
         super().__init__(
             optic=optic,
             fields=[field],
-            wavelengths=[wavelength],
+            wavelengths=[resolved_wavelength],
             num_rays=num_rays,
             distribution="uniform",
             strategy=strategy,

--- a/optiland/psf/fft.py
+++ b/optiland/psf/fft.py
@@ -55,7 +55,8 @@ class FFTPSF(BasePSF):
             paraxial data and surface information.
         field (tuple): The field point (e.g., (Hx, Hy) in normalized field
             coordinates) at which to compute the PSF.
-        wavelength (float): The wavelength of light in micrometers.
+        wavelength (str | float): The wavelength of light in micrometers. Can be
+            'primary' or a float value.
         num_rays (int, optional): The number of rays used to sample the pupil
             plane along one dimension. The pupil will be a grid of
             `num_rays` x `num_rays`. Defaults to 128.
@@ -87,7 +88,7 @@ class FFTPSF(BasePSF):
         self,
         optic,
         field,
-        wavelength,
+        wavelength: str | float,
         num_rays=128,
         grid_size=None,
         strategy="chief_ray",

--- a/optiland/psf/huygens_fresnel.py
+++ b/optiland/psf/huygens_fresnel.py
@@ -313,8 +313,8 @@ class HuygensPSF(BasePSF):
                 self.optic,
                 distribution="uniform",
                 num_rays=self.num_rays,
-                fields=((0, 0),),
-                wavelengths=(self.wavelengths[0],),
+                fields=[(0, 0)],
+                wavelengths=[self.wavelengths[0]],
             )
             data = wf.get_data((0, 0), self.wavelengths[0])
 

--- a/optiland/psf/huygens_fresnel.py
+++ b/optiland/psf/huygens_fresnel.py
@@ -37,7 +37,8 @@ class HuygensPSF(BasePSF):
             paraxial data and surface information.
         field (tuple): The field point (e.g., (Hx, Hy) in normalized field
             coordinates) at which to compute the PSF.
-        wavelength (float): The wavelength of light in micrometers.
+        wavelength (str | float): The wavelength of light in micrometers. Can be
+            'primary' or a float value.
         num_rays (int, optional): The number of rays used to sample the pupil
             plane along one dimension. The pupil will be a grid of
             `num_rays` x `num_rays`. Defaults to 128.
@@ -61,7 +62,7 @@ class HuygensPSF(BasePSF):
         self,
         optic,
         field,
-        wavelength,
+        wavelength: str | float,
         num_rays=128,
         image_size=128,
         strategy="chief_ray",

--- a/optiland/psf/mmdft.py
+++ b/optiland/psf/mmdft.py
@@ -28,7 +28,8 @@ class MMDFTPSF(BasePSF):
             paraxial data and surface information.
         field (tuple): The field point (e.g., (Hx, Hy) in normalized field
             coordinates) at which to compute the PSF.
-        wavelength (float): The wavelength of light in micrometers.
+        wavelength (str | float): The wavelength of light in micrometers. Can be
+            'primary' or a float value.
         num_rays (int, optional): The number of rays used to sample the pupil
             plane along one dimension. The pupil will be a grid of
             `num_rays` x `num_rays`. Defaults to 128.
@@ -60,7 +61,7 @@ class MMDFTPSF(BasePSF):
         self,
         optic,
         field,
-        wavelength,
+        wavelength: str | float,
         num_rays=128,
         image_size=None,
         pixel_pitch=None,

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -129,7 +129,7 @@ def resolve_wavelength(optic, wavelength):
                 "Invalid wavelength string. For a single wavelength, it must be "
                 "'primary'."
             )
-    elif isinstance(wavelength, int | float):
+    elif isinstance(wavelength, (int, float)):
         return float(wavelength)
     else:
         raise TypeError("Wavelength must be a string ('primary') or a number.")

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -28,7 +28,7 @@ def get_working_FNO(optic, field, wavelength):
         4. Compute the angle between each marginal ray and the chief ray.
         4. Calculate the average of the squared numerical apertures from all traced
             marginal rays.
-        5. Compute the working F-number as 1 / (2 * sqrt(average_NA_squared)).
+        5. Compute the working F-number as 1 / (2 * be.sqrt(average_NA_squared)).
         6. Cap the calculated F/# at 10,000 if it exceeds this value.
 
     Returns:
@@ -62,3 +62,74 @@ def get_working_FNO(optic, field, wavelength):
         raise ValueError("Working F/# could not be calculated due to raytrace errors.")
 
     return fno
+
+
+def resolve_wavelengths(optic, wavelengths):
+    """Resolves wavelength input into a list of wavelength values.
+
+    Args:
+        optic (Optic): The optic object.
+        wavelengths (str or list): The wavelengths to resolve.
+            Can be 'all', 'primary', or a list of wavelength values.
+
+    Returns:
+        list: A list of wavelength values.
+    """
+    if isinstance(wavelengths, str):
+        if wavelengths == "all":
+            return optic.wavelengths.get_wavelengths()
+        elif wavelengths == "primary":
+            return [optic.primary_wavelength]
+        else:
+            raise ValueError("Invalid wavelength string. Must be 'all' or 'primary'.")
+    elif isinstance(wavelengths, list):
+        return wavelengths
+    else:
+        raise TypeError("Wavelengths must be a string ('all', 'primary') or a list.")
+
+
+def resolve_fields(optic, fields):
+    """Resolves field input into a list of field coordinates.
+
+    Args:
+        optic (Optic): The optic object.
+        fields (str or list): The fields to resolve.
+            Can be 'all' or a list of field coordinates.
+
+    Returns:
+        list: A list of field coordinates.
+    """
+    if isinstance(fields, str):
+        if fields == "all":
+            return optic.fields.get_field_coords()
+        else:
+            raise ValueError("Invalid field string. Must be 'all'.")
+    elif isinstance(fields, list):
+        return fields
+    else:
+        raise TypeError("Fields must be a string ('all') or a list.")
+
+
+def resolve_wavelength(optic, wavelength):
+    """Resolves a single wavelength input into a float value.
+
+    Args:
+        optic (Optic): The optic object.
+        wavelength (str or float or int): The wavelength to resolve.
+            Can be 'primary' or a numerical value.
+
+    Returns:
+        float: A single wavelength value.
+    """
+    if isinstance(wavelength, str):
+        if wavelength == "primary":
+            return optic.primary_wavelength
+        else:
+            raise ValueError(
+                "Invalid wavelength string. For a single wavelength, it must be "
+                "'primary'."
+            )
+    elif isinstance(wavelength, (int, float)):
+        return float(wavelength)
+    else:
+        raise TypeError("Wavelength must be a string ('primary') or a number.")

--- a/optiland/utils.py
+++ b/optiland/utils.py
@@ -129,7 +129,7 @@ def resolve_wavelength(optic, wavelength):
                 "Invalid wavelength string. For a single wavelength, it must be "
                 "'primary'."
             )
-    elif isinstance(wavelength, (int, float)):
+    elif isinstance(wavelength, int | float):
         return float(wavelength)
     else:
         raise TypeError("Wavelength must be a string ('primary') or a number.")

--- a/optiland/visualization/system/rays.py
+++ b/optiland/visualization/system/rays.py
@@ -11,6 +11,7 @@ import numpy as np
 import vtk
 
 import optiland.backend as be
+from optiland.utils import resolve_fields, resolve_wavelengths
 from optiland.visualization.system.utils import transform
 
 
@@ -69,11 +70,8 @@ class Rays2D:
                 include "chief" and "marginal". Defaults to None.
 
         """
-        if fields == "all":
-            fields = self.optic.fields.get_field_coords()
-
-        if wavelengths == "primary":
-            wavelengths = [self.optic.wavelengths.primary_wavelength.value]
+        fields = resolve_fields(self.optic, fields)
+        wavelengths = resolve_wavelengths(self.optic, wavelengths)
 
         for i, field in enumerate(fields):
             for j, wavelength in enumerate(wavelengths):

--- a/optiland/wavefront/opd.py
+++ b/optiland/wavefront/opd.py
@@ -13,7 +13,6 @@ import numpy as np
 from scipy.interpolate import griddata
 
 import optiland.backend as be
-
 from optiland.utils import resolve_wavelength
 
 from .wavefront import Wavefront

--- a/optiland/wavefront/opd.py
+++ b/optiland/wavefront/opd.py
@@ -14,6 +14,8 @@ from scipy.interpolate import griddata
 
 import optiland.backend as be
 
+from optiland.utils import resolve_wavelength
+
 from .wavefront import Wavefront
 
 if TYPE_CHECKING:
@@ -39,7 +41,8 @@ class OPD(Wavefront):
     Args:
         optic (Optic): The optic object.
         field (tuple): The field at which to calculate the OPD.
-        wavelength (float): The wavelength of the wavefront.
+        wavelength (str | float): The wavelength of the wavefront. Can be 'primary'
+            or a float value.
         num_rings (int, optional): The number of rings for ray tracing.
             Defaults to 15.
         strategy (str): The calculation strategy to use. Supported options are
@@ -70,17 +73,18 @@ class OPD(Wavefront):
         self,
         optic: Optic,
         field: tuple[float, float],
-        wavelength: float,
+        wavelength: str | float,
         num_rays: int = 15,
         distribution: DistributionType = "hexapolar",
         strategy: WavefrontStrategyType = "chief_ray",
         remove_tilt: bool = False,
         **kwargs,
     ) -> None:
+        resolved_wavelength = resolve_wavelength(optic, wavelength)
         super().__init__(
             optic,
             fields=[field],
-            wavelengths=[wavelength],
+            wavelengths=[resolved_wavelength],
             num_rays=num_rays,
             distribution=distribution,
             strategy=strategy,

--- a/optiland/wavefront/opd.py
+++ b/optiland/wavefront/opd.py
@@ -13,6 +13,7 @@ import numpy as np
 from scipy.interpolate import griddata
 
 import optiland.backend as be
+
 from optiland.utils import resolve_wavelength
 
 from .wavefront import Wavefront

--- a/optiland/wavefront/wavefront.py
+++ b/optiland/wavefront/wavefront.py
@@ -16,6 +16,8 @@ from optiland.utils import resolve_fields, resolve_wavelengths
 from .strategy import create_strategy
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from optiland._types import DistributionType, Fields, Wavelengths
     from optiland.optic.optic import Optic
     from optiland.wavefront.strategy import WavefrontStrategyType

--- a/optiland/wavefront/wavefront.py
+++ b/optiland/wavefront/wavefront.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import optiland.backend as be
 from optiland.distribution import BaseDistribution, create_distribution
+from optiland.utils import resolve_fields, resolve_wavelengths
 
 from .strategy import create_strategy
 
@@ -65,8 +66,8 @@ class Wavefront:
         **kwargs,
     ):
         self.optic = optic
-        self.fields = self._resolve_fields(fields)
-        self.wavelengths = self._resolve_wavelengths(wavelengths)
+        self.fields = resolve_fields(optic, fields)
+        self.wavelengths = resolve_wavelengths(optic, wavelengths)
         self.num_rays = num_rays
         self.distribution = self._resolve_distribution(distribution, self.num_rays)
 
@@ -140,21 +141,6 @@ class Wavefront:
         opd_detrended = opd - fitted
 
         return opd_detrended
-
-    def _resolve_fields(self, fields: Fields) -> Sequence[tuple[float, float]]:
-        """Resolves field coordinates from the input specification."""
-        if fields == "all":
-            return self.optic.fields.get_field_coords()
-
-        return fields
-
-    def _resolve_wavelengths(self, wavelengths: Wavelengths) -> Sequence[float]:
-        """Resolves wavelengths from the input specification."""
-        if wavelengths == "all":
-            return self.optic.wavelengths.get_wavelengths()
-        if wavelengths == "primary":
-            return [self.optic.primary_wavelength]
-        return wavelengths
 
     def _resolve_distribution(
         self, dist: DistributionType | BaseDistribution, num_rays

--- a/optiland/wavefront/wavefront.py
+++ b/optiland/wavefront/wavefront.py
@@ -16,8 +16,6 @@ from optiland.utils import resolve_fields, resolve_wavelengths
 from .strategy import create_strategy
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from optiland._types import DistributionType, Fields, Wavelengths
     from optiland.optic.optic import Optic
     from optiland.wavefront.strategy import WavefrontStrategyType

--- a/optiland/wavefront/zernike_opd.py
+++ b/optiland/wavefront/zernike_opd.py
@@ -27,7 +27,8 @@ class ZernikeOPD(ZernikeFit, OPD):
     Args:
         optic (object): The optic object representing the optical system.
         field (tuple): The field used for the calculation.
-        wavelength (float): The wavelength of light used in the calculation.
+        wavelength (str | float): The wavelength of light used in the calculation.
+            Can be 'primary' or a float value.
         num_rings (int, optional): The number of rings used in the Zernike
             calculation. Default is 15.
         zernike_type (str, optional): The type of Zernike polynomials used.
@@ -47,7 +48,7 @@ class ZernikeOPD(ZernikeFit, OPD):
         self,
         optic: Optic,
         field: tuple[float, float],
-        wavelength: float,
+        wavelength: str | float,
         num_rings: int = 15,
         zernike_type: ZernikeType = "fringe",
         num_terms: int = 37,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,75 @@
+import pytest
+from optiland.optic import Optic
+from optiland.utils import resolve_fields, resolve_wavelength, resolve_wavelengths
+
+
+@pytest.fixture
+def optic():
+    o = Optic()
+    o.add_wavelength(value=0.5, is_primary=True)
+    o.add_wavelength(value=0.6)
+    o.add_field(y=0)
+    o.add_field(y=1)
+    return o
+
+
+def test_resolve_wavelengths_all(optic):
+    assert resolve_wavelengths(optic, "all") == [0.5, 0.6]
+
+
+def test_resolve_wavelengths_primary(optic):
+    assert resolve_wavelengths(optic, "primary") == [0.5]
+
+
+def test_resolve_wavelengths_list(optic):
+    assert resolve_wavelengths(optic, [0.7, 0.8]) == [0.7, 0.8]
+
+
+def test_resolve_wavelengths_invalid_string(optic):
+    with pytest.raises(ValueError):
+        resolve_wavelengths(optic, "invalid")
+
+
+def test_resolve_wavelengths_invalid_type(optic):
+    with pytest.raises(TypeError):
+        resolve_wavelengths(optic, 123)
+
+
+def test_resolve_fields_all(optic):
+    assert resolve_fields(optic, "all") == [(0.0, 0.0), (0.0, 1.0)]
+
+
+def test_resolve_fields_list(optic):
+    assert resolve_fields(optic, [(0.1, 0.2)]) == [(0.1, 0.2)]
+
+
+def test_resolve_fields_invalid_string(optic):
+    with pytest.raises(ValueError):
+        resolve_fields(optic, "primary")
+
+
+def test_resolve_fields_invalid_type(optic):
+    with pytest.raises(TypeError):
+        resolve_fields(optic, 123)
+
+
+def test_resolve_wavelength_primary(optic):
+    assert resolve_wavelength(optic, "primary") == 0.5
+
+
+def test_resolve_wavelength_float(optic):
+    assert resolve_wavelength(optic, 0.7) == 0.7
+
+
+def test_resolve_wavelength_int(optic):
+    assert resolve_wavelength(optic, 1) == 1.0
+
+
+def test_resolve_wavelength_invalid_string(optic):
+    with pytest.raises(ValueError):
+        resolve_wavelength(optic, "all")
+
+
+def test_resolve_wavelength_invalid_type(optic):
+    with pytest.raises(TypeError):
+        resolve_wavelength(optic, [0.5])

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -187,6 +187,17 @@ class TestOpticViewer:
         assert ax.get_ylim() == custom_ylim
         plt.close(fig)
 
+    def test_view_all_wavelengths(self, set_test_backend):
+        lens = ReverseTelephoto()
+        # Add a second wavelength to test "all"
+        lens.add_wavelength(value=0.65)
+        viewer = OpticViewer(lens)
+        fig, ax = viewer.view(wavelengths="all")
+        assert fig is not None
+        assert ax is not None
+        assert len(ax.get_lines()) > 0  # Ensure rays were drawn
+        plt.close(fig)
+
 
 class TestOpticViewer3D:
     def test_init(self, set_test_backend):


### PR DESCRIPTION
This commit addresses a bug where `Rays2D.plot()` would raise a `UFuncTypeError` when an unsupported string was passed for the `wavelengths` argument.

The fix introduces three new utility functions in `optiland/utils.py`:
- `resolve_wavelengths`: Handles "all", "primary", or a list of wavelengths.
- `resolve_fields`: Handles "all" or a list of fields.
- `resolve_wavelength`: Handles "primary" or a single float/int wavelength.

These functions are now used throughout the codebase to centralize and standardize the resolution of wavelength and field inputs, replacing duplicated logic in the following modules:
- analysis
- mtf
- psf
- wavefront
- visualization

This change also includes new unit tests for the utility functions in `tests/test_utils.py` and an additional test in `tests/test_visualization.py` to verify the original bug fix.

Fixes #336 