### PR TITLE
Rename `geometry.c` to `geometry.coefficients`

### DIFF
--- a/optiland/optic/optic_updater.py
+++ b/optiland/optic/optic_updater.py
@@ -141,7 +141,7 @@ class OpticUpdater:
 
         """
         surface = self.optic.surface_group.surfaces[surface_number]
-        surface.geometry.c[aspher_coeff_idx] = value
+        surface.geometry.coefficients[aspher_coeff_idx] = value
 
     def set_polarization(self, polarization: PolarizationState | str):
         """Set the polarization state of the optic.

--- a/optiland/optimization/variable/asphere_coeff.py
+++ b/optiland/optimization/variable/asphere_coeff.py
@@ -55,16 +55,16 @@ class AsphereCoeffVariable(VariableBehavior):
         """
         surf = self._surfaces.surfaces[self.surface_number]
         try:
-            value = surf.geometry.c[self.coeff_number]
+            value = surf.geometry.coefficients[self.coeff_number]
         except IndexError:
             pad_width_i = max(0, self.coeff_number + 1)
             c_new = np.pad(
-                surf.geometry.c,
+                surf.geometry.coefficients,
                 pad_width=(0, pad_width_i),
                 mode="constant",
                 constant_values=0,
             )
-            surf.geometry.c = c_new
+            surf.geometry.coefficients = c_new
             value = 0
         if self.apply_scaling:
             return self.scale(value)

--- a/optiland/optimization/variable/polynomial_coeff.py
+++ b/optiland/optimization/variable/polynomial_coeff.py
@@ -52,17 +52,17 @@ class PolynomialCoeffVariable(VariableBehavior):
         surf = self._surfaces.surfaces[self.surface_number]
         i, j = self.coeff_index
         try:
-            value = surf.geometry.c[i][j]
+            value = surf.geometry.coefficients[i][j]
         except IndexError:
-            pad_width_i = max(0, i + 1 - surf.geometry.c.shape[0])
-            pad_width_j = max(0, j + 1 - surf.geometry.c.shape[1])
+            pad_width_i = max(0, i + 1 - surf.geometry.coefficients.shape[0])
+            pad_width_j = max(0, j + 1 - surf.geometry.coefficients.shape[1])
             c_new = np.pad(
-                surf.geometry.c,
+                surf.geometry.coefficients,
                 pad_width=((0, pad_width_i), (0, pad_width_j)),
                 mode="constant",
                 constant_values=0,
             )
-            surf.geometry.c = c_new
+            surf.geometry.coefficients = c_new
             value = 0
         if self.apply_scaling:
             return self.scale(value)
@@ -80,18 +80,18 @@ class PolynomialCoeffVariable(VariableBehavior):
         surf = self.optic.surface_group.surfaces[self.surface_number]
         i, j = self.coeff_index
         try:
-            surf.geometry.c[i][j] = new_value
+            surf.geometry.coefficients[i][j] = new_value
         except IndexError:
-            pad_width_i = max(0, i + 1 - surf.geometry.c.shape[0])
-            pad_width_j = max(0, j + 1 - surf.geometry.c.shape[1])
+            pad_width_i = max(0, i + 1 - surf.geometry.coefficients.shape[0])
+            pad_width_j = max(0, j + 1 - surf.geometry.coefficients.shape[1])
             c_new = np.pad(
-                surf.geometry.c,
+                surf.geometry.coefficients,
                 pad_width=((0, pad_width_i), (0, pad_width_j)),
                 mode="constant",
                 constant_values=0,
             )
             c_new[i][j] = new_value
-            surf.geometry.c = c_new
+            surf.geometry.coefficients = c_new
 
     def scale(self, value):
         """Scale the value of the variable for improved optimization performance.

--- a/optiland/visualization/info/lens_info_viewer.py
+++ b/optiland/visualization/info/lens_info_viewer.py
@@ -156,7 +156,7 @@ class LensInfoViewer(BaseViewer):
         surface_coeffs = []
         for i, surface in enumerate(self.optic.surface_group.surfaces):
             if isinstance(surface.geometry, valid_geometry_types):
-                coefficients = list(surface.geometry.c)
+                coefficients = list(surface.geometry.coefficients)
                 if coefficients:
                     rows = [f"Surface {i}"] + coefficients
                     surface_coeffs.append(rows)

--- a/tests/test_optic.py
+++ b/tests/test_optic.py
@@ -222,7 +222,7 @@ class TestOptic:
             coefficients=[0.0, 0.0, 0.0],
         )
         self.optic.set_asphere_coeff(0.1, 0, 2)
-        assert self.optic.surface_group.surfaces[0].geometry.c[2] == 0.1
+        assert self.optic.surface_group.surfaces[0].geometry.coefficients[2] == 0.1
 
     def test_set_polarization(self, set_test_backend):
         self.optic.set_polarization("ignore")

--- a/tests/test_surface_factory.py
+++ b/tests/test_surface_factory.py
@@ -49,7 +49,7 @@ class TestSurfaceFactory:
         assert isinstance(surface, Surface)
         assert surface.geometry.radius == 10
         assert surface.geometry.k == 0
-        assert surface.geometry.c == [1, 2, 3]
+        assert surface.geometry.coefficients == [1, 2, 3]
         assert isinstance(surface.material_pre, IdealMaterial)
         assert isinstance(surface.material_post, IdealMaterial)
 
@@ -68,7 +68,7 @@ class TestSurfaceFactory:
         assert isinstance(surface, Surface)
         assert surface.geometry.radius == 10
         assert surface.geometry.k == 0
-        assert surface.geometry.c == [1, 2, 3]
+        assert surface.geometry.coefficients == [1, 2, 3]
         assert isinstance(surface.material_pre, IdealMaterial)
         assert isinstance(surface.material_post, IdealMaterial)
 
@@ -89,7 +89,7 @@ class TestSurfaceFactory:
         assert isinstance(surface, Surface)
         assert surface.geometry.radius == 10
         assert surface.geometry.k == 0
-        assert be.array_equal(surface.geometry.c, be.array([[1, 2, 3]]))
+        assert be.array_equal(surface.geometry.coefficients, be.array([[1, 2, 3]]))
         assert surface.geometry.tol == 1e-6
         assert surface.geometry.max_iter == 100
         assert isinstance(surface.material_pre, IdealMaterial)
@@ -114,7 +114,7 @@ class TestSurfaceFactory:
         assert isinstance(surface, Surface)
         assert surface.geometry.radius == 10
         assert surface.geometry.k == 0
-        assert be.all(surface.geometry.c == be.arange(9).reshape(3, 3))
+        assert be.all(surface.geometry.coefficients == be.arange(9).reshape(3, 3))
         assert surface.geometry.tol == 1e-6
         assert surface.geometry.max_iter == 100
         assert surface.geometry.norm_x == 1


### PR DESCRIPTION
Improve readability by renaming `geometry.c` to `geometry.coefficients` for aspheric surfaces.
Best, DrPaprika