### PR TITLE
fix `AOI` operand: single-element array

### DIFF
--- a/optiland/optimization/operand/ray.py
+++ b/optiland/optimization/operand/ray.py
@@ -286,8 +286,15 @@ class RayOperand:
         dot_product_clip = be.minimum(dot_product, be.array(1.0))
 
         angle_rad = be.arccos(dot_product_clip)
+        angle_deg = be.rad2deg(angle_rad)
 
-        return be.rad2deg(angle_rad)
+        # For some reason angle_deg can sometimes be a single-element array.
+        # In that case, retreive the float inside.
+        # This is a workaround until a solution is found.
+        if be.is_array_like(angle_deg):
+            angle_deg = angle_deg.item()
+
+        return angle_deg
 
     @staticmethod
     def rms_spot_size(


### PR DESCRIPTION
Hi, it appears that just like `RayOperand.z_intercept_lcs`, `RayOperand.AOI` can sometimes return a single-element array.
In that case, re-use the solution implemented in `z_intercept_lcs` to retreive the float inside.

Example with the current behavior:
```python
input_data = {
    "optic": lens,
    "surface_number": 4,
    "Hx": 0,
    "Hy": 0,
    "Px": 0,
    "Py": 0,
    "wavelength": primary_wl,
}
problem.add_operand(
    operand_type = "AOI",
    input_data = input_data,
    target = 0,
    weight = 1,
)
```
results in the error:

```python
optiland\optimization\problem.py line 105: return be.stack(terms) ** 2
ValueError: all input arrays must have the same shape
```

This PR should (temporarily) fix this.
Best, DrPaprika