### PR TITLE
Allow setting `primary_index` in `WavelengthGroup`

### DIFF
--- a/optiland/wavelength.py
+++ b/optiland/wavelength.py
@@ -154,6 +154,14 @@ class WavelengthGroup:
             if wavelength.is_primary:
                 return index
 
+    @primary_index.setter
+    def primary_index(self, index: int):
+        """set the wavelength indexed by `index` as primary"""
+        if not 0 <= index < len(self.wavelengths):
+            raise ValueError("Index out of range")
+        for idx, wavelength in enumerate(self.wavelengths):
+            wavelength.is_primary = idx == index
+
     @property
     def primary_wavelength(self):
         """float: the primary wavelength"""

--- a/tests/test_wavelength.py
+++ b/tests/test_wavelength.py
@@ -90,6 +90,21 @@ class TestWavelengthGroups:
         wg.add_wavelength(500, unit="nm")
         wg.add_wavelength(600, is_primary=True, unit="nm")
         assert wg.primary_wavelength.value == 0.6
+    
+    def test_set_primary_index(self, set_test_backend):
+        wg = WavelengthGroup()
+        wg.add_wavelength(500, unit="nm")
+        wg.add_wavelength(600, is_primary=True, unit="nm")
+        wg.primary_index = 0
+        assert wg.primary_wavelength.value == 0.5
+
+    @pytest.mark.parametrize("index", (-1, 2))
+    def test_set_primary_index_raises(self, index, set_test_backend):
+        wg = WavelengthGroup()
+        wg.add_wavelength(500, unit="nm")
+        wg.add_wavelength(600, is_primary=True, unit="nm")
+        with pytest.raises(ValueError, match="Index out of range"):
+            wg.primary_index = index
 
     def test_multiple_wavelengths(self, set_test_backend):
         wg = WavelengthGroup()


### PR DESCRIPTION
This small PR adds a setter function for `WavelengthGroup.primary_index`, for convenience. I included Pytests, but unfortunately I could not test the whole suite because of some issues with the PyTorch backend on my machine (MacOS, if that matters - I've never used PyTorch before). Without the PyTorch backend, about half of the tests fail (makes sense), but with the backend installed, the Python interpreter crashes. 