### PR TITLE
Fix/rel cs loading

### DIFF
--- a/optiland/surfaces/standard_surface.py
+++ b/optiland/surfaces/standard_surface.py
@@ -227,6 +227,7 @@ class Surface:
 
         return {
             "type": self.__class__.__name__,
+            "thickness": self.thickness,
             "geometry": self.geometry.to_dict(),
             "material_pre": self.material_pre.to_dict(),
             "material_post": self.material_post.to_dict(),
@@ -293,7 +294,7 @@ class Surface:
             )
 
         surface_class = cls._registry.get(surface_type, cls)
-        return surface_class(
+        surface = surface_class(
             geometry=geometry,
             material_pre=material_pre,
             material_post=material_post,
@@ -302,3 +303,5 @@ class Surface:
             comment=data.get("comment", ""),
             interaction_model=interaction_model,
         )
+        surface.thickness = data.get("thickness", 0.0)
+        return surface

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -5,6 +5,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from optiland.fileio.optiland_handler import load_obj_from_json, save_obj_to_json
+from optiland.fileio import save_optiland_file, load_optiland_file
 from optiland.fileio.zemax_handler import (
     ZemaxDataModel,
     ZemaxDataParser,
@@ -14,6 +15,8 @@ from optiland.fileio.zemax_handler import (
 from optiland.materials import Material
 from optiland.optic import Optic
 from optiland.samples.objectives import HeliarLens
+import optiland.backend as be
+from .utils import assert_allclose
 
 
 @pytest.fixture
@@ -192,3 +195,64 @@ def test_load_legacy_optiland_file_with_field_type():
     assert modern_dict == loaded_lens.to_dict()
 
     os.remove(filepath)
+
+
+def test_remove_surface_after_load(set_test_backend, tmp_path):
+    """
+    Test that removing a surface after loading from a file works correctly.
+    This reproduces a bug where surface thicknesses were not being deserialized,
+    leading to incorrect surface positions after removal.
+    """
+    # 1. Create a lens and save it
+    lens = Optic(name="TestLens")
+    lens.add_surface(index=0, thickness=be.inf, material="Air")
+    lens.add_surface(
+        index=1,
+        surface_type="standard",
+        material="Air",
+        thickness=10,
+        radius=150,
+    )
+    lens.add_surface(
+        index=2,
+        surface_type="standard",
+        material="N-BK7",
+        thickness=10,
+        radius=150,
+        is_stop=True,
+    )
+    lens.add_surface(
+        index=3,
+        surface_type="standard",
+        material="Air",
+        thickness=20,
+        radius=be.inf,
+    )
+    lens.add_surface(index=4)
+    lens.set_aperture("float_by_stop_size", 25)
+
+    filepath = tmp_path / "lens.json"
+    save_optiland_file(lens, filepath)
+
+    # 2. Load the lens from the file
+    loaded_lens = load_optiland_file(filepath)
+
+    # 3. Remove the second surface (the air spacer)
+    loaded_lens.surface_group.remove_surface(1)
+
+    # 4. Assert that the positions of the remaining surfaces are correct
+    # Original surfaces: 0 (obj), 1 (air), 2 (n-bk7), 3 (air), 4 (img)
+    # Positions before removal: inf, 0, 10, 20, 40
+    # Thicknesses: inf, 10, 10, 20, 0
+    # After removing surf 1:
+    # New surfaces: 0 (obj), 1 (n-bk7), 2 (air), 3 (img)
+    # New surf 1 (orig 2) z -> 0.0. Its thickness is 10.
+    # New surf 2 (orig 3) z -> 0.0 + 10 = 10.0. Its thickness is 20.
+    # New surf 3 (orig 4) z -> 10.0 + 20 = 30.0. Its thickness is 0.
+    positions = loaded_lens.surface_group.positions.flatten()
+
+    # The object surface's position (index 0) is be.inf and not relevant to the bug.
+    # We check the positions of the subsequent surfaces.
+    expected_positions_after_object = be.array([0.0, 10.0, 30.0])
+
+    assert_allclose(positions[1:], expected_positions_after_object)


### PR DESCRIPTION
## Bug Fix

- `thickness` attribute of surface is now saved and loaded properly during serialization and deserialization
- Omitting this previously resulted in potentially invalid surface positioning for saved/loaded lenses

Fixes #358 